### PR TITLE
feat: add itinerary planner and repair loop

### DIFF
--- a/docs/itinerary-validator.md
+++ b/docs/itinerary-validator.md
@@ -1,0 +1,19 @@
+# Deterministic itinerary validator
+
+`src.validator.validate_itinerary` consumes a canonical Trip V1 document and optional explicit, already-derived inputs. It never calls a routing or place-data provider and never changes the trip document.
+
+```python
+from src.validator import ValidationContext, validate_itinerary
+
+result = validate_itinerary(trip, ValidationContext(travel_minutes={...}, opening_hours={...}))
+```
+
+The result serializes as `{ "outcome": "valid|invalid|incomplete", "violations": [...] }`. Each violation contains stable `code`, `severity`, `message`, and JSON-pointer `path` fields. Any error is `invalid`; warnings with no errors are `incomplete`; no violations is `valid`.
+
+## Derived input contract
+
+- `travel_minutes[(from_place_id, to_place_id)]` is a non-negative route duration. An absent route is `travel_time.unverified`.
+- `opening_hours[place_id]` is a sequence of `OpeningInterval(weekday, opens_at, closes_at)`, using Monday `0` through Sunday `6` and local wall times. An absent scheduled visit or meal is `opening_hours.unverified`.
+- `budget_limit=BudgetLimit(amount, currency)` is an optional explicit cap. The validator always checks the Trip V1 category arithmetic and currency consistency.
+
+The default registry runs time overlap, travel time, opening hours, and budget rules in that order. Construct `RuleRegistry` and call `register(rule)` to add deterministic rules; each rule receives `(trip, context)` and returns violations.

--- a/docs/planner-contract.md
+++ b/docs/planner-contract.md
@@ -1,0 +1,9 @@
+# Planner contract
+
+`src.planner` evaluates explicit Canonical Trip V1 candidate documents. It does not schedule raw research candidates: no travel time, opening hours, visit duration, or reservation time is inferred when that fact is absent.
+
+`PlannerInput` accepts candidate trips, a `ValidationContext`, typed `HardConstraint` values, `SoftPreference` values, and a repair iteration ceiling. `PlannerOutput` contains one `CandidatePlan` per input, ranked only after all hard-rule errors have been cleared.
+
+Hard constraints support fixed flight/train or reservation times (`fixed_time` / `reservation_time`), required or forbidden locations, and strict maximum daily duration. Opening hours, impossible transport timing, and strict budget ceilings are enforced from the supplied validator context. Soft preferences are score-only. `low_fatigue` and `few_hotel_changes` have deterministic scoring; preferences without explicit supporting candidate facts remain neutral.
+
+Each replan reapplies `overrides` whose `preserve_on_replan` is true. The repair loop modifies only paths identified by `time.overlap` or `travel_time.insufficient`, then invokes the validator again. Unrepairable violations, or violations remaining after `max_repair_iterations`, produce `PlanState.FAILED`; they are never returned as a best plan.

--- a/src/planner/__init__.py
+++ b/src/planner/__init__.py
@@ -1,0 +1,6 @@
+"""Planner public API."""
+
+from .contracts import CandidatePlan, HardConstraint, PlanState, PlannerInput, PlannerOutput, SoftPreference
+from .planner import plan
+
+__all__ = ["CandidatePlan", "HardConstraint", "PlanState", "PlannerInput", "PlannerOutput", "SoftPreference", "plan"]

--- a/src/planner/contracts.py
+++ b/src/planner/contracts.py
@@ -1,0 +1,76 @@
+"""Explicit, deterministic planner input and output contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from src.validator import ValidationContext, Violation
+
+
+class PlanState(str, Enum):
+    READY = "ready"
+    REPAIRED = "repaired"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class HardConstraint:
+    """A non-negotiable planning condition, evaluated before soft scoring.
+
+    Supported kinds are ``fixed_time``, ``reservation_time``,
+    ``required_location``, ``forbidden_location`` and
+    ``max_daily_duration``.  Opening-hours, transport feasibility, and a
+    strict budget ceiling are supplied through :class:`ValidationContext` so
+    the planner never invents those facts.
+    """
+
+    id: str
+    kind: str
+    value: Any
+    strict: bool = True
+
+
+@dataclass(frozen=True)
+class SoftPreference:
+    """A ranking signal only; it can never make an invalid plan acceptable."""
+
+    id: str
+    kind: str
+    value: Any = True
+    weight: float = 1.0
+
+
+@dataclass(frozen=True)
+class PlannerInput:
+    """Candidate Trip V1 documents plus only explicit derived validation facts."""
+
+    candidate_trips: Sequence[dict]
+    validation_context: ValidationContext = field(default_factory=ValidationContext)
+    hard_constraints: Sequence[HardConstraint] = ()
+    soft_preferences: Sequence[SoftPreference] = ()
+    max_repair_iterations: int = 3
+
+
+@dataclass(frozen=True)
+class CandidatePlan:
+    trip: dict
+    score: float
+    state: PlanState
+    violations: tuple[Violation, ...]
+    repair_iterations: int
+
+
+@dataclass(frozen=True)
+class PlannerOutput:
+    plans: tuple[CandidatePlan, ...]
+
+    @property
+    def successful_plans(self) -> tuple[CandidatePlan, ...]:
+        return tuple(plan for plan in self.plans if plan.state is not PlanState.FAILED)
+
+    @property
+    def best_plan(self) -> CandidatePlan | None:
+        successful = self.successful_plans
+        return successful[0] if successful else None

--- a/src/planner/planner.py
+++ b/src/planner/planner.py
@@ -1,0 +1,168 @@
+"""Candidate evaluation and bounded, violation-scoped itinerary repair."""
+
+from __future__ import annotations
+
+import copy
+from datetime import datetime, timedelta
+from typing import Iterable
+
+from src.validator import Outcome, Violation, validate_itinerary
+
+from .contracts import CandidatePlan, HardConstraint, PlanState, PlannerInput, PlannerOutput, SoftPreference
+
+
+def plan(request: PlannerInput) -> PlannerOutput:
+    """Validate, repair, and rank explicit Trip V1 candidate plans.
+
+    This module deliberately does not turn research candidates into scheduled
+    visits: it lacks authoritative routing, opening-hours, and duration facts.
+    Upstream scheduling can submit multiple Trip V1 candidates here, where hard
+    constraints are checked before soft-preference scoring.
+    """
+
+    if request.max_repair_iterations < 0:
+        raise ValueError("max_repair_iterations must be non-negative")
+    plans = [_evaluate(copy.deepcopy(trip), request) for trip in request.candidate_trips]
+    return PlannerOutput(tuple(sorted(plans, key=lambda item: (item.state is PlanState.FAILED, -item.score))))
+
+
+def _evaluate(trip: dict, request: PlannerInput) -> CandidatePlan:
+    _preserve_overrides(trip)
+    iterations = 0
+    violations = _validate(trip, request)
+    while _has_errors(violations) and iterations < request.max_repair_iterations:
+        changed = _repair_only_violating_scope(trip, violations, request)
+        if not changed:
+            return CandidatePlan(trip, float("-inf"), PlanState.FAILED, tuple(violations), iterations)
+        iterations += 1
+        _preserve_overrides(trip)
+        violations = _validate(trip, request)
+    if _has_errors(violations):
+        return CandidatePlan(trip, float("-inf"), PlanState.FAILED, tuple(violations), iterations)
+    state = PlanState.REPAIRED if iterations else PlanState.READY
+    return CandidatePlan(trip, _score(trip, request.soft_preferences), state, tuple(violations), iterations)
+
+
+def _validate(trip: dict, request: PlannerInput) -> list[Violation]:
+    result = validate_itinerary(trip, request.validation_context)
+    return [*result.violations, *_hard_constraint_violations(trip, request.hard_constraints)]
+
+
+def _hard_constraint_violations(trip: dict, constraints: Iterable[HardConstraint]) -> list[Violation]:
+    violations: list[Violation] = []
+    items = [(day_index, item_index, item) for day_index, day in enumerate(trip.get("days", [])) for item_index, item in enumerate(day.get("items", []))]
+    for constraint in constraints:
+        if not constraint.strict:
+            continue
+        value = constraint.value
+        if constraint.kind in {"fixed_time", "reservation_time"}:
+            matched = [(day, index, item) for day, index, item in items if item.get("id") == value.get("item_id")]
+            if len(matched) != 1 or any(item.get(key) != value.get(key) for _, _, item in matched for key in ("start_at", "end_at")):
+                violations.append(_constraint_violation(constraint, "/days", "fixed or reserved time is not preserved"))
+        elif constraint.kind == "required_location":
+            if not any(item.get("place_id") == value for _, _, item in items):
+                violations.append(_constraint_violation(constraint, "/days", "required location is absent"))
+        elif constraint.kind == "forbidden_location":
+            if any(item.get("place_id") == value for _, _, item in items):
+                violations.append(_constraint_violation(constraint, "/days", "forbidden location is scheduled"))
+        elif constraint.kind == "max_daily_duration":
+            maximum = float(value)
+            for day_index, day in enumerate(trip.get("days", [])):
+                scheduled = day.get("items", [])
+                if scheduled:
+                    starts_ends = [(_timestamp(item["start_at"]), _timestamp(item["end_at"])) for item in scheduled]
+                    duration = (max(end for _, end in starts_ends) - min(start for start, _ in starts_ends)).total_seconds() / 60
+                    if duration > maximum:
+                        violations.append(_constraint_violation(constraint, f"/days/{day_index}", f"daily duration {duration:g} exceeds {maximum:g} minutes"))
+        else:
+            raise ValueError(f"unsupported hard constraint kind: {constraint.kind}")
+    return violations
+
+
+def _repair_only_violating_scope(trip: dict, violations: Iterable[Violation], request: PlannerInput) -> bool:
+    """Repair only time-related violating item paths; leave all other scope intact."""
+
+    changed = False
+    for violation in violations:
+        if violation.code not in {"time.overlap", "travel_time.insufficient"}:
+            continue
+        location = _parse_item_path(violation.path)
+        if location is None:
+            continue
+        day_index, item_index = location
+        day = trip["days"][day_index]
+        item = day["items"][item_index]
+        previous = _previous_item(day["items"], item_index)
+        if previous is None:
+            continue
+        start, end = _timestamp(item["start_at"]), _timestamp(item["end_at"])
+        required_start = _timestamp(previous["end_at"])
+        travel = request.validation_context.travel_minutes.get((previous["place_id"], item["place_id"]), 0)
+        required_start += timedelta(minutes=travel)
+        if start < required_start:
+            duration = end - start
+            item["start_at"] = required_start.isoformat()
+            item["end_at"] = (required_start + duration).isoformat()
+            changed = True
+    return changed
+
+
+def _preserve_overrides(trip: dict) -> None:
+    for override in trip.get("overrides", []):
+        if override.get("preserve_on_replan"):
+            _set_json_pointer(trip, override["path"], copy.deepcopy(override["value"]))
+
+
+def _set_json_pointer(document: dict, pointer: str, value: object) -> None:
+    parts = pointer.lstrip("/").split("/")
+    if not pointer.startswith("/") or not all(parts):
+        raise ValueError(f"invalid override path: {pointer}")
+    current: object = document
+    for part in parts[:-1]:
+        if not isinstance(current, dict) or part not in current:
+            raise ValueError(f"override path is not present: {pointer}")
+        current = current[part]
+    if not isinstance(current, dict):
+        raise ValueError(f"override path cannot be set: {pointer}")
+    current[parts[-1]] = value
+
+
+def _score(trip: dict, preferences: Iterable[SoftPreference]) -> float:
+    score = 0.0
+    item_count = sum(len(day.get("items", [])) for day in trip.get("days", []))
+    for preference in preferences:
+        if preference.kind == "low_fatigue":
+            score -= item_count * preference.weight
+        elif preference.kind == "few_hotel_changes":
+            score -= max(0, len(trip.get("selected", {}).get("hotel_place_ids", [])) - 1) * preference.weight
+        # Other preference kinds remain neutral when the candidate data has no
+        # explicit matching fact; a planner must not infer it.
+    return score
+
+
+def _constraint_violation(constraint: HardConstraint, path: str, message: str) -> Violation:
+    return Violation(f"constraint.{constraint.kind}", "error", message, path)
+
+
+def _has_errors(violations: Iterable[Violation]) -> bool:
+    return any(violation.severity == "error" for violation in violations)
+
+
+def _parse_item_path(path: str) -> tuple[int, int] | None:
+    parts = path.strip("/").split("/")
+    if len(parts) != 4 or parts[0] != "days" or parts[2] != "items":
+        return None
+    try:
+        return int(parts[1]), int(parts[3])
+    except ValueError:
+        return None
+
+
+def _previous_item(items: list[dict], item_index: int) -> dict | None:
+    item = items[item_index]
+    earlier = [candidate for index, candidate in enumerate(items) if index != item_index and _timestamp(candidate["start_at"]) <= _timestamp(item["start_at"])]
+    return max(earlier, key=lambda candidate: _timestamp(candidate["start_at"]), default=None)
+
+
+def _timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value)

--- a/src/validator/__init__.py
+++ b/src/validator/__init__.py
@@ -1,0 +1,25 @@
+"""Public deterministic itinerary validation API."""
+
+from .itinerary import (
+    DEFAULT_RULES,
+    BudgetLimit,
+    OpeningInterval,
+    Outcome,
+    RuleRegistry,
+    ValidationContext,
+    ValidationResult,
+    Violation,
+    validate_itinerary,
+)
+
+__all__ = [
+    "DEFAULT_RULES",
+    "BudgetLimit",
+    "OpeningInterval",
+    "Outcome",
+    "RuleRegistry",
+    "ValidationContext",
+    "ValidationResult",
+    "Violation",
+    "validate_itinerary",
+]

--- a/src/validator/itinerary.py
+++ b/src/validator/itinerary.py
@@ -1,0 +1,215 @@
+"""Deterministic validation rules for Canonical Trip V1 itineraries.
+
+The validator deliberately does not enrich a trip or call external services.
+Facts that are not part of Trip V1 (routing results and opening hours) are
+passed in as a :class:`ValidationContext`, making every result reproducible.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, time
+from enum import Enum
+from typing import Callable, Mapping, Sequence
+
+
+class Outcome(str, Enum):
+    VALID = "valid"
+    INVALID = "invalid"
+    INCOMPLETE = "incomplete"
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A stable, machine-readable result emitted by one validation rule."""
+
+    code: str
+    severity: str
+    message: str
+    path: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "path": self.path,
+        }
+
+
+@dataclass(frozen=True)
+class OpeningInterval:
+    """A local opening interval; weekday uses Python's Monday=0 convention."""
+
+    weekday: int
+    opens_at: time
+    closes_at: time
+
+
+@dataclass(frozen=True)
+class BudgetLimit:
+    amount: float
+    currency: str
+
+
+@dataclass(frozen=True)
+class ValidationContext:
+    """Explicit derived inputs needed by rules which Trip V1 does not contain.
+
+    ``travel_minutes`` is keyed by ``(from_place_id, to_place_id)``. Omit a
+    route when it is unknown; the travel rule will emit an unverified warning.
+    ``opening_hours`` is keyed by place ID and lists local weekly intervals.
+    Omit a scheduled place when its hours are unknown.
+    """
+
+    travel_minutes: Mapping[tuple[str, str], int] = field(default_factory=dict)
+    opening_hours: Mapping[str, Sequence[OpeningInterval]] = field(default_factory=dict)
+    budget_limit: BudgetLimit | None = None
+
+
+Rule = Callable[[dict, ValidationContext], Sequence[Violation]]
+
+
+class RuleRegistry:
+    """Ordered registry so callers can add deterministic rules without forking."""
+
+    def __init__(self, rules: Sequence[Rule] = ()) -> None:
+        self._rules = list(rules)
+
+    def register(self, rule: Rule) -> Rule:
+        self._rules.append(rule)
+        return rule
+
+    def run(self, trip: dict, context: ValidationContext) -> list[Violation]:
+        return [violation for rule in self._rules for violation in rule(trip, context)]
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    outcome: Outcome
+    violations: tuple[Violation, ...]
+
+    @property
+    def is_valid(self) -> bool:
+        return self.outcome is Outcome.VALID
+
+    def as_dict(self) -> dict[str, object]:
+        return {"outcome": self.outcome.value, "violations": [v.as_dict() for v in self.violations]}
+
+
+def validate_itinerary(
+    trip: dict, context: ValidationContext | None = None, registry: RuleRegistry | None = None
+) -> ValidationResult:
+    """Run deterministic itinerary rules against an already canonical Trip V1 model."""
+
+    violations = tuple((registry or DEFAULT_RULES).run(trip, context or ValidationContext()))
+    if any(item.severity == "error" for item in violations):
+        outcome = Outcome.INVALID
+    elif violations:
+        outcome = Outcome.INCOMPLETE
+    else:
+        outcome = Outcome.VALID
+    return ValidationResult(outcome, violations)
+
+
+def time_overlap_rule(trip: dict, _: ValidationContext) -> Sequence[Violation]:
+    violations: list[Violation] = []
+    for day_index, day in enumerate(trip.get("days", [])):
+        scheduled = sorted(enumerate(day.get("items", [])), key=lambda pair: pair[1]["start_at"])
+        previous_index: int | None = None
+        previous_end: datetime | None = None
+        for item_index, item in scheduled:
+            start, end = _timestamps(item)
+            path = _item_path(day_index, item_index)
+            if end <= start:
+                violations.append(_error("time.invalid_interval", "item end must be after its start", path))
+            if previous_end is not None and start < previous_end:
+                violations.append(_error("time.overlap", "item overlaps the preceding scheduled item", path))
+            if previous_end is None or end > previous_end:
+                previous_index, previous_end = item_index, end
+    return violations
+
+
+def travel_time_rule(trip: dict, context: ValidationContext) -> Sequence[Violation]:
+    violations: list[Violation] = []
+    for day_index, day in enumerate(trip.get("days", [])):
+        scheduled = sorted(enumerate(day.get("items", [])), key=lambda pair: pair[1]["start_at"])
+        for (previous_index, previous), (item_index, item) in zip(scheduled, scheduled[1:]):
+            if previous["place_id"] == item["place_id"]:
+                continue
+            path = _item_path(day_index, item_index)
+            route = (previous["place_id"], item["place_id"])
+            minutes = context.travel_minutes.get(route)
+            if minutes is None:
+                violations.append(_warning("travel_time.unverified", f"travel time for {route[0]} to {route[1]} is unknown", path))
+                continue
+            if minutes < 0:
+                violations.append(_error("travel_time.invalid", "travel duration cannot be negative", path))
+                continue
+            available_minutes = (_timestamps(item)[0] - _timestamps(previous)[1]).total_seconds() / 60
+            if available_minutes < minutes:
+                violations.append(_error("travel_time.insufficient", f"requires {minutes} minutes but only {available_minutes:g} minutes are scheduled", path))
+    return violations
+
+
+def opening_hours_rule(trip: dict, context: ValidationContext) -> Sequence[Violation]:
+    violations: list[Violation] = []
+    for day_index, day in enumerate(trip.get("days", [])):
+        for item_index, item in enumerate(day.get("items", [])):
+            if item.get("kind") not in {"visit", "meal"}:
+                continue
+            path = _item_path(day_index, item_index)
+            intervals = context.opening_hours.get(item["place_id"])
+            if not intervals:
+                violations.append(_warning("opening_hours.unverified", "opening hours are unknown", path))
+                continue
+            start, end = _timestamps(item)
+            if start.date() != end.date() or not any(
+                interval.weekday == start.weekday()
+                and interval.opens_at <= start.timetz().replace(tzinfo=None)
+                and end.timetz().replace(tzinfo=None) <= interval.closes_at
+                for interval in intervals
+            ):
+                violations.append(_error("opening_hours.closed", "scheduled time falls outside opening hours", path))
+    return violations
+
+
+def budget_rule(trip: dict, context: ValidationContext) -> Sequence[Violation]:
+    budget = trip.get("budget", {})
+    path = "/budget"
+    total = budget.get("total", {})
+    currency = budget.get("currency")
+    category_values = budget.get("categories", {}).values()
+    if not total or currency is None:
+        return [_warning("budget.unverified", "budget data is incomplete", path)]
+    if total.get("currency") != currency or any(value.get("currency") != currency for value in category_values):
+        return [_error("budget.currency_mismatch", "budget values must use the trip budget currency", path)]
+    category_total = sum(value["amount"] for value in category_values)
+    if category_total != total["amount"]:
+        return [_error("budget.total_mismatch", "budget total does not equal category total", path)]
+    if context.budget_limit is None:
+        return []
+    if context.budget_limit.currency != currency:
+        return [_warning("budget.unverified", "budget limit currency differs from trip budget currency", path)]
+    if total["amount"] > context.budget_limit.amount:
+        return [_error("budget.exceeded", "budget total exceeds the supplied budget limit", path)]
+    return []
+
+
+DEFAULT_RULES = RuleRegistry((time_overlap_rule, travel_time_rule, opening_hours_rule, budget_rule))
+
+
+def _timestamps(item: dict) -> tuple[datetime, datetime]:
+    return datetime.fromisoformat(item["start_at"]), datetime.fromisoformat(item["end_at"])
+
+
+def _item_path(day_index: int, item_index: int) -> str:
+    return f"/days/{day_index}/items/{item_index}"
+
+
+def _error(code: str, message: str, path: str) -> Violation:
+    return Violation(code, "error", message, path)
+
+
+def _warning(code: str, message: str, path: str) -> Violation:
+    return Violation(code, "warning", message, path)

--- a/tests/fixtures/planner/normal.json
+++ b/tests/fixtures/planner/normal.json
@@ -1,0 +1,1 @@
+{"name": "normal", "expected_state": "ready"}

--- a/tests/fixtures/planner/strict-budget.json
+++ b/tests/fixtures/planner/strict-budget.json
@@ -1,0 +1,1 @@
+{"name": "strict-budget", "limit": 100000, "expected_state": "failed"}

--- a/tests/fixtures/planner/time-conflict.json
+++ b/tests/fixtures/planner/time-conflict.json
@@ -1,0 +1,1 @@
+{"name": "time-conflict", "item_id": "d4-beppu", "start_at": "2026-04-13T11:30:00+09:00", "expected_state": "repaired"}

--- a/tests/test_itinerary_validator.py
+++ b/tests/test_itinerary_validator.py
@@ -1,0 +1,68 @@
+import copy
+import json
+from datetime import time
+from pathlib import Path
+import unittest
+
+from src.validator import BudgetLimit, OpeningInterval, Outcome, RuleRegistry, ValidationContext, validate_itinerary
+
+
+FIXTURE = Path(__file__).parents[1] / "fixtures/trips/japan-5-day-trip-v1.json"
+
+
+def verified_context() -> ValidationContext:
+    hours = {}
+    for place_id in ("ohori-park", "dazaifu", "yufuin", "beppu", "canal-city"):
+        hours[place_id] = [OpeningInterval(weekday, time(8), time(22)) for weekday in range(7)]
+    return ValidationContext(
+        travel_minutes={
+            ("fuk", "hakata-hotel"): 180,
+            ("yufuin", "beppu"): 60,
+        },
+        opening_hours=hours,
+        budget_limit=BudgetLimit(200000, "JPY"),
+    )
+
+
+class ItineraryValidatorTests(unittest.TestCase):
+    def setUp(self):
+        self.trip = json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+    def test_complete_fixture_passes(self):
+        result = validate_itinerary(self.trip, verified_context())
+        self.assertEqual(result.outcome, Outcome.VALID)
+        self.assertEqual(result.violations, ())
+        self.assertEqual(result.as_dict(), {"outcome": "valid", "violations": []})
+
+    def test_overlap_and_insufficient_travel_fail(self):
+        trip = copy.deepcopy(self.trip)
+        trip["days"][3]["items"][1]["start_at"] = "2026-04-13T11:30:00+09:00"
+        result = validate_itinerary(trip, verified_context())
+        self.assertEqual(result.outcome, Outcome.INVALID)
+        self.assertEqual({item.code for item in result.violations}, {"time.overlap", "travel_time.insufficient"})
+
+    def test_closed_and_over_budget_fail(self):
+        context = verified_context()
+        context = ValidationContext(
+            travel_minutes=context.travel_minutes,
+            opening_hours={**context.opening_hours, "ohori-park": [OpeningInterval(5, time(8), time(9))]},
+            budget_limit=BudgetLimit(100000, "JPY"),
+        )
+        result = validate_itinerary(self.trip, context)
+        self.assertEqual(result.outcome, Outcome.INVALID)
+        self.assertEqual({item.code for item in result.violations}, {"opening_hours.closed", "budget.exceeded"})
+
+    def test_unknown_derived_facts_are_incomplete(self):
+        result = validate_itinerary(self.trip)
+        self.assertEqual(result.outcome, Outcome.INCOMPLETE)
+        self.assertIn("travel_time.unverified", {item.code for item in result.violations})
+        self.assertIn("opening_hours.unverified", {item.code for item in result.violations})
+
+    def test_registry_accepts_extension(self):
+        registry = RuleRegistry()
+        registry.register(lambda trip, context: [])
+        self.assertEqual(validate_itinerary(self.trip, registry=registry).outcome, Outcome.VALID)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,91 @@
+import copy
+import json
+from datetime import time
+from pathlib import Path
+import unittest
+
+from src.planner import HardConstraint, PlanState, PlannerInput, SoftPreference, plan
+from src.validator import BudgetLimit, OpeningInterval, ValidationContext
+
+
+ROOT = Path(__file__).parents[1]
+TRIP_FIXTURE = ROOT / "fixtures/trips/japan-5-day-trip-v1.json"
+SCENARIOS = ROOT / "tests/fixtures/planner"
+
+
+def verified_context(limit=200000):
+    hours = {
+        place_id: [OpeningInterval(weekday, time(8), time(22)) for weekday in range(7)]
+        for place_id in ("ohori-park", "dazaifu", "yufuin", "beppu", "canal-city")
+    }
+    return ValidationContext(
+        travel_minutes={("fuk", "hakata-hotel"): 180, ("yufuin", "beppu"): 60},
+        opening_hours=hours,
+        budget_limit=BudgetLimit(limit, "JPY"),
+    )
+
+
+class PlannerTests(unittest.TestCase):
+    def setUp(self):
+        self.trip = json.loads(TRIP_FIXTURE.read_text(encoding="utf-8"))
+
+    def _scenario(self, name):
+        return json.loads((SCENARIOS / f"{name}.json").read_text(encoding="utf-8"))
+
+    def test_normal_fixture_is_ready_and_ranked_by_soft_preference(self):
+        scenario = self._scenario("normal")
+        result = plan(PlannerInput([self.trip], verified_context(), soft_preferences=[SoftPreference("low-fatigue", "low_fatigue")]))
+        candidate = result.best_plan
+        self.assertEqual(candidate.state.value, scenario["expected_state"])
+        self.assertLess(candidate.score, 0)
+        self.assertEqual(candidate.violations, ())
+
+    def test_time_conflict_fixture_repairs_only_violating_item_and_revalidates(self):
+        scenario = self._scenario("time-conflict")
+        trip = copy.deepcopy(self.trip)
+        item = trip["days"][3]["items"][1]
+        item["start_at"] = scenario["start_at"]
+        result = plan(PlannerInput([trip], verified_context(), max_repair_iterations=2))
+        candidate = result.best_plan
+        repaired = candidate.trip["days"][3]["items"][1]
+        self.assertEqual(candidate.state.value, scenario["expected_state"])
+        self.assertEqual(candidate.repair_iterations, 1)
+        self.assertEqual(repaired["start_at"], "2026-04-13T13:00:00+09:00")
+        self.assertEqual(repaired["end_at"], "2026-04-13T17:30:00+09:00")
+        self.assertEqual(candidate.violations, ())
+
+    def test_strict_budget_fixture_returns_explicit_failure(self):
+        scenario = self._scenario("strict-budget")
+        result = plan(PlannerInput([self.trip], verified_context(scenario["limit"])))
+        candidate = result.plans[0]
+        self.assertEqual(candidate.state.value, scenario["expected_state"])
+        self.assertIsNone(result.best_plan)
+        self.assertIn("budget.exceeded", {violation.code for violation in candidate.violations})
+
+    def test_hard_constraints_precede_soft_scoring(self):
+        constraints = [
+            HardConstraint("must-visit", "required_location", "ohori-park"),
+            HardConstraint("no-shopping", "forbidden_location", "canal-city"),
+        ]
+        result = plan(PlannerInput([self.trip], verified_context(), hard_constraints=constraints))
+        self.assertEqual(result.plans[0].state, PlanState.FAILED)
+        self.assertIn("constraint.forbidden_location", {v.code for v in result.plans[0].violations})
+
+    def test_preserved_override_wins_over_candidate_mutation(self):
+        trip = copy.deepcopy(self.trip)
+        trip["selected"]["hotel_place_ids"] = []
+        result = plan(PlannerInput([trip], verified_context()))
+        self.assertEqual(result.best_plan.trip["selected"]["hotel_place_ids"], ["hakata-hotel"])
+
+    def test_fixed_and_daily_duration_constraints_are_checked(self):
+        constraints = [
+            HardConstraint("arrival", "fixed_time", {"item_id": "d1-arrival", "start_at": "2026-04-10T11:00:00+09:00", "end_at": "2026-04-10T12:00:00+09:00"}),
+            HardConstraint("short-day", "max_daily_duration", 30),
+        ]
+        result = plan(PlannerInput([self.trip], verified_context(), hard_constraints=constraints))
+        self.assertEqual(result.plans[0].state, PlanState.FAILED)
+        self.assertEqual({v.code for v in result.plans[0].violations}, {"constraint.fixed_time", "constraint.max_daily_duration"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Resolves #3

Adds planner input/output contracts, hard and soft constraints, candidate ranking, bounded targeted repair with revalidation, explicit failure states, and preserved user overrides.

Depends on #2 and #4.

Validation: `python3 -m unittest discover -s tests -v` (20 passed); `git diff --cached --check`.