### PR TITLE
feat: add source adapters and candidate store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/docs/source-evidence-priority.md
+++ b/docs/source-evidence-priority.md
@@ -1,0 +1,27 @@
+# Source evidence priority
+
+## Boundary
+
+Source adapters fetch and normalize facts into the existing Trip V1 `candidate_sets` contract. They never receive or change `days`, therefore cannot turn research into an itinerary decision. `CandidateStore` tracks the operational lifecycle (`fetched`, `normalized`, `selected`, `rejected`) outside Trip V1; only its canonical candidate payload may enter `candidate_sets`.
+
+Every dynamic candidate must retain the existing provenance object: `source_type`, `provider`, `retrieved_at`, and `status`, plus URL, confidence, or note where available. Freshness is assessed by the caller with a category-appropriate maximum age; a stale fact remains traceable but must not be treated as current confirmation.
+
+## Evidence priority
+
+| Fact type | First-choice evidence | Community use | Rule |
+| --- | --- | --- | --- |
+| Closures, opening hours, entry rules, safety advisories | Official operator, municipality, tourism authority | May flag a possible change | Community reports cannot replace an official operational fact. Keep both provenance records if they conflict and mark the community fact `reported` or `unverified`. |
+| Fares, schedules, availability, reservations | Carrier, hotel, venue, booking provider | Discovery only | Confirm against the responsible provider before planning a hard constraint. |
+| Route duration and distance | Routing provider with query timestamp | Practical context only | Do not convert anecdotal travel time into confirmed routing data. |
+| Restaurant queues, stroller access, crowding, practical tips | Venue/provider when published | Primary supplementary evidence | Keep as `community` / `reported`; it may influence soft scoring, never silently change hours or reservation policy. |
+| Attractions and descriptive content | Official tourism/operator sources | Supplemental perspective | Preserve provider and retrieval time for each assertion. |
+
+## Japan-first normalization
+
+Use `place.name` and `place.address` as Unicode strings, preserving Japanese plus a useful English or Chinese display name when supplied by the evidence. Do not add Tabelog, Google, or scraper-specific score fields to Trip V1: adapters must translate only fields already in the schema (price range, opening-hours note, reservation, queue risk, child-friendly, parking where supported). Raw provider payloads remain outside the planner contract.
+
+## Conflict and selection
+
+1. Store each independently sourced candidate with its own provenance; do not overwrite a higher-priority fact.
+2. Planner may use `confirmed` official/provider facts for hard constraints. `reported` community facts are soft signals.
+3. Mark a candidate selected only after it has been normalized; the planner then writes the final Trip selection through existing IDs, not by mutating research evidence.

--- a/src/sources/__init__.py
+++ b/src/sources/__init__.py
@@ -1,0 +1,17 @@
+"""Research source adapters and the candidate-store boundary."""
+
+from .adapters import AdapterFailure, FixtureCommunityRestaurantAdapter, FixtureOfficialPoiAdapter, SourceAdapter, SourceQuery, collect_from_adapters
+from .candidate_store import CandidateRecord, CandidateState, CandidateStore, StaleCandidateError
+
+__all__ = [
+    "AdapterFailure",
+    "CandidateRecord",
+    "CandidateState",
+    "CandidateStore",
+    "FixtureCommunityRestaurantAdapter",
+    "FixtureOfficialPoiAdapter",
+    "SourceAdapter",
+    "SourceQuery",
+    "StaleCandidateError",
+    "collect_from_adapters",
+]

--- a/src/sources/adapters.py
+++ b/src/sources/adapters.py
@@ -1,0 +1,121 @@
+"""Replaceable adapters that return canonical Trip V1 candidate payloads.
+
+Adapters are deliberately read-only: they never receive a Trip document and cannot
+write ``days``.  Provider responses are normalized before crossing this boundary.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class SourceQuery:
+    """A provider-neutral research request."""
+
+    destination: str
+    categories: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AdapterFailure:
+    """A captured failure; one provider must not discard other research results."""
+
+    adapter: str
+    message: str
+
+
+class SourceAdapter(ABC):
+    """Normalize one provider into ``{candidate_sets collection, candidate}`` records."""
+
+    name: str
+
+    @abstractmethod
+    def fetch(self, query: SourceQuery) -> Iterable[tuple[str, dict[str, Any]]]:
+        """Return canonical candidates without provider-specific fields.
+
+        Each tuple's first value is one Trip V1 ``candidate_sets`` collection.
+        Each candidate must contain canonical ``provenance`` with ``retrieved_at``.
+        """
+
+
+def collect_from_adapters(
+    adapters: Iterable[SourceAdapter], query: SourceQuery
+) -> tuple[list[tuple[str, dict[str, Any]]], list[AdapterFailure]]:
+    """Collect independent adapter output, isolating expected provider failures."""
+
+    candidates: list[tuple[str, dict[str, Any]]] = []
+    failures: list[AdapterFailure] = []
+    for adapter in adapters:
+        try:
+            candidates.extend(adapter.fetch(query))
+        except Exception as exc:  # provider/network failures are non-fatal per adapter
+            failures.append(AdapterFailure(adapter=adapter.name, message=str(exc)))
+    return candidates, failures
+
+
+class FixtureOfficialPoiAdapter(SourceAdapter):
+    """Deterministic official-tourism adapter fixture for contract tests."""
+
+    name = "fixture-official-tourism"
+
+    def __init__(self, retrieved_at: datetime | None = None) -> None:
+        self.retrieved_at = retrieved_at or datetime.now(timezone.utc)
+
+    def fetch(self, query: SourceQuery) -> Iterable[tuple[str, dict[str, Any]]]:
+        if "pois" not in query.categories:
+            return []
+        provenance = {
+            "source_type": "official",
+            "provider": "Fukuoka City Official Tourism Guide fixture",
+            "source_url": "https://gofukuoka.jp/",
+            "retrieved_at": self.retrieved_at.isoformat(),
+            "confidence": 0.95,
+            "status": "confirmed",
+        }
+        return [("places", {
+            "id": "ohori-park",
+            "name": "大濠公園 / Ohori Park",
+            "kind": "poi",
+            "address": "福岡県福岡市中央区大濠公園",
+            "provenance": provenance,
+        })]
+
+
+class FixtureCommunityRestaurantAdapter(SourceAdapter):
+    """Deterministic community-source fixture; its facts remain reported, not official."""
+
+    name = "fixture-community-restaurant"
+
+    def __init__(self, retrieved_at: datetime | None = None) -> None:
+        self.retrieved_at = retrieved_at or datetime.now(timezone.utc)
+
+    def fetch(self, query: SourceQuery) -> Iterable[tuple[str, dict[str, Any]]]:
+        if "restaurants" not in query.categories:
+            return []
+        provenance = {
+            "source_type": "community",
+            "provider": "Fukuoka family travel community fixture",
+            "source_url": "https://example.test/fukuoka-family-ramen",
+            "retrieved_at": self.retrieved_at.isoformat(),
+            "confidence": 0.55,
+            "status": "reported",
+            "note": "Queue and child-friendly signals are community reports.",
+        }
+        return [("restaurants", {
+            "place": {
+                "id": "fixture-ramen",
+                "name": "フィクスチャーラーメン / Fixture Ramen",
+                "kind": "restaurant",
+                "address": "福岡県福岡市中央区",
+                "provenance": provenance,
+            },
+            "price_range": "¥1,000–¥2,000",
+            "reservation_required": False,
+            "wait_risk": "high",
+            "child_friendly": True,
+            "provenance": provenance,
+        })]

--- a/src/sources/candidate_store.py
+++ b/src/sources/candidate_store.py
@@ -1,0 +1,124 @@
+"""Lifecycle-aware store for research candidates before planner selection.
+
+The store intentionally has no method that accepts or returns an itinerary day.
+It stores canonical Trip V1 candidate payloads and lifecycle state separately, so
+the state does not leak into the immutable Trip schema.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Any, Iterable
+
+
+class CandidateState(str, Enum):
+    FETCHED = "fetched"
+    NORMALIZED = "normalized"
+    SELECTED = "selected"
+    REJECTED = "rejected"
+
+
+class StaleCandidateError(ValueError):
+    """Raised when a dynamic fact is too old for its caller-defined freshness limit."""
+
+
+@dataclass(frozen=True)
+class CandidateRecord:
+    collection: str
+    candidate: dict[str, Any]
+    state: CandidateState
+    stored_at: datetime
+
+    @property
+    def candidate_id(self) -> str:
+        if self.collection in {"restaurants", "hotels"}:
+            return self.candidate["place"]["id"]
+        return self.candidate["id"]
+
+
+class CandidateStore:
+    """In-memory candidate lifecycle store for one research job.
+
+    Candidate payloads remain compatible with Trip V1's ``candidate_sets``.  The
+    store's lifecycle state is operational metadata only and is never serialized
+    into that schema.
+    """
+
+    VALID_COLLECTIONS = frozenset({"places", "restaurants", "hotels", "flights", "transport_legs"})
+
+    def __init__(self, now: datetime | None = None) -> None:
+        self._now = now or datetime.now(timezone.utc)
+        self._records: dict[str, CandidateRecord] = {}
+
+    def ingest(self, collection: str, candidate: dict[str, Any]) -> CandidateRecord:
+        """Store a fetched canonical candidate after enforcing provenance invariants."""
+
+        if collection not in self.VALID_COLLECTIONS:
+            raise ValueError(f"unsupported candidate collection: {collection}")
+        provenance = candidate.get("provenance")
+        if not isinstance(provenance, dict) and collection in {"restaurants", "hotels"}:
+            provenance = candidate.get("place", {}).get("provenance")
+        retrieved_at = _parse_retrieved_at(provenance)
+        if not isinstance(provenance.get("provider"), str) or not provenance["provider"]:
+            raise ValueError("candidate provenance requires a provider")
+        record = CandidateRecord(collection, candidate, CandidateState.FETCHED, self._now)
+        self._records[record.candidate_id] = record
+        return record
+
+    def normalize(self, candidate_id: str) -> CandidateRecord:
+        return self._transition(candidate_id, {CandidateState.FETCHED}, CandidateState.NORMALIZED)
+
+    def select(self, candidate_id: str) -> CandidateRecord:
+        return self._transition(candidate_id, {CandidateState.NORMALIZED}, CandidateState.SELECTED)
+
+    def reject(self, candidate_id: str) -> CandidateRecord:
+        return self._transition(candidate_id, {CandidateState.FETCHED, CandidateState.NORMALIZED}, CandidateState.REJECTED)
+
+    def fresh(self, max_age: timedelta, now: datetime | None = None) -> list[CandidateRecord]:
+        """Return non-rejected records whose canonical provenance is still fresh."""
+
+        reference = now or datetime.now(timezone.utc)
+        records = []
+        for record in self._records.values():
+            if record.state is CandidateState.REJECTED:
+                continue
+            retrieved_at = _parse_retrieved_at(_provenance_for(record))
+            if reference - retrieved_at <= max_age:
+                records.append(record)
+        return records
+
+    def require_fresh(self, candidate_id: str, max_age: timedelta, now: datetime | None = None) -> CandidateRecord:
+        record = self._records[candidate_id]
+        reference = now or datetime.now(timezone.utc)
+        if reference - _parse_retrieved_at(_provenance_for(record)) > max_age:
+            raise StaleCandidateError(f"candidate {candidate_id} exceeds freshness limit")
+        return record
+
+    def records(self) -> Iterable[CandidateRecord]:
+        return tuple(self._records.values())
+
+    def _transition(self, candidate_id: str, allowed: set[CandidateState], target: CandidateState) -> CandidateRecord:
+        record = self._records[candidate_id]
+        if record.state not in allowed:
+            raise ValueError(f"cannot transition {candidate_id} from {record.state} to {target}")
+        updated = CandidateRecord(record.collection, record.candidate, target, record.stored_at)
+        self._records[candidate_id] = updated
+        return updated
+
+
+def _provenance_for(record: CandidateRecord) -> dict[str, Any]:
+    return record.candidate.get("provenance") or record.candidate["place"]["provenance"]
+
+
+def _parse_retrieved_at(provenance: Any) -> datetime:
+    if not isinstance(provenance, dict) or not provenance.get("retrieved_at"):
+        raise ValueError("candidate provenance requires retrieved_at")
+    try:
+        parsed = datetime.fromisoformat(provenance["retrieved_at"])
+    except (TypeError, ValueError) as exc:
+        raise ValueError("candidate provenance retrieved_at must be ISO 8601") from exc
+    if parsed.tzinfo is None:
+        raise ValueError("candidate provenance retrieved_at must include a timezone offset")
+    return parsed

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from src.sources import (
+    CandidateState,
+    CandidateStore,
+    FixtureCommunityRestaurantAdapter,
+    FixtureOfficialPoiAdapter,
+    SourceAdapter,
+    SourceQuery,
+    StaleCandidateError,
+    collect_from_adapters,
+)
+
+
+NOW = datetime(2026, 8, 10, 8, 0, tzinfo=timezone.utc)
+QUERY = SourceQuery(destination="福岡", categories=("pois", "restaurants"))
+
+
+class BrokenAdapter(SourceAdapter):
+    name = "broken-fixture"
+
+    def fetch(self, query):
+        raise RuntimeError("provider timeout")
+
+
+class SourceAdapterTests(unittest.TestCase):
+    def test_fixture_adapters_emit_canonical_provenance(self):
+        candidates, failures = collect_from_adapters(
+            [FixtureOfficialPoiAdapter(NOW), FixtureCommunityRestaurantAdapter(NOW)], QUERY
+        )
+        self.assertEqual([], failures)
+        self.assertEqual({"places", "restaurants"}, {collection for collection, _ in candidates})
+        for _, candidate in candidates:
+            provenance = candidate["provenance"]
+            self.assertEqual(NOW.isoformat(), provenance["retrieved_at"])
+            self.assertIn(provenance["source_type"], {"official", "community"})
+
+    def test_adapter_failure_is_isolated(self):
+        candidates, failures = collect_from_adapters(
+            [BrokenAdapter(), FixtureOfficialPoiAdapter(NOW)], QUERY
+        )
+        self.assertEqual(1, len(candidates))
+        self.assertEqual("places", candidates[0][0])
+        self.assertEqual(["broken-fixture"], [failure.adapter for failure in failures])
+
+
+class CandidateStoreTests(unittest.TestCase):
+    def setUp(self):
+        self.store = CandidateStore(now=NOW)
+        self.poi = list(FixtureOfficialPoiAdapter(NOW).fetch(QUERY))[0]
+
+    def test_lifecycle_does_not_mutate_canonical_candidate(self):
+        collection, candidate = self.poi
+        fetched = self.store.ingest(collection, candidate)
+        normalized = self.store.normalize(fetched.candidate_id)
+        selected = self.store.select(fetched.candidate_id)
+        self.assertEqual(CandidateState.FETCHED, fetched.state)
+        self.assertEqual(CandidateState.NORMALIZED, normalized.state)
+        self.assertEqual(CandidateState.SELECTED, selected.state)
+        self.assertNotIn("state", candidate)
+        self.assertNotIn("selected", candidate)
+
+    def test_retrieved_at_is_required_and_staleness_is_enforced(self):
+        collection, candidate = self.poi
+        self.store.ingest(collection, candidate)
+        self.assertEqual(1, len(self.store.fresh(timedelta(hours=1), now=NOW + timedelta(minutes=59))))
+        with self.assertRaises(StaleCandidateError):
+            self.store.require_fresh("ohori-park", timedelta(hours=1), now=NOW + timedelta(hours=1, seconds=1))
+        invalid = {**candidate, "provenance": {**candidate["provenance"]}}
+        del invalid["provenance"]["retrieved_at"]
+        with self.assertRaisesRegex(ValueError, "retrieved_at"):
+            CandidateStore(now=NOW).ingest(collection, invalid)
+
+    def test_community_candidate_preserves_reported_provenance(self):
+        collection, candidate = list(FixtureCommunityRestaurantAdapter(NOW).fetch(QUERY))[0]
+        record = self.store.ingest(collection, candidate)
+        self.assertEqual("community", record.candidate["provenance"]["source_type"])
+        self.assertEqual("reported", record.candidate["provenance"]["status"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Resolves #2

Adds provider-neutral source adapters, a candidate-store lifecycle, fixture adapters, provenance/staleness validation, and official-versus-community evidence guidance.

Validation: `python3 -m unittest discover -s tests -v`; `git diff --check`.