### PR TITLE
feat: add provider-neutral routing optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ AI 旅遊規劃平台：自動研究、最佳化行程、驗證時間與預算�
 
 [`Trip V1`](docs/canonical-trip-v1.md) 是 planner、validator、renderer、trip storage、map 與 budget 的唯一 source of truth。候選研究資料位於 `candidate_sets`，而最終行程只透過 ID 參照並保留在 `days`，兩者不可混用。
 
+## Routing / ordering
+
+路由與 POI 排序使用 provider-neutral 的 [`Routing and optimizer V1`](docs/routing-optimizer-v1.md)。路程查無資料會明確保留為 `unknown` 並交給 validator，不會被當成零分鐘。
+
 ## Architecture principles
 
 - **Trip data is the source of truth**：網站、地圖、預算與列印內容都從同一份 Trip schema 產生。

--- a/docs/routing-optimizer-v1.md
+++ b/docs/routing-optimizer-v1.md
@@ -1,0 +1,17 @@
+# Routing and optimizer V1
+
+`src.sources.routing` is the provider-neutral boundary for travel time. The planner, optimizer and validator receive one `RouteMatrix`; they do not import a provider SDK. A provider supplies a `Route` for a pair of canonical `PlaceRef` IDs (with optional coordinates) and one of `driving`, `transit` or `walking` modes.
+
+Each route retains `duration_seconds`, `distance_meters`, `RouteStatus`, and `RouteProvenance` (`provider`, `retrieved_at`, source metadata). An unavailable lookup is `RouteStatus.UNKNOWN` and has neither duration nor distance. It must not be converted to a guessed or zero-cost route.
+
+## Cache behaviour
+
+`RouteMatrix` caches both available and unknown provider results using `(mode, origin_place_id, destination_place_id)`. It may receive a TTL for live providers; without one, an instance is stable for the pipeline run. Passing that same instance to validation guarantees validation sees the same result that informed the ordering.
+
+`FixtureRoutingProvider` is a deterministic provider stub. `fixtures/routes/fukuoka-routing-fixture.json` documents the portable fixture shape; test fixtures can be instantiated directly as `Route` objects to avoid an I/O dependency.
+
+## Optimizer boundary
+
+`RouteOptimizer` brute-forces flexible POI order within each segment bounded by fixed-time anchors. It scores available route duration (with distance emitted in its result), keeping anchors in their original sequence and retaining their exact timestamps. The optimizer never creates, shifts, or relaxes schedule times.
+
+If any selected consecutive route is unknown, `OptimizationResult.travel_seconds` and `travel_meters` are `None` and it exposes `unknown_route_keys`. `validate_route_availability` turns those into machine-readable `route_unknown` warnings for the trip validator / repair loop.

--- a/fixtures/routes/fukuoka-routing-fixture.json
+++ b/fixtures/routes/fukuoka-routing-fixture.json
@@ -1,0 +1,10 @@
+{
+  "provider": "fixture-routing",
+  "retrieved_at": "2026-01-15T11:00:00+09:00",
+  "purpose": "Deterministic route data for local tests; absent entries represent unknown routes.",
+  "routes": [
+    {"mode": "driving", "origin_place_id": "ohori-park", "destination_place_id": "dazaifu", "duration_seconds": 2100, "distance_meters": 17000},
+    {"mode": "transit", "origin_place_id": "hakata-hotel", "destination_place_id": "ohori-park", "duration_seconds": 1500, "distance_meters": 5200},
+    {"mode": "walking", "origin_place_id": "hakata-hotel", "destination_place_id": "canal-city", "duration_seconds": 900, "distance_meters": 1100}
+  ]
+}

--- a/src/optimizer/__init__.py
+++ b/src/optimizer/__init__.py
@@ -1,0 +1,3 @@
+from .route_optimizer import OptimizationResult, RouteOptimizer, Stop
+
+__all__ = ["OptimizationResult", "RouteOptimizer", "Stop"]

--- a/src/optimizer/route_optimizer.py
+++ b/src/optimizer/route_optimizer.py
@@ -1,0 +1,100 @@
+"""Deterministic first-pass POI ordering using the shared route matrix."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from itertools import permutations
+
+from src.sources.routing import PlaceRef, RouteMatrix, RouteMode, RouteStatus
+
+
+@dataclass(frozen=True)
+class Stop:
+    place: PlaceRef
+    fixed_start_at: datetime | None = None
+    fixed_end_at: datetime | None = None
+
+    @property
+    def is_fixed_anchor(self) -> bool:
+        return self.fixed_start_at is not None or self.fixed_end_at is not None
+
+    def __post_init__(self) -> None:
+        if (self.fixed_start_at is None) != (self.fixed_end_at is None):
+            raise ValueError("fixed anchors require both start and end times")
+        if self.fixed_start_at is not None and self.fixed_start_at >= self.fixed_end_at:
+            raise ValueError("fixed anchor end must be after start")
+
+
+@dataclass(frozen=True)
+class OptimizationResult:
+    stops: tuple[Stop, ...]
+    travel_seconds: int | None
+    travel_meters: int | None
+    unknown_route_keys: tuple[tuple[str, str, str], ...]
+
+    @property
+    def has_unknown_routes(self) -> bool:
+        return bool(self.unknown_route_keys)
+
+
+class RouteOptimizer:
+    """Order flexible POIs inside fixed-anchor boundaries without scheduling changes.
+
+    Anchor timestamps are immutable and no stop may cross an anchor. Unknown routes make
+    the result explicitly unscored instead of being treated as zero-cost travel.
+    """
+
+    def __init__(self, matrix: RouteMatrix, mode: RouteMode) -> None:
+        self.matrix = matrix
+        self.mode = mode
+
+    def optimize(self, stops: list[Stop] | tuple[Stop, ...]) -> OptimizationResult:
+        result: list[Stop] = []
+        flexible: list[Stop] = []
+        previous_boundary: Stop | None = None
+
+        for stop in stops:
+            if stop.is_fixed_anchor:
+                result.extend(self._best_block(flexible, previous_boundary, stop))
+                flexible = []
+                result.append(stop)
+                previous_boundary = stop
+            else:
+                flexible.append(stop)
+        result.extend(self._best_block(flexible, previous_boundary, None))
+        return self._score(tuple(result))
+
+    def _best_block(self, stops: list[Stop], before: Stop | None, after: Stop | None) -> tuple[Stop, ...]:
+        if len(stops) < 2:
+            return tuple(stops)
+        candidates = tuple(permutations(stops))
+        scored = [(self._candidate_cost(order, before, after), order) for order in candidates]
+        usable = [candidate for candidate in scored if candidate[0] is not None]
+        if not usable:
+            return candidates[0]
+        return min(usable, key=lambda candidate: (candidate[0], tuple(s.place.place_id for s in candidate[1])))[1]
+
+    def _candidate_cost(self, stops: tuple[Stop, ...], before: Stop | None, after: Stop | None) -> int | None:
+        chain = ((before,) if before else ()) + stops + ((after,) if after else ())
+        total = 0
+        for first, second in zip(chain, chain[1:]):
+            route = self.matrix.route(first.place, second.place, self.mode)
+            if route.status is RouteStatus.UNKNOWN:
+                return None
+            total += route.duration_seconds or 0
+        return total
+
+    def _score(self, stops: tuple[Stop, ...]) -> OptimizationResult:
+        total_seconds = total_meters = 0
+        unknown: list[tuple[str, str, str]] = []
+        for first, second in zip(stops, stops[1:]):
+            route = self.matrix.route(first.place, second.place, self.mode)
+            if route.status is RouteStatus.UNKNOWN:
+                unknown.append(route.cache_key)
+                continue
+            total_seconds += route.duration_seconds or 0
+            total_meters += route.distance_meters or 0
+        if unknown:
+            return OptimizationResult(stops, None, None, tuple(unknown))
+        return OptimizationResult(stops, total_seconds, total_meters, ())

--- a/src/sources/routing/__init__.py
+++ b/src/sources/routing/__init__.py
@@ -1,0 +1,14 @@
+from .matrix import RouteMatrix
+from .models import PlaceRef, Route, RouteMode, RouteProvenance, RouteStatus
+from .provider import FixtureRoutingProvider, RoutingProvider
+
+__all__ = [
+    "FixtureRoutingProvider",
+    "PlaceRef",
+    "Route",
+    "RouteMatrix",
+    "RouteMode",
+    "RouteProvenance",
+    "RouteStatus",
+    "RoutingProvider",
+]

--- a/src/sources/routing/matrix.py
+++ b/src/sources/routing/matrix.py
@@ -1,0 +1,47 @@
+"""Shared route matrix with a cache for planner, optimizer and validator reuse."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Callable
+
+from .models import PlaceRef, Route, RouteMode
+from .provider import RoutingProvider
+
+
+class RouteMatrix:
+    """Cache every provider response, including UNKNOWN, by mode and canonical place IDs.
+
+    A finite TTL can be supplied for dynamic providers. A single matrix instance is passed
+    through pipeline stages so validation observes exactly the route result used by planning.
+    """
+
+    def __init__(
+        self,
+        provider: RoutingProvider,
+        *,
+        ttl: timedelta | None = None,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.provider = provider
+        self.ttl = ttl
+        self._now = now or (lambda: datetime.now(timezone.utc))
+        self._cache: dict[tuple[str, str, str], tuple[Route, datetime]] = {}
+
+    def route(self, origin: PlaceRef, destination: PlaceRef, mode: RouteMode) -> Route:
+        key = (mode.value, origin.place_id, destination.place_id)
+        cached = self._cache.get(key)
+        if cached is not None and not self._expired(cached[1]):
+            return cached[0]
+        route = self.provider.fetch(origin, destination, mode)
+        if route.cache_key != key:
+            raise ValueError("routing provider returned a route for a different request")
+        self._cache[key] = (route, self._now())
+        return route
+
+    def _expired(self, stored_at: datetime) -> bool:
+        return self.ttl is not None and self._now() - stored_at >= self.ttl
+
+    @property
+    def cached_routes(self) -> tuple[Route, ...]:
+        return tuple(item[0] for item in self._cache.values())

--- a/src/sources/routing/models.py
+++ b/src/sources/routing/models.py
@@ -1,0 +1,66 @@
+"""Provider-neutral route records used by planning, optimisation and validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+
+class RouteMode(str, Enum):
+    DRIVING = "driving"
+    TRANSIT = "transit"
+    WALKING = "walking"
+
+
+class RouteStatus(str, Enum):
+    AVAILABLE = "available"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class PlaceRef:
+    """A canonical place ID, optionally accompanied by coordinates for a provider."""
+
+    place_id: str
+    latitude: float | None = None
+    longitude: float | None = None
+
+    def __post_init__(self) -> None:
+        if (self.latitude is None) != (self.longitude is None):
+            raise ValueError("latitude and longitude must be provided together")
+
+
+@dataclass(frozen=True)
+class RouteProvenance:
+    provider: str
+    retrieved_at: datetime
+    source_type: str = "provider"
+    source_url: str | None = None
+    note: str | None = None
+
+
+@dataclass(frozen=True)
+class Route:
+    """A route result. Unknown results deliberately have no invented cost."""
+
+    origin: PlaceRef
+    destination: PlaceRef
+    mode: RouteMode
+    status: RouteStatus
+    provenance: RouteProvenance
+    duration_seconds: int | None = None
+    distance_meters: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.status is RouteStatus.AVAILABLE:
+            if self.duration_seconds is None or self.distance_meters is None:
+                raise ValueError("available routes require duration_seconds and distance_meters")
+            if self.duration_seconds < 0 or self.distance_meters < 0:
+                raise ValueError("route costs cannot be negative")
+        elif self.duration_seconds is not None or self.distance_meters is not None:
+            raise ValueError("unknown routes cannot contain guessed duration or distance")
+
+    @property
+    def cache_key(self) -> tuple[str, str, str]:
+        return (self.mode.value, self.origin.place_id, self.destination.place_id)

--- a/src/sources/routing/provider.py
+++ b/src/sources/routing/provider.py
@@ -1,0 +1,45 @@
+"""Routing provider contract and a fixture-backed deterministic implementation."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from typing import Iterable
+
+from .models import PlaceRef, Route, RouteMode, RouteProvenance, RouteStatus
+
+
+class RoutingProvider(ABC):
+    """Provider SDKs stay behind this contract."""
+
+    @abstractmethod
+    def fetch(self, origin: PlaceRef, destination: PlaceRef, mode: RouteMode) -> Route:
+        """Fetch one route. Implementations must return UNKNOWN on an unavailable route."""
+
+
+class FixtureRoutingProvider(RoutingProvider):
+    """In-memory provider stub for tests and repeatable local planning."""
+
+    def __init__(self, routes: Iterable[Route], provider_name: str = "fixture-routing") -> None:
+        self._routes = {route.cache_key: route for route in routes}
+        self.provider_name = provider_name
+        self.calls = 0
+
+    def fetch(self, origin: PlaceRef, destination: PlaceRef, mode: RouteMode) -> Route:
+        self.calls += 1
+        key = (mode.value, origin.place_id, destination.place_id)
+        route = self._routes.get(key)
+        if route is not None:
+            return route
+        return Route(
+            origin=origin,
+            destination=destination,
+            mode=mode,
+            status=RouteStatus.UNKNOWN,
+            provenance=RouteProvenance(
+                provider=self.provider_name,
+                retrieved_at=datetime.now(timezone.utc),
+                source_type="provider",
+                note="No fixture route is available",
+            ),
+        )

--- a/src/validator/__init__.py
+++ b/src/validator/__init__.py
@@ -11,6 +11,7 @@ from .itinerary import (
     Violation,
     validate_itinerary,
 )
+from .routing import validate_route_availability
 
 __all__ = [
     "DEFAULT_RULES",
@@ -22,4 +23,5 @@ __all__ = [
     "ValidationResult",
     "Violation",
     "validate_itinerary",
+    "validate_route_availability",
 ]

--- a/src/validator/routing.py
+++ b/src/validator/routing.py
@@ -1,0 +1,14 @@
+"""Machine-readable route availability checks reusable by a trip validator."""
+
+from __future__ import annotations
+
+from src.optimizer import OptimizationResult
+from .itinerary import Violation
+
+
+def validate_route_availability(result: OptimizationResult, path: str = "/days") -> list[Violation]:
+    """Expose unknown routing as a validator warning; never silently zero-cost it."""
+    return [
+        Violation("route_unknown", "warning", f"Route is unavailable for {origin} -> {destination} ({mode})", path)
+        for mode, origin, destination in result.unknown_route_keys
+    ]

--- a/tests/test_routing_optimizer.py
+++ b/tests/test_routing_optimizer.py
@@ -1,0 +1,86 @@
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from src.optimizer import RouteOptimizer, Stop
+from src.sources.routing import (
+    FixtureRoutingProvider,
+    PlaceRef,
+    Route,
+    RouteMatrix,
+    RouteMode,
+    RouteProvenance,
+    RouteStatus,
+)
+from src.validator import validate_route_availability
+
+
+NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def route(origin: str, destination: str, seconds: int, meters: int | None = None) -> Route:
+    return Route(
+        PlaceRef(origin), PlaceRef(destination), RouteMode.DRIVING, RouteStatus.AVAILABLE,
+        RouteProvenance("fixture-routing", NOW), seconds, meters if meters is not None else seconds * 10,
+    )
+
+
+class RoutingAndOptimizerTests(unittest.TestCase):
+    def test_matrix_caches_provider_result_including_unknown(self):
+        provider = FixtureRoutingProvider([route("a", "b", 120)])
+        matrix = RouteMatrix(provider)
+        self.assertEqual(matrix.route(PlaceRef("a"), PlaceRef("b"), RouteMode.DRIVING).duration_seconds, 120)
+        self.assertEqual(matrix.route(PlaceRef("a"), PlaceRef("b"), RouteMode.DRIVING).duration_seconds, 120)
+        self.assertEqual(provider.calls, 1)
+        self.assertEqual(matrix.route(PlaceRef("b"), PlaceRef("missing"), RouteMode.DRIVING).status, RouteStatus.UNKNOWN)
+        self.assertEqual(matrix.route(PlaceRef("b"), PlaceRef("missing"), RouteMode.DRIVING).status, RouteStatus.UNKNOWN)
+        self.assertEqual(provider.calls, 2)
+
+    def test_matrix_refreshes_after_ttl(self):
+        clock = [NOW]
+        provider = FixtureRoutingProvider([route("a", "b", 120)])
+        matrix = RouteMatrix(provider, ttl=timedelta(minutes=5), now=lambda: clock[0])
+        matrix.route(PlaceRef("a"), PlaceRef("b"), RouteMode.DRIVING)
+        clock[0] += timedelta(minutes=5)
+        matrix.route(PlaceRef("a"), PlaceRef("b"), RouteMode.DRIVING)
+        self.assertEqual(provider.calls, 2)
+
+    def test_four_poi_ordering_clusters_low_travel_route(self):
+        # a -> c -> b -> d is 3 minutes total; the input deliberately is scrambled.
+        routes = [
+            route("a", "c", 60), route("c", "b", 60), route("b", "d", 60),
+            route("a", "b", 600), route("a", "d", 900), route("b", "c", 600),
+            route("c", "d", 600), route("d", "b", 900), route("d", "c", 900),
+        ]
+        optimizer = RouteOptimizer(RouteMatrix(FixtureRoutingProvider(routes)), RouteMode.DRIVING)
+        result = optimizer.optimize([Stop(PlaceRef("a")), Stop(PlaceRef("d")), Stop(PlaceRef("b")), Stop(PlaceRef("c"))])
+        self.assertEqual([stop.place.place_id for stop in result.stops], ["a", "c", "b", "d"])
+        self.assertEqual(result.travel_seconds, 180)
+        self.assertEqual(result.travel_meters, 1800)
+
+    def test_fixed_time_anchor_is_not_moved_or_rescheduled(self):
+        fixed_start = datetime(2026, 4, 10, 12, tzinfo=timezone.utc)
+        fixed_end = datetime(2026, 4, 10, 13, tzinfo=timezone.utc)
+        anchor = Stop(PlaceRef("reservation"), fixed_start, fixed_end)
+        routes = [
+            route("a", "b", 60), route("b", "reservation", 60), route("a", "reservation", 500),
+            route("reservation", "c", 60), route("reservation", "d", 500), route("c", "d", 60),
+        ]
+        optimizer = RouteOptimizer(RouteMatrix(FixtureRoutingProvider(routes)), RouteMode.DRIVING)
+        result = optimizer.optimize([Stop(PlaceRef("b")), Stop(PlaceRef("a")), anchor, Stop(PlaceRef("d")), Stop(PlaceRef("c"))])
+        self.assertEqual([stop.place.place_id for stop in result.stops], ["a", "b", "reservation", "c", "d"])
+        optimized_anchor = result.stops[2]
+        self.assertEqual((optimized_anchor.fixed_start_at, optimized_anchor.fixed_end_at), (fixed_start, fixed_end))
+
+    def test_unknown_route_reaches_validator_without_zero_cost(self):
+        optimizer = RouteOptimizer(RouteMatrix(FixtureRoutingProvider([])), RouteMode.WALKING)
+        result = optimizer.optimize([Stop(PlaceRef("a")), Stop(PlaceRef("b"))])
+        self.assertTrue(result.has_unknown_routes)
+        self.assertIsNone(result.travel_seconds)
+        self.assertIsNone(result.travel_meters)
+        violations = validate_route_availability(result, "/days/0/items")
+        self.assertEqual(violations[0].code, "route_unknown")
+        self.assertEqual(violations[0].path, "/days/0/items")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Resolves #5

Adds provider-neutral route-matrix contracts, caching and provenance, fixture routing, a four-POI optimizer, fixed-time anchor handling, and unknown-route validator propagation.

Validation: `python3 -m unittest discover -s tests -v` (14 passed).