### PR TITLE
feat: add deterministic itinerary validator

### DIFF
--- a/docs/itinerary-validator.md
+++ b/docs/itinerary-validator.md
@@ -1,0 +1,19 @@
+# Deterministic itinerary validator
+
+`src.validator.validate_itinerary` consumes a canonical Trip V1 document and optional explicit, already-derived inputs. It never calls a routing or place-data provider and never changes the trip document.
+
+```python
+from src.validator import ValidationContext, validate_itinerary
+
+result = validate_itinerary(trip, ValidationContext(travel_minutes={...}, opening_hours={...}))
+```
+
+The result serializes as `{ "outcome": "valid|invalid|incomplete", "violations": [...] }`. Each violation contains stable `code`, `severity`, `message`, and JSON-pointer `path` fields. Any error is `invalid`; warnings with no errors are `incomplete`; no violations is `valid`.
+
+## Derived input contract
+
+- `travel_minutes[(from_place_id, to_place_id)]` is a non-negative route duration. An absent route is `travel_time.unverified`.
+- `opening_hours[place_id]` is a sequence of `OpeningInterval(weekday, opens_at, closes_at)`, using Monday `0` through Sunday `6` and local wall times. An absent scheduled visit or meal is `opening_hours.unverified`.
+- `budget_limit=BudgetLimit(amount, currency)` is an optional explicit cap. The validator always checks the Trip V1 category arithmetic and currency consistency.
+
+The default registry runs time overlap, travel time, opening hours, and budget rules in that order. Construct `RuleRegistry` and call `register(rule)` to add deterministic rules; each rule receives `(trip, context)` and returns violations.

--- a/src/validator/__init__.py
+++ b/src/validator/__init__.py
@@ -1,0 +1,25 @@
+"""Public deterministic itinerary validation API."""
+
+from .itinerary import (
+    DEFAULT_RULES,
+    BudgetLimit,
+    OpeningInterval,
+    Outcome,
+    RuleRegistry,
+    ValidationContext,
+    ValidationResult,
+    Violation,
+    validate_itinerary,
+)
+
+__all__ = [
+    "DEFAULT_RULES",
+    "BudgetLimit",
+    "OpeningInterval",
+    "Outcome",
+    "RuleRegistry",
+    "ValidationContext",
+    "ValidationResult",
+    "Violation",
+    "validate_itinerary",
+]

--- a/src/validator/itinerary.py
+++ b/src/validator/itinerary.py
@@ -1,0 +1,215 @@
+"""Deterministic validation rules for Canonical Trip V1 itineraries.
+
+The validator deliberately does not enrich a trip or call external services.
+Facts that are not part of Trip V1 (routing results and opening hours) are
+passed in as a :class:`ValidationContext`, making every result reproducible.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, time
+from enum import Enum
+from typing import Callable, Mapping, Sequence
+
+
+class Outcome(str, Enum):
+    VALID = "valid"
+    INVALID = "invalid"
+    INCOMPLETE = "incomplete"
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A stable, machine-readable result emitted by one validation rule."""
+
+    code: str
+    severity: str
+    message: str
+    path: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "path": self.path,
+        }
+
+
+@dataclass(frozen=True)
+class OpeningInterval:
+    """A local opening interval; weekday uses Python's Monday=0 convention."""
+
+    weekday: int
+    opens_at: time
+    closes_at: time
+
+
+@dataclass(frozen=True)
+class BudgetLimit:
+    amount: float
+    currency: str
+
+
+@dataclass(frozen=True)
+class ValidationContext:
+    """Explicit derived inputs needed by rules which Trip V1 does not contain.
+
+    ``travel_minutes`` is keyed by ``(from_place_id, to_place_id)``. Omit a
+    route when it is unknown; the travel rule will emit an unverified warning.
+    ``opening_hours`` is keyed by place ID and lists local weekly intervals.
+    Omit a scheduled place when its hours are unknown.
+    """
+
+    travel_minutes: Mapping[tuple[str, str], int] = field(default_factory=dict)
+    opening_hours: Mapping[str, Sequence[OpeningInterval]] = field(default_factory=dict)
+    budget_limit: BudgetLimit | None = None
+
+
+Rule = Callable[[dict, ValidationContext], Sequence[Violation]]
+
+
+class RuleRegistry:
+    """Ordered registry so callers can add deterministic rules without forking."""
+
+    def __init__(self, rules: Sequence[Rule] = ()) -> None:
+        self._rules = list(rules)
+
+    def register(self, rule: Rule) -> Rule:
+        self._rules.append(rule)
+        return rule
+
+    def run(self, trip: dict, context: ValidationContext) -> list[Violation]:
+        return [violation for rule in self._rules for violation in rule(trip, context)]
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    outcome: Outcome
+    violations: tuple[Violation, ...]
+
+    @property
+    def is_valid(self) -> bool:
+        return self.outcome is Outcome.VALID
+
+    def as_dict(self) -> dict[str, object]:
+        return {"outcome": self.outcome.value, "violations": [v.as_dict() for v in self.violations]}
+
+
+def validate_itinerary(
+    trip: dict, context: ValidationContext | None = None, registry: RuleRegistry | None = None
+) -> ValidationResult:
+    """Run deterministic itinerary rules against an already canonical Trip V1 model."""
+
+    violations = tuple((registry or DEFAULT_RULES).run(trip, context or ValidationContext()))
+    if any(item.severity == "error" for item in violations):
+        outcome = Outcome.INVALID
+    elif violations:
+        outcome = Outcome.INCOMPLETE
+    else:
+        outcome = Outcome.VALID
+    return ValidationResult(outcome, violations)
+
+
+def time_overlap_rule(trip: dict, _: ValidationContext) -> Sequence[Violation]:
+    violations: list[Violation] = []
+    for day_index, day in enumerate(trip.get("days", [])):
+        scheduled = sorted(enumerate(day.get("items", [])), key=lambda pair: pair[1]["start_at"])
+        previous_index: int | None = None
+        previous_end: datetime | None = None
+        for item_index, item in scheduled:
+            start, end = _timestamps(item)
+            path = _item_path(day_index, item_index)
+            if end <= start:
+                violations.append(_error("time.invalid_interval", "item end must be after its start", path))
+            if previous_end is not None and start < previous_end:
+                violations.append(_error("time.overlap", "item overlaps the preceding scheduled item", path))
+            if previous_end is None or end > previous_end:
+                previous_index, previous_end = item_index, end
+    return violations
+
+
+def travel_time_rule(trip: dict, context: ValidationContext) -> Sequence[Violation]:
+    violations: list[Violation] = []
+    for day_index, day in enumerate(trip.get("days", [])):
+        scheduled = sorted(enumerate(day.get("items", [])), key=lambda pair: pair[1]["start_at"])
+        for (previous_index, previous), (item_index, item) in zip(scheduled, scheduled[1:]):
+            if previous["place_id"] == item["place_id"]:
+                continue
+            path = _item_path(day_index, item_index)
+            route = (previous["place_id"], item["place_id"])
+            minutes = context.travel_minutes.get(route)
+            if minutes is None:
+                violations.append(_warning("travel_time.unverified", f"travel time for {route[0]} to {route[1]} is unknown", path))
+                continue
+            if minutes < 0:
+                violations.append(_error("travel_time.invalid", "travel duration cannot be negative", path))
+                continue
+            available_minutes = (_timestamps(item)[0] - _timestamps(previous)[1]).total_seconds() / 60
+            if available_minutes < minutes:
+                violations.append(_error("travel_time.insufficient", f"requires {minutes} minutes but only {available_minutes:g} minutes are scheduled", path))
+    return violations
+
+
+def opening_hours_rule(trip: dict, context: ValidationContext) -> Sequence[Violation]:
+    violations: list[Violation] = []
+    for day_index, day in enumerate(trip.get("days", [])):
+        for item_index, item in enumerate(day.get("items", [])):
+            if item.get("kind") not in {"visit", "meal"}:
+                continue
+            path = _item_path(day_index, item_index)
+            intervals = context.opening_hours.get(item["place_id"])
+            if not intervals:
+                violations.append(_warning("opening_hours.unverified", "opening hours are unknown", path))
+                continue
+            start, end = _timestamps(item)
+            if start.date() != end.date() or not any(
+                interval.weekday == start.weekday()
+                and interval.opens_at <= start.timetz().replace(tzinfo=None)
+                and end.timetz().replace(tzinfo=None) <= interval.closes_at
+                for interval in intervals
+            ):
+                violations.append(_error("opening_hours.closed", "scheduled time falls outside opening hours", path))
+    return violations
+
+
+def budget_rule(trip: dict, context: ValidationContext) -> Sequence[Violation]:
+    budget = trip.get("budget", {})
+    path = "/budget"
+    total = budget.get("total", {})
+    currency = budget.get("currency")
+    category_values = budget.get("categories", {}).values()
+    if not total or currency is None:
+        return [_warning("budget.unverified", "budget data is incomplete", path)]
+    if total.get("currency") != currency or any(value.get("currency") != currency for value in category_values):
+        return [_error("budget.currency_mismatch", "budget values must use the trip budget currency", path)]
+    category_total = sum(value["amount"] for value in category_values)
+    if category_total != total["amount"]:
+        return [_error("budget.total_mismatch", "budget total does not equal category total", path)]
+    if context.budget_limit is None:
+        return []
+    if context.budget_limit.currency != currency:
+        return [_warning("budget.unverified", "budget limit currency differs from trip budget currency", path)]
+    if total["amount"] > context.budget_limit.amount:
+        return [_error("budget.exceeded", "budget total exceeds the supplied budget limit", path)]
+    return []
+
+
+DEFAULT_RULES = RuleRegistry((time_overlap_rule, travel_time_rule, opening_hours_rule, budget_rule))
+
+
+def _timestamps(item: dict) -> tuple[datetime, datetime]:
+    return datetime.fromisoformat(item["start_at"]), datetime.fromisoformat(item["end_at"])
+
+
+def _item_path(day_index: int, item_index: int) -> str:
+    return f"/days/{day_index}/items/{item_index}"
+
+
+def _error(code: str, message: str, path: str) -> Violation:
+    return Violation(code, "error", message, path)
+
+
+def _warning(code: str, message: str, path: str) -> Violation:
+    return Violation(code, "warning", message, path)

--- a/tests/test_itinerary_validator.py
+++ b/tests/test_itinerary_validator.py
@@ -1,0 +1,68 @@
+import copy
+import json
+from datetime import time
+from pathlib import Path
+import unittest
+
+from src.validator import BudgetLimit, OpeningInterval, Outcome, RuleRegistry, ValidationContext, validate_itinerary
+
+
+FIXTURE = Path(__file__).parents[1] / "fixtures/trips/japan-5-day-trip-v1.json"
+
+
+def verified_context() -> ValidationContext:
+    hours = {}
+    for place_id in ("ohori-park", "dazaifu", "yufuin", "beppu", "canal-city"):
+        hours[place_id] = [OpeningInterval(weekday, time(8), time(22)) for weekday in range(7)]
+    return ValidationContext(
+        travel_minutes={
+            ("fuk", "hakata-hotel"): 180,
+            ("yufuin", "beppu"): 60,
+        },
+        opening_hours=hours,
+        budget_limit=BudgetLimit(200000, "JPY"),
+    )
+
+
+class ItineraryValidatorTests(unittest.TestCase):
+    def setUp(self):
+        self.trip = json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+    def test_complete_fixture_passes(self):
+        result = validate_itinerary(self.trip, verified_context())
+        self.assertEqual(result.outcome, Outcome.VALID)
+        self.assertEqual(result.violations, ())
+        self.assertEqual(result.as_dict(), {"outcome": "valid", "violations": []})
+
+    def test_overlap_and_insufficient_travel_fail(self):
+        trip = copy.deepcopy(self.trip)
+        trip["days"][3]["items"][1]["start_at"] = "2026-04-13T11:30:00+09:00"
+        result = validate_itinerary(trip, verified_context())
+        self.assertEqual(result.outcome, Outcome.INVALID)
+        self.assertEqual({item.code for item in result.violations}, {"time.overlap", "travel_time.insufficient"})
+
+    def test_closed_and_over_budget_fail(self):
+        context = verified_context()
+        context = ValidationContext(
+            travel_minutes=context.travel_minutes,
+            opening_hours={**context.opening_hours, "ohori-park": [OpeningInterval(5, time(8), time(9))]},
+            budget_limit=BudgetLimit(100000, "JPY"),
+        )
+        result = validate_itinerary(self.trip, context)
+        self.assertEqual(result.outcome, Outcome.INVALID)
+        self.assertEqual({item.code for item in result.violations}, {"opening_hours.closed", "budget.exceeded"})
+
+    def test_unknown_derived_facts_are_incomplete(self):
+        result = validate_itinerary(self.trip)
+        self.assertEqual(result.outcome, Outcome.INCOMPLETE)
+        self.assertIn("travel_time.unverified", {item.code for item in result.violations})
+        self.assertIn("opening_hours.unverified", {item.code for item in result.violations})
+
+    def test_registry_accepts_extension(self):
+        registry = RuleRegistry()
+        registry.register(lambda trip, context: [])
+        self.assertEqual(validate_itinerary(self.trip, registry=registry).outcome, Outcome.VALID)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Resolves #4

Adds an extensible deterministic itinerary validator with time-overlap, route-time, opening-hours, and budget checks. Results and violations are machine-readable and distinguish valid, invalid, and incomplete states.

Validation: `python3 -m unittest -v tests/test_trip_v1.py tests/test_itinerary_validator.py`; `git diff --check`.