### PR TITLE
feat: add mobile static trip renderer

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,32 @@
+name: Deploy trip site to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - name: Build static site from canonical fixture
+        run: python3 -m src.renderer.build_site fixtures/trips/japan-5-day-trip-v1.json --output site
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -63,3 +63,19 @@ ai-travel-planner/
 > 輸入「五天四夜 XX 日本行 + 人數 + 預算 + 偏好」後，產生結構化 Trip 資料，驗證時間 / 路程 / 預算，並生成可在旅途中使用的 mobile-first 網站。
 
 `ai_kyushu` 將作為第一個 reference trip / golden output，用來定義實際旅途中需要的資訊密度與網站可用性。
+
+## Static trip renderer
+
+The dependency-free renderer turns Canonical Trip V1 JSON into a mobile-first
+static site. It only presents canonical fields and optional upstream derived
+read models; it does not validate, route, optimise, or calculate correctness.
+
+```sh
+python3 -m src.renderer.build_site fixtures/trips/japan-5-day-trip-v1.json --output site
+open site/index.html
+```
+
+The page includes Overview, Itinerary, and Budget. It surfaces upstream
+`validation` messages, provenance status, and each source's `retrieved_at`
+value (source freshness). GitHub Pages runs this same fixture build on pushes
+to `main` via `.github/workflows/deploy-pages.yml`.

--- a/src/renderer/build_site.py
+++ b/src/renderer/build_site.py
@@ -1,0 +1,86 @@
+"""Dependency-free static renderer for Canonical Trip V1 documents.
+
+It only formats canonical fields and optional upstream read models. It never
+validates, routes, optimises, or decides whether an itinerary is correct.
+"""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from html import escape
+import json
+from pathlib import Path
+from typing import Any
+
+
+def build_site(trip: dict[str, Any], derived: dict[str, Any] | None = None) -> str:
+    """Render a self-contained mobile-first HTML document."""
+    derived = derived or {}
+    places = {p["id"]: p for p in trip["candidate_sets"].get("places", [])}
+    title = escape(trip.get("title", "Trip"))
+    dates = trip.get("date_range", {})
+    overview = derived.get("overview", {})
+    stats = "".join(f'<div class="stat"><span>{escape(str(k))}</span><strong>{escape(str(v))}</strong></div>' for k, v in overview.items())
+    if not stats:
+        stats = f'<div class="stat"><span>旅遊日期</span><strong>{escape(dates.get("start_date", "—"))} ～ {escape(dates.get("end_date", "—"))}</strong></div>'
+    warnings = "".join(f"<li>{escape(_warning_text(x))}</li>" for x in trip.get("validation", [])) or '<li class="quiet">目前沒有上游 validation warning。</li>'
+    days = "".join(_render_day(day, places) for day in trip.get("days", []))
+    budget = "".join(f"<tr><th>{escape(str(k))}</th><td>{escape(_money(v))}</td></tr>" for k, v in trip.get("budget", {}).get("categories", {}).items())
+    total = derived.get("budget", {}).get("total_label") or _money(trip.get("budget", {}).get("total", {}))
+    sources = "".join(_render_source(x) for x in _sources(trip)) or '<p class="quiet">沒有未確認來源資料。</p>'
+    return f'''<!doctype html><html lang="zh-Hant"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>{title}</title><style>{_CSS}</style></head><body><main>
+<header><p class="eyebrow">TRIP · {escape(trip.get("local_timezone", ""))}</p><h1>{title}</h1><div class="stats">{stats}</div></header>
+<nav aria-label="行程區段"><a href="#overview">總覽</a><a href="#itinerary">行程</a><a href="#budget">預算</a></nav>
+<section id="overview"><h2>總覽</h2><h3>Validation warnings</h3><ul class="warnings">{warnings}</ul><h3>未確認與估算資訊</h3><p class="hint">以下狀態由資料來源提供；此頁不判定行程是否可行。</p><div class="sources">{sources}</div></section>
+<section id="itinerary"><h2>行程</h2>{days}</section><section id="budget"><h2>預算</h2><table><tbody>{budget}</tbody><tfoot><tr><th>總計</th><td>{escape(str(total))}</td></tr></tfoot></table></section>
+</main></body></html>'''
+
+
+def _render_day(day: dict[str, Any], places: dict[str, dict[str, Any]]) -> str:
+    items = []
+    for item in day.get("items", []):
+        place = places.get(item.get("place_id"), {})
+        items.append(f'<li><time>{escape(_time(item.get("start_at", "")))}</time><strong>{escape(place.get("name", item.get("place_id", "—")))}</strong><span>{escape(item.get("kind", ""))}</span></li>')
+    return f'<article><p class="eyebrow">{escape(day.get("date", ""))}</p><h3>{escape(day.get("summary", ""))}</h3><ol>{"".join(items)}</ol></article>'
+
+
+def _sources(trip: dict[str, Any]) -> list[dict[str, Any]]:
+    return [{"name": p.get("name", p.get("id", "—")), "provenance": p["provenance"]} for p in trip.get("candidate_sets", {}).get("places", []) if p.get("provenance", {}).get("status") in {"reported", "estimated", "unverified"}]
+
+
+def _render_source(item: dict[str, Any]) -> str:
+    p = item["provenance"]
+    provider = escape(str(p.get("provider", "未知來源")))
+    provider = f'<a href="{escape(str(p["source_url"]), quote=True)}">{provider}</a>' if p.get("source_url") else provider
+    return f'<article class="source"><strong>{escape(str(item["name"]))}</strong><span class="badge">{escape(str(p.get("status", "unknown")))}</span><p>{provider} · source freshness: {escape(str(p.get("retrieved_at", "unknown")))}</p></article>'
+
+
+def _warning_text(value: Any) -> str:
+    return value if isinstance(value, str) else json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _time(value: str) -> str:
+    try: return datetime.fromisoformat(value).strftime("%H:%M")
+    except ValueError: return value
+
+
+def _money(value: Any) -> str:
+    if not isinstance(value, dict): return "—"
+    amount, currency = value.get("amount", "—"), value.get("currency", "")
+    return f"{currency} {amount:,}" if isinstance(amount, (int, float)) else f"{currency} {amount}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build a static Trip V1 site")
+    parser.add_argument("trip", type=Path); parser.add_argument("--derived", type=Path); parser.add_argument("--output", type=Path, default=Path("site"))
+    args = parser.parse_args(); trip = json.loads(args.trip.read_text(encoding="utf-8"))
+    derived = json.loads(args.derived.read_text(encoding="utf-8")) if args.derived else None
+    args.output.mkdir(parents=True, exist_ok=True); (args.output / "index.html").write_text(build_site(trip, derived), encoding="utf-8")
+
+
+_CSS = '''
+:root{--ink:#172033;--muted:#5d6779;--line:#dce1e9;--accent:#0b6e69}*{box-sizing:border-box}body{margin:0;background:#f3f6f8;color:var(--ink);font:16px/1.5 -apple-system,BlinkMacSystemFont,"Noto Sans TC",sans-serif}main{max-width:680px;margin:auto;padding:20px 16px 48px}header,section,article{background:#fff;border:1px solid var(--line);border-radius:16px}header,section{padding:20px;margin-bottom:14px}h1{font-size:28px;line-height:1.2;margin:4px 0 18px}h2{font-size:21px;margin:0 0 16px}h3{font-size:17px;margin:12px 0 8px}.eyebrow{color:var(--muted);font-size:12px;font-weight:700;letter-spacing:.06em;margin:0}.stats{display:grid;gap:8px}.stat{background:#eaf5f3;border-radius:10px;padding:10px 12px}.stat span,.stat strong{display:block}.stat span,.hint,.quiet,.source p{color:var(--muted);font-size:14px}nav{display:flex;gap:8px;overflow:auto;position:sticky;top:0;padding:8px 0;background:#f3f6f8;z-index:1}nav a{background:#fff;border:1px solid var(--line);border-radius:999px;color:var(--ink);padding:7px 13px;text-decoration:none;white-space:nowrap}ul,ol{padding-left:20px}.warnings li{color:#9a5200;margin:6px 0}.warnings .quiet{color:var(--muted)}article{padding:14px;margin:10px 0}article h3{margin-top:3px}ol{list-style:none;padding:0;margin:10px 0 0}ol li{display:grid;grid-template-columns:56px 1fr;gap:3px 10px;border-top:1px solid var(--line);padding:10px 0}ol li:first-child{border-top:0}time,ol span{color:var(--muted);font-size:14px}ol span{grid-column:2}.source{display:grid;grid-template-columns:1fr auto;gap:2px 8px}.source p{grid-column:1/-1;margin:2px 0 0}.badge{color:#704400;background:#fff1d6;border-radius:999px;font-size:12px;font-weight:700;padding:2px 8px}table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid var(--line);padding:10px 0;text-align:left}td{text-align:right}tfoot{font-weight:800}@media(max-width:390px){main{padding:12px 10px 32px}header,section{padding:16px}h1{font-size:25px}}
+'''
+
+
+if __name__ == "__main__": main()

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+from src.renderer.build_site import build_site
+
+
+FIXTURE = Path("fixtures/trips/japan-5-day-trip-v1.json")
+
+
+def test_renderer_shows_core_views_and_provenance_state():
+    html = build_site(json.loads(FIXTURE.read_text(encoding="utf-8")))
+    assert "總覽" in html and "行程" in html and "預算" in html
+    assert "博多家庭飯店" in html
+    assert "JPY 169,000" in html
+    assert "reported" in html
+    assert "source freshness:" in html
+    assert "目前沒有上游 validation warning" in html
+
+
+def test_renderer_displays_upstream_validation_without_evaluating_it():
+    trip = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    trip["validation"] = [{"code": "schedule_conflict", "message": "由 validator 提供"}]
+    assert "schedule_conflict" in build_site(trip)


### PR DESCRIPTION
Resolves #6

Adds a canonical-Trip-only mobile static renderer with Overview, Itinerary, and Budget views; it surfaces upstream validation and source freshness without making itinerary decisions. Includes a GitHub Pages deployment workflow.

Validation: `python3 -m pytest -q` (6 passed); fixture static-site build verified.