### PR TITLE
feat: integrate M1 travel planning pipeline

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,32 @@
+name: Deploy trip site to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - name: Build static site from canonical fixture
+        run: python3 -m src.renderer.build_site fixtures/trips/japan-5-day-trip-v1.json --output site
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -63,3 +63,19 @@ ai-travel-planner/
 > 輸入「五天四夜 XX 日本行 + 人數 + 預算 + 偏好」後，產生結構化 Trip 資料，驗證時間 / 路程 / 預算，並生成可在旅途中使用的 mobile-first 網站。
 
 `ai_kyushu` 將作為第一個 reference trip / golden output，用來定義實際旅途中需要的資訊密度與網站可用性。
+
+## Static trip renderer
+
+The dependency-free renderer turns Canonical Trip V1 JSON into a mobile-first
+static site. It only presents canonical fields and optional upstream derived
+read models; it does not validate, route, optimise, or calculate correctness.
+
+```sh
+python3 -m src.renderer.build_site fixtures/trips/japan-5-day-trip-v1.json --output site
+open site/index.html
+```
+
+The page includes Overview, Itinerary, and Budget. It surfaces upstream
+`validation` messages, provenance status, and each source's `retrieved_at`
+value (source freshness). GitHub Pages runs this same fixture build on pushes
+to `main` via `.github/workflows/deploy-pages.yml`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ AI 旅遊規劃平台：自動研究、最佳化行程、驗證時間與預算�
 
 [`Trip V1`](docs/canonical-trip-v1.md) 是 planner、validator、renderer、trip storage、map 與 budget 的唯一 source of truth。候選研究資料位於 `candidate_sets`，而最終行程只透過 ID 參照並保留在 `days`，兩者不可混用。
 
+## Routing / ordering
+
+路由與 POI 排序使用 provider-neutral 的 [`Routing and optimizer V1`](docs/routing-optimizer-v1.md)。路程查無資料會明確保留為 `unknown` 並交給 validator，不會被當成零分鐘。
+
 ## Architecture principles
 
 - **Trip data is the source of truth**：網站、地圖、預算與列印內容都從同一份 Trip schema 產生。

--- a/docs/itinerary-validator.md
+++ b/docs/itinerary-validator.md
@@ -1,0 +1,19 @@
+# Deterministic itinerary validator
+
+`src.validator.validate_itinerary` consumes a canonical Trip V1 document and optional explicit, already-derived inputs. It never calls a routing or place-data provider and never changes the trip document.
+
+```python
+from src.validator import ValidationContext, validate_itinerary
+
+result = validate_itinerary(trip, ValidationContext(travel_minutes={...}, opening_hours={...}))
+```
+
+The result serializes as `{ "outcome": "valid|invalid|incomplete", "violations": [...] }`. Each violation contains stable `code`, `severity`, `message`, and JSON-pointer `path` fields. Any error is `invalid`; warnings with no errors are `incomplete`; no violations is `valid`.
+
+## Derived input contract
+
+- `travel_minutes[(from_place_id, to_place_id)]` is a non-negative route duration. An absent route is `travel_time.unverified`.
+- `opening_hours[place_id]` is a sequence of `OpeningInterval(weekday, opens_at, closes_at)`, using Monday `0` through Sunday `6` and local wall times. An absent scheduled visit or meal is `opening_hours.unverified`.
+- `budget_limit=BudgetLimit(amount, currency)` is an optional explicit cap. The validator always checks the Trip V1 category arithmetic and currency consistency.
+
+The default registry runs time overlap, travel time, opening hours, and budget rules in that order. Construct `RuleRegistry` and call `register(rule)` to add deterministic rules; each rule receives `(trip, context)` and returns violations.

--- a/docs/planner-contract.md
+++ b/docs/planner-contract.md
@@ -1,0 +1,9 @@
+# Planner contract
+
+`src.planner` evaluates explicit Canonical Trip V1 candidate documents. It does not schedule raw research candidates: no travel time, opening hours, visit duration, or reservation time is inferred when that fact is absent.
+
+`PlannerInput` accepts candidate trips, a `ValidationContext`, typed `HardConstraint` values, `SoftPreference` values, and a repair iteration ceiling. `PlannerOutput` contains one `CandidatePlan` per input, ranked only after all hard-rule errors have been cleared.
+
+Hard constraints support fixed flight/train or reservation times (`fixed_time` / `reservation_time`), required or forbidden locations, and strict maximum daily duration. Opening hours, impossible transport timing, and strict budget ceilings are enforced from the supplied validator context. Soft preferences are score-only. `low_fatigue` and `few_hotel_changes` have deterministic scoring; preferences without explicit supporting candidate facts remain neutral.
+
+Each replan reapplies `overrides` whose `preserve_on_replan` is true. The repair loop modifies only paths identified by `time.overlap` or `travel_time.insufficient`, then invokes the validator again. Unrepairable violations, or violations remaining after `max_repair_iterations`, produce `PlanState.FAILED`; they are never returned as a best plan.

--- a/docs/routing-optimizer-v1.md
+++ b/docs/routing-optimizer-v1.md
@@ -1,0 +1,17 @@
+# Routing and optimizer V1
+
+`src.sources.routing` is the provider-neutral boundary for travel time. The planner, optimizer and validator receive one `RouteMatrix`; they do not import a provider SDK. A provider supplies a `Route` for a pair of canonical `PlaceRef` IDs (with optional coordinates) and one of `driving`, `transit` or `walking` modes.
+
+Each route retains `duration_seconds`, `distance_meters`, `RouteStatus`, and `RouteProvenance` (`provider`, `retrieved_at`, source metadata). An unavailable lookup is `RouteStatus.UNKNOWN` and has neither duration nor distance. It must not be converted to a guessed or zero-cost route.
+
+## Cache behaviour
+
+`RouteMatrix` caches both available and unknown provider results using `(mode, origin_place_id, destination_place_id)`. It may receive a TTL for live providers; without one, an instance is stable for the pipeline run. Passing that same instance to validation guarantees validation sees the same result that informed the ordering.
+
+`FixtureRoutingProvider` is a deterministic provider stub. `fixtures/routes/fukuoka-routing-fixture.json` documents the portable fixture shape; test fixtures can be instantiated directly as `Route` objects to avoid an I/O dependency.
+
+## Optimizer boundary
+
+`RouteOptimizer` brute-forces flexible POI order within each segment bounded by fixed-time anchors. It scores available route duration (with distance emitted in its result), keeping anchors in their original sequence and retaining their exact timestamps. The optimizer never creates, shifts, or relaxes schedule times.
+
+If any selected consecutive route is unknown, `OptimizationResult.travel_seconds` and `travel_meters` are `None` and it exposes `unknown_route_keys`. `validate_route_availability` turns those into machine-readable `route_unknown` warnings for the trip validator / repair loop.

--- a/docs/source-evidence-priority.md
+++ b/docs/source-evidence-priority.md
@@ -1,0 +1,27 @@
+# Source evidence priority
+
+## Boundary
+
+Source adapters fetch and normalize facts into the existing Trip V1 `candidate_sets` contract. They never receive or change `days`, therefore cannot turn research into an itinerary decision. `CandidateStore` tracks the operational lifecycle (`fetched`, `normalized`, `selected`, `rejected`) outside Trip V1; only its canonical candidate payload may enter `candidate_sets`.
+
+Every dynamic candidate must retain the existing provenance object: `source_type`, `provider`, `retrieved_at`, and `status`, plus URL, confidence, or note where available. Freshness is assessed by the caller with a category-appropriate maximum age; a stale fact remains traceable but must not be treated as current confirmation.
+
+## Evidence priority
+
+| Fact type | First-choice evidence | Community use | Rule |
+| --- | --- | --- | --- |
+| Closures, opening hours, entry rules, safety advisories | Official operator, municipality, tourism authority | May flag a possible change | Community reports cannot replace an official operational fact. Keep both provenance records if they conflict and mark the community fact `reported` or `unverified`. |
+| Fares, schedules, availability, reservations | Carrier, hotel, venue, booking provider | Discovery only | Confirm against the responsible provider before planning a hard constraint. |
+| Route duration and distance | Routing provider with query timestamp | Practical context only | Do not convert anecdotal travel time into confirmed routing data. |
+| Restaurant queues, stroller access, crowding, practical tips | Venue/provider when published | Primary supplementary evidence | Keep as `community` / `reported`; it may influence soft scoring, never silently change hours or reservation policy. |
+| Attractions and descriptive content | Official tourism/operator sources | Supplemental perspective | Preserve provider and retrieval time for each assertion. |
+
+## Japan-first normalization
+
+Use `place.name` and `place.address` as Unicode strings, preserving Japanese plus a useful English or Chinese display name when supplied by the evidence. Do not add Tabelog, Google, or scraper-specific score fields to Trip V1: adapters must translate only fields already in the schema (price range, opening-hours note, reservation, queue risk, child-friendly, parking where supported). Raw provider payloads remain outside the planner contract.
+
+## Conflict and selection
+
+1. Store each independently sourced candidate with its own provenance; do not overwrite a higher-priority fact.
+2. Planner may use `confirmed` official/provider facts for hard constraints. `reported` community facts are soft signals.
+3. Mark a candidate selected only after it has been normalized; the planner then writes the final Trip selection through existing IDs, not by mutating research evidence.

--- a/fixtures/routes/fukuoka-routing-fixture.json
+++ b/fixtures/routes/fukuoka-routing-fixture.json
@@ -1,0 +1,10 @@
+{
+  "provider": "fixture-routing",
+  "retrieved_at": "2026-01-15T11:00:00+09:00",
+  "purpose": "Deterministic route data for local tests; absent entries represent unknown routes.",
+  "routes": [
+    {"mode": "driving", "origin_place_id": "ohori-park", "destination_place_id": "dazaifu", "duration_seconds": 2100, "distance_meters": 17000},
+    {"mode": "transit", "origin_place_id": "hakata-hotel", "destination_place_id": "ohori-park", "duration_seconds": 1500, "distance_meters": 5200},
+    {"mode": "walking", "origin_place_id": "hakata-hotel", "destination_place_id": "canal-city", "duration_seconds": 900, "distance_meters": 1100}
+  ]
+}

--- a/src/optimizer/__init__.py
+++ b/src/optimizer/__init__.py
@@ -1,0 +1,3 @@
+from .route_optimizer import OptimizationResult, RouteOptimizer, Stop
+
+__all__ = ["OptimizationResult", "RouteOptimizer", "Stop"]

--- a/src/optimizer/route_optimizer.py
+++ b/src/optimizer/route_optimizer.py
@@ -1,0 +1,100 @@
+"""Deterministic first-pass POI ordering using the shared route matrix."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from itertools import permutations
+
+from src.sources.routing import PlaceRef, RouteMatrix, RouteMode, RouteStatus
+
+
+@dataclass(frozen=True)
+class Stop:
+    place: PlaceRef
+    fixed_start_at: datetime | None = None
+    fixed_end_at: datetime | None = None
+
+    @property
+    def is_fixed_anchor(self) -> bool:
+        return self.fixed_start_at is not None or self.fixed_end_at is not None
+
+    def __post_init__(self) -> None:
+        if (self.fixed_start_at is None) != (self.fixed_end_at is None):
+            raise ValueError("fixed anchors require both start and end times")
+        if self.fixed_start_at is not None and self.fixed_start_at >= self.fixed_end_at:
+            raise ValueError("fixed anchor end must be after start")
+
+
+@dataclass(frozen=True)
+class OptimizationResult:
+    stops: tuple[Stop, ...]
+    travel_seconds: int | None
+    travel_meters: int | None
+    unknown_route_keys: tuple[tuple[str, str, str], ...]
+
+    @property
+    def has_unknown_routes(self) -> bool:
+        return bool(self.unknown_route_keys)
+
+
+class RouteOptimizer:
+    """Order flexible POIs inside fixed-anchor boundaries without scheduling changes.
+
+    Anchor timestamps are immutable and no stop may cross an anchor. Unknown routes make
+    the result explicitly unscored instead of being treated as zero-cost travel.
+    """
+
+    def __init__(self, matrix: RouteMatrix, mode: RouteMode) -> None:
+        self.matrix = matrix
+        self.mode = mode
+
+    def optimize(self, stops: list[Stop] | tuple[Stop, ...]) -> OptimizationResult:
+        result: list[Stop] = []
+        flexible: list[Stop] = []
+        previous_boundary: Stop | None = None
+
+        for stop in stops:
+            if stop.is_fixed_anchor:
+                result.extend(self._best_block(flexible, previous_boundary, stop))
+                flexible = []
+                result.append(stop)
+                previous_boundary = stop
+            else:
+                flexible.append(stop)
+        result.extend(self._best_block(flexible, previous_boundary, None))
+        return self._score(tuple(result))
+
+    def _best_block(self, stops: list[Stop], before: Stop | None, after: Stop | None) -> tuple[Stop, ...]:
+        if len(stops) < 2:
+            return tuple(stops)
+        candidates = tuple(permutations(stops))
+        scored = [(self._candidate_cost(order, before, after), order) for order in candidates]
+        usable = [candidate for candidate in scored if candidate[0] is not None]
+        if not usable:
+            return candidates[0]
+        return min(usable, key=lambda candidate: (candidate[0], tuple(s.place.place_id for s in candidate[1])))[1]
+
+    def _candidate_cost(self, stops: tuple[Stop, ...], before: Stop | None, after: Stop | None) -> int | None:
+        chain = ((before,) if before else ()) + stops + ((after,) if after else ())
+        total = 0
+        for first, second in zip(chain, chain[1:]):
+            route = self.matrix.route(first.place, second.place, self.mode)
+            if route.status is RouteStatus.UNKNOWN:
+                return None
+            total += route.duration_seconds or 0
+        return total
+
+    def _score(self, stops: tuple[Stop, ...]) -> OptimizationResult:
+        total_seconds = total_meters = 0
+        unknown: list[tuple[str, str, str]] = []
+        for first, second in zip(stops, stops[1:]):
+            route = self.matrix.route(first.place, second.place, self.mode)
+            if route.status is RouteStatus.UNKNOWN:
+                unknown.append(route.cache_key)
+                continue
+            total_seconds += route.duration_seconds or 0
+            total_meters += route.distance_meters or 0
+        if unknown:
+            return OptimizationResult(stops, None, None, tuple(unknown))
+        return OptimizationResult(stops, total_seconds, total_meters, ())

--- a/src/planner/__init__.py
+++ b/src/planner/__init__.py
@@ -1,0 +1,6 @@
+"""Planner public API."""
+
+from .contracts import CandidatePlan, HardConstraint, PlanState, PlannerInput, PlannerOutput, SoftPreference
+from .planner import plan
+
+__all__ = ["CandidatePlan", "HardConstraint", "PlanState", "PlannerInput", "PlannerOutput", "SoftPreference", "plan"]

--- a/src/planner/contracts.py
+++ b/src/planner/contracts.py
@@ -1,0 +1,76 @@
+"""Explicit, deterministic planner input and output contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from src.validator import ValidationContext, Violation
+
+
+class PlanState(str, Enum):
+    READY = "ready"
+    REPAIRED = "repaired"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class HardConstraint:
+    """A non-negotiable planning condition, evaluated before soft scoring.
+
+    Supported kinds are ``fixed_time``, ``reservation_time``,
+    ``required_location``, ``forbidden_location`` and
+    ``max_daily_duration``.  Opening-hours, transport feasibility, and a
+    strict budget ceiling are supplied through :class:`ValidationContext` so
+    the planner never invents those facts.
+    """
+
+    id: str
+    kind: str
+    value: Any
+    strict: bool = True
+
+
+@dataclass(frozen=True)
+class SoftPreference:
+    """A ranking signal only; it can never make an invalid plan acceptable."""
+
+    id: str
+    kind: str
+    value: Any = True
+    weight: float = 1.0
+
+
+@dataclass(frozen=True)
+class PlannerInput:
+    """Candidate Trip V1 documents plus only explicit derived validation facts."""
+
+    candidate_trips: Sequence[dict]
+    validation_context: ValidationContext = field(default_factory=ValidationContext)
+    hard_constraints: Sequence[HardConstraint] = ()
+    soft_preferences: Sequence[SoftPreference] = ()
+    max_repair_iterations: int = 3
+
+
+@dataclass(frozen=True)
+class CandidatePlan:
+    trip: dict
+    score: float
+    state: PlanState
+    violations: tuple[Violation, ...]
+    repair_iterations: int
+
+
+@dataclass(frozen=True)
+class PlannerOutput:
+    plans: tuple[CandidatePlan, ...]
+
+    @property
+    def successful_plans(self) -> tuple[CandidatePlan, ...]:
+        return tuple(plan for plan in self.plans if plan.state is not PlanState.FAILED)
+
+    @property
+    def best_plan(self) -> CandidatePlan | None:
+        successful = self.successful_plans
+        return successful[0] if successful else None

--- a/src/planner/planner.py
+++ b/src/planner/planner.py
@@ -1,0 +1,168 @@
+"""Candidate evaluation and bounded, violation-scoped itinerary repair."""
+
+from __future__ import annotations
+
+import copy
+from datetime import datetime, timedelta
+from typing import Iterable
+
+from src.validator import Outcome, Violation, validate_itinerary
+
+from .contracts import CandidatePlan, HardConstraint, PlanState, PlannerInput, PlannerOutput, SoftPreference
+
+
+def plan(request: PlannerInput) -> PlannerOutput:
+    """Validate, repair, and rank explicit Trip V1 candidate plans.
+
+    This module deliberately does not turn research candidates into scheduled
+    visits: it lacks authoritative routing, opening-hours, and duration facts.
+    Upstream scheduling can submit multiple Trip V1 candidates here, where hard
+    constraints are checked before soft-preference scoring.
+    """
+
+    if request.max_repair_iterations < 0:
+        raise ValueError("max_repair_iterations must be non-negative")
+    plans = [_evaluate(copy.deepcopy(trip), request) for trip in request.candidate_trips]
+    return PlannerOutput(tuple(sorted(plans, key=lambda item: (item.state is PlanState.FAILED, -item.score))))
+
+
+def _evaluate(trip: dict, request: PlannerInput) -> CandidatePlan:
+    _preserve_overrides(trip)
+    iterations = 0
+    violations = _validate(trip, request)
+    while _has_errors(violations) and iterations < request.max_repair_iterations:
+        changed = _repair_only_violating_scope(trip, violations, request)
+        if not changed:
+            return CandidatePlan(trip, float("-inf"), PlanState.FAILED, tuple(violations), iterations)
+        iterations += 1
+        _preserve_overrides(trip)
+        violations = _validate(trip, request)
+    if _has_errors(violations):
+        return CandidatePlan(trip, float("-inf"), PlanState.FAILED, tuple(violations), iterations)
+    state = PlanState.REPAIRED if iterations else PlanState.READY
+    return CandidatePlan(trip, _score(trip, request.soft_preferences), state, tuple(violations), iterations)
+
+
+def _validate(trip: dict, request: PlannerInput) -> list[Violation]:
+    result = validate_itinerary(trip, request.validation_context)
+    return [*result.violations, *_hard_constraint_violations(trip, request.hard_constraints)]
+
+
+def _hard_constraint_violations(trip: dict, constraints: Iterable[HardConstraint]) -> list[Violation]:
+    violations: list[Violation] = []
+    items = [(day_index, item_index, item) for day_index, day in enumerate(trip.get("days", [])) for item_index, item in enumerate(day.get("items", []))]
+    for constraint in constraints:
+        if not constraint.strict:
+            continue
+        value = constraint.value
+        if constraint.kind in {"fixed_time", "reservation_time"}:
+            matched = [(day, index, item) for day, index, item in items if item.get("id") == value.get("item_id")]
+            if len(matched) != 1 or any(item.get(key) != value.get(key) for _, _, item in matched for key in ("start_at", "end_at")):
+                violations.append(_constraint_violation(constraint, "/days", "fixed or reserved time is not preserved"))
+        elif constraint.kind == "required_location":
+            if not any(item.get("place_id") == value for _, _, item in items):
+                violations.append(_constraint_violation(constraint, "/days", "required location is absent"))
+        elif constraint.kind == "forbidden_location":
+            if any(item.get("place_id") == value for _, _, item in items):
+                violations.append(_constraint_violation(constraint, "/days", "forbidden location is scheduled"))
+        elif constraint.kind == "max_daily_duration":
+            maximum = float(value)
+            for day_index, day in enumerate(trip.get("days", [])):
+                scheduled = day.get("items", [])
+                if scheduled:
+                    starts_ends = [(_timestamp(item["start_at"]), _timestamp(item["end_at"])) for item in scheduled]
+                    duration = (max(end for _, end in starts_ends) - min(start for start, _ in starts_ends)).total_seconds() / 60
+                    if duration > maximum:
+                        violations.append(_constraint_violation(constraint, f"/days/{day_index}", f"daily duration {duration:g} exceeds {maximum:g} minutes"))
+        else:
+            raise ValueError(f"unsupported hard constraint kind: {constraint.kind}")
+    return violations
+
+
+def _repair_only_violating_scope(trip: dict, violations: Iterable[Violation], request: PlannerInput) -> bool:
+    """Repair only time-related violating item paths; leave all other scope intact."""
+
+    changed = False
+    for violation in violations:
+        if violation.code not in {"time.overlap", "travel_time.insufficient"}:
+            continue
+        location = _parse_item_path(violation.path)
+        if location is None:
+            continue
+        day_index, item_index = location
+        day = trip["days"][day_index]
+        item = day["items"][item_index]
+        previous = _previous_item(day["items"], item_index)
+        if previous is None:
+            continue
+        start, end = _timestamp(item["start_at"]), _timestamp(item["end_at"])
+        required_start = _timestamp(previous["end_at"])
+        travel = request.validation_context.travel_minutes.get((previous["place_id"], item["place_id"]), 0)
+        required_start += timedelta(minutes=travel)
+        if start < required_start:
+            duration = end - start
+            item["start_at"] = required_start.isoformat()
+            item["end_at"] = (required_start + duration).isoformat()
+            changed = True
+    return changed
+
+
+def _preserve_overrides(trip: dict) -> None:
+    for override in trip.get("overrides", []):
+        if override.get("preserve_on_replan"):
+            _set_json_pointer(trip, override["path"], copy.deepcopy(override["value"]))
+
+
+def _set_json_pointer(document: dict, pointer: str, value: object) -> None:
+    parts = pointer.lstrip("/").split("/")
+    if not pointer.startswith("/") or not all(parts):
+        raise ValueError(f"invalid override path: {pointer}")
+    current: object = document
+    for part in parts[:-1]:
+        if not isinstance(current, dict) or part not in current:
+            raise ValueError(f"override path is not present: {pointer}")
+        current = current[part]
+    if not isinstance(current, dict):
+        raise ValueError(f"override path cannot be set: {pointer}")
+    current[parts[-1]] = value
+
+
+def _score(trip: dict, preferences: Iterable[SoftPreference]) -> float:
+    score = 0.0
+    item_count = sum(len(day.get("items", [])) for day in trip.get("days", []))
+    for preference in preferences:
+        if preference.kind == "low_fatigue":
+            score -= item_count * preference.weight
+        elif preference.kind == "few_hotel_changes":
+            score -= max(0, len(trip.get("selected", {}).get("hotel_place_ids", [])) - 1) * preference.weight
+        # Other preference kinds remain neutral when the candidate data has no
+        # explicit matching fact; a planner must not infer it.
+    return score
+
+
+def _constraint_violation(constraint: HardConstraint, path: str, message: str) -> Violation:
+    return Violation(f"constraint.{constraint.kind}", "error", message, path)
+
+
+def _has_errors(violations: Iterable[Violation]) -> bool:
+    return any(violation.severity == "error" for violation in violations)
+
+
+def _parse_item_path(path: str) -> tuple[int, int] | None:
+    parts = path.strip("/").split("/")
+    if len(parts) != 4 or parts[0] != "days" or parts[2] != "items":
+        return None
+    try:
+        return int(parts[1]), int(parts[3])
+    except ValueError:
+        return None
+
+
+def _previous_item(items: list[dict], item_index: int) -> dict | None:
+    item = items[item_index]
+    earlier = [candidate for index, candidate in enumerate(items) if index != item_index and _timestamp(candidate["start_at"]) <= _timestamp(item["start_at"])]
+    return max(earlier, key=lambda candidate: _timestamp(candidate["start_at"]), default=None)
+
+
+def _timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value)

--- a/src/renderer/build_site.py
+++ b/src/renderer/build_site.py
@@ -1,0 +1,86 @@
+"""Dependency-free static renderer for Canonical Trip V1 documents.
+
+It only formats canonical fields and optional upstream read models. It never
+validates, routes, optimises, or decides whether an itinerary is correct.
+"""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from html import escape
+import json
+from pathlib import Path
+from typing import Any
+
+
+def build_site(trip: dict[str, Any], derived: dict[str, Any] | None = None) -> str:
+    """Render a self-contained mobile-first HTML document."""
+    derived = derived or {}
+    places = {p["id"]: p for p in trip["candidate_sets"].get("places", [])}
+    title = escape(trip.get("title", "Trip"))
+    dates = trip.get("date_range", {})
+    overview = derived.get("overview", {})
+    stats = "".join(f'<div class="stat"><span>{escape(str(k))}</span><strong>{escape(str(v))}</strong></div>' for k, v in overview.items())
+    if not stats:
+        stats = f'<div class="stat"><span>旅遊日期</span><strong>{escape(dates.get("start_date", "—"))} ～ {escape(dates.get("end_date", "—"))}</strong></div>'
+    warnings = "".join(f"<li>{escape(_warning_text(x))}</li>" for x in trip.get("validation", [])) or '<li class="quiet">目前沒有上游 validation warning。</li>'
+    days = "".join(_render_day(day, places) for day in trip.get("days", []))
+    budget = "".join(f"<tr><th>{escape(str(k))}</th><td>{escape(_money(v))}</td></tr>" for k, v in trip.get("budget", {}).get("categories", {}).items())
+    total = derived.get("budget", {}).get("total_label") or _money(trip.get("budget", {}).get("total", {}))
+    sources = "".join(_render_source(x) for x in _sources(trip)) or '<p class="quiet">沒有未確認來源資料。</p>'
+    return f'''<!doctype html><html lang="zh-Hant"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>{title}</title><style>{_CSS}</style></head><body><main>
+<header><p class="eyebrow">TRIP · {escape(trip.get("local_timezone", ""))}</p><h1>{title}</h1><div class="stats">{stats}</div></header>
+<nav aria-label="行程區段"><a href="#overview">總覽</a><a href="#itinerary">行程</a><a href="#budget">預算</a></nav>
+<section id="overview"><h2>總覽</h2><h3>Validation warnings</h3><ul class="warnings">{warnings}</ul><h3>未確認與估算資訊</h3><p class="hint">以下狀態由資料來源提供；此頁不判定行程是否可行。</p><div class="sources">{sources}</div></section>
+<section id="itinerary"><h2>行程</h2>{days}</section><section id="budget"><h2>預算</h2><table><tbody>{budget}</tbody><tfoot><tr><th>總計</th><td>{escape(str(total))}</td></tr></tfoot></table></section>
+</main></body></html>'''
+
+
+def _render_day(day: dict[str, Any], places: dict[str, dict[str, Any]]) -> str:
+    items = []
+    for item in day.get("items", []):
+        place = places.get(item.get("place_id"), {})
+        items.append(f'<li><time>{escape(_time(item.get("start_at", "")))}</time><strong>{escape(place.get("name", item.get("place_id", "—")))}</strong><span>{escape(item.get("kind", ""))}</span></li>')
+    return f'<article><p class="eyebrow">{escape(day.get("date", ""))}</p><h3>{escape(day.get("summary", ""))}</h3><ol>{"".join(items)}</ol></article>'
+
+
+def _sources(trip: dict[str, Any]) -> list[dict[str, Any]]:
+    return [{"name": p.get("name", p.get("id", "—")), "provenance": p["provenance"]} for p in trip.get("candidate_sets", {}).get("places", []) if p.get("provenance", {}).get("status") in {"reported", "estimated", "unverified"}]
+
+
+def _render_source(item: dict[str, Any]) -> str:
+    p = item["provenance"]
+    provider = escape(str(p.get("provider", "未知來源")))
+    provider = f'<a href="{escape(str(p["source_url"]), quote=True)}">{provider}</a>' if p.get("source_url") else provider
+    return f'<article class="source"><strong>{escape(str(item["name"]))}</strong><span class="badge">{escape(str(p.get("status", "unknown")))}</span><p>{provider} · source freshness: {escape(str(p.get("retrieved_at", "unknown")))}</p></article>'
+
+
+def _warning_text(value: Any) -> str:
+    return value if isinstance(value, str) else json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _time(value: str) -> str:
+    try: return datetime.fromisoformat(value).strftime("%H:%M")
+    except ValueError: return value
+
+
+def _money(value: Any) -> str:
+    if not isinstance(value, dict): return "—"
+    amount, currency = value.get("amount", "—"), value.get("currency", "")
+    return f"{currency} {amount:,}" if isinstance(amount, (int, float)) else f"{currency} {amount}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build a static Trip V1 site")
+    parser.add_argument("trip", type=Path); parser.add_argument("--derived", type=Path); parser.add_argument("--output", type=Path, default=Path("site"))
+    args = parser.parse_args(); trip = json.loads(args.trip.read_text(encoding="utf-8"))
+    derived = json.loads(args.derived.read_text(encoding="utf-8")) if args.derived else None
+    args.output.mkdir(parents=True, exist_ok=True); (args.output / "index.html").write_text(build_site(trip, derived), encoding="utf-8")
+
+
+_CSS = '''
+:root{--ink:#172033;--muted:#5d6779;--line:#dce1e9;--accent:#0b6e69}*{box-sizing:border-box}body{margin:0;background:#f3f6f8;color:var(--ink);font:16px/1.5 -apple-system,BlinkMacSystemFont,"Noto Sans TC",sans-serif}main{max-width:680px;margin:auto;padding:20px 16px 48px}header,section,article{background:#fff;border:1px solid var(--line);border-radius:16px}header,section{padding:20px;margin-bottom:14px}h1{font-size:28px;line-height:1.2;margin:4px 0 18px}h2{font-size:21px;margin:0 0 16px}h3{font-size:17px;margin:12px 0 8px}.eyebrow{color:var(--muted);font-size:12px;font-weight:700;letter-spacing:.06em;margin:0}.stats{display:grid;gap:8px}.stat{background:#eaf5f3;border-radius:10px;padding:10px 12px}.stat span,.stat strong{display:block}.stat span,.hint,.quiet,.source p{color:var(--muted);font-size:14px}nav{display:flex;gap:8px;overflow:auto;position:sticky;top:0;padding:8px 0;background:#f3f6f8;z-index:1}nav a{background:#fff;border:1px solid var(--line);border-radius:999px;color:var(--ink);padding:7px 13px;text-decoration:none;white-space:nowrap}ul,ol{padding-left:20px}.warnings li{color:#9a5200;margin:6px 0}.warnings .quiet{color:var(--muted)}article{padding:14px;margin:10px 0}article h3{margin-top:3px}ol{list-style:none;padding:0;margin:10px 0 0}ol li{display:grid;grid-template-columns:56px 1fr;gap:3px 10px;border-top:1px solid var(--line);padding:10px 0}ol li:first-child{border-top:0}time,ol span{color:var(--muted);font-size:14px}ol span{grid-column:2}.source{display:grid;grid-template-columns:1fr auto;gap:2px 8px}.source p{grid-column:1/-1;margin:2px 0 0}.badge{color:#704400;background:#fff1d6;border-radius:999px;font-size:12px;font-weight:700;padding:2px 8px}table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid var(--line);padding:10px 0;text-align:left}td{text-align:right}tfoot{font-weight:800}@media(max-width:390px){main{padding:12px 10px 32px}header,section{padding:16px}h1{font-size:25px}}
+'''
+
+
+if __name__ == "__main__": main()

--- a/src/sources/__init__.py
+++ b/src/sources/__init__.py
@@ -1,0 +1,17 @@
+"""Research source adapters and the candidate-store boundary."""
+
+from .adapters import AdapterFailure, FixtureCommunityRestaurantAdapter, FixtureOfficialPoiAdapter, SourceAdapter, SourceQuery, collect_from_adapters
+from .candidate_store import CandidateRecord, CandidateState, CandidateStore, StaleCandidateError
+
+__all__ = [
+    "AdapterFailure",
+    "CandidateRecord",
+    "CandidateState",
+    "CandidateStore",
+    "FixtureCommunityRestaurantAdapter",
+    "FixtureOfficialPoiAdapter",
+    "SourceAdapter",
+    "SourceQuery",
+    "StaleCandidateError",
+    "collect_from_adapters",
+]

--- a/src/sources/adapters.py
+++ b/src/sources/adapters.py
@@ -1,0 +1,121 @@
+"""Replaceable adapters that return canonical Trip V1 candidate payloads.
+
+Adapters are deliberately read-only: they never receive a Trip document and cannot
+write ``days``.  Provider responses are normalized before crossing this boundary.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class SourceQuery:
+    """A provider-neutral research request."""
+
+    destination: str
+    categories: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AdapterFailure:
+    """A captured failure; one provider must not discard other research results."""
+
+    adapter: str
+    message: str
+
+
+class SourceAdapter(ABC):
+    """Normalize one provider into ``{candidate_sets collection, candidate}`` records."""
+
+    name: str
+
+    @abstractmethod
+    def fetch(self, query: SourceQuery) -> Iterable[tuple[str, dict[str, Any]]]:
+        """Return canonical candidates without provider-specific fields.
+
+        Each tuple's first value is one Trip V1 ``candidate_sets`` collection.
+        Each candidate must contain canonical ``provenance`` with ``retrieved_at``.
+        """
+
+
+def collect_from_adapters(
+    adapters: Iterable[SourceAdapter], query: SourceQuery
+) -> tuple[list[tuple[str, dict[str, Any]]], list[AdapterFailure]]:
+    """Collect independent adapter output, isolating expected provider failures."""
+
+    candidates: list[tuple[str, dict[str, Any]]] = []
+    failures: list[AdapterFailure] = []
+    for adapter in adapters:
+        try:
+            candidates.extend(adapter.fetch(query))
+        except Exception as exc:  # provider/network failures are non-fatal per adapter
+            failures.append(AdapterFailure(adapter=adapter.name, message=str(exc)))
+    return candidates, failures
+
+
+class FixtureOfficialPoiAdapter(SourceAdapter):
+    """Deterministic official-tourism adapter fixture for contract tests."""
+
+    name = "fixture-official-tourism"
+
+    def __init__(self, retrieved_at: datetime | None = None) -> None:
+        self.retrieved_at = retrieved_at or datetime.now(timezone.utc)
+
+    def fetch(self, query: SourceQuery) -> Iterable[tuple[str, dict[str, Any]]]:
+        if "pois" not in query.categories:
+            return []
+        provenance = {
+            "source_type": "official",
+            "provider": "Fukuoka City Official Tourism Guide fixture",
+            "source_url": "https://gofukuoka.jp/",
+            "retrieved_at": self.retrieved_at.isoformat(),
+            "confidence": 0.95,
+            "status": "confirmed",
+        }
+        return [("places", {
+            "id": "ohori-park",
+            "name": "大濠公園 / Ohori Park",
+            "kind": "poi",
+            "address": "福岡県福岡市中央区大濠公園",
+            "provenance": provenance,
+        })]
+
+
+class FixtureCommunityRestaurantAdapter(SourceAdapter):
+    """Deterministic community-source fixture; its facts remain reported, not official."""
+
+    name = "fixture-community-restaurant"
+
+    def __init__(self, retrieved_at: datetime | None = None) -> None:
+        self.retrieved_at = retrieved_at or datetime.now(timezone.utc)
+
+    def fetch(self, query: SourceQuery) -> Iterable[tuple[str, dict[str, Any]]]:
+        if "restaurants" not in query.categories:
+            return []
+        provenance = {
+            "source_type": "community",
+            "provider": "Fukuoka family travel community fixture",
+            "source_url": "https://example.test/fukuoka-family-ramen",
+            "retrieved_at": self.retrieved_at.isoformat(),
+            "confidence": 0.55,
+            "status": "reported",
+            "note": "Queue and child-friendly signals are community reports.",
+        }
+        return [("restaurants", {
+            "place": {
+                "id": "fixture-ramen",
+                "name": "フィクスチャーラーメン / Fixture Ramen",
+                "kind": "restaurant",
+                "address": "福岡県福岡市中央区",
+                "provenance": provenance,
+            },
+            "price_range": "¥1,000–¥2,000",
+            "reservation_required": False,
+            "wait_risk": "high",
+            "child_friendly": True,
+            "provenance": provenance,
+        })]

--- a/src/sources/candidate_store.py
+++ b/src/sources/candidate_store.py
@@ -1,0 +1,124 @@
+"""Lifecycle-aware store for research candidates before planner selection.
+
+The store intentionally has no method that accepts or returns an itinerary day.
+It stores canonical Trip V1 candidate payloads and lifecycle state separately, so
+the state does not leak into the immutable Trip schema.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Any, Iterable
+
+
+class CandidateState(str, Enum):
+    FETCHED = "fetched"
+    NORMALIZED = "normalized"
+    SELECTED = "selected"
+    REJECTED = "rejected"
+
+
+class StaleCandidateError(ValueError):
+    """Raised when a dynamic fact is too old for its caller-defined freshness limit."""
+
+
+@dataclass(frozen=True)
+class CandidateRecord:
+    collection: str
+    candidate: dict[str, Any]
+    state: CandidateState
+    stored_at: datetime
+
+    @property
+    def candidate_id(self) -> str:
+        if self.collection in {"restaurants", "hotels"}:
+            return self.candidate["place"]["id"]
+        return self.candidate["id"]
+
+
+class CandidateStore:
+    """In-memory candidate lifecycle store for one research job.
+
+    Candidate payloads remain compatible with Trip V1's ``candidate_sets``.  The
+    store's lifecycle state is operational metadata only and is never serialized
+    into that schema.
+    """
+
+    VALID_COLLECTIONS = frozenset({"places", "restaurants", "hotels", "flights", "transport_legs"})
+
+    def __init__(self, now: datetime | None = None) -> None:
+        self._now = now or datetime.now(timezone.utc)
+        self._records: dict[str, CandidateRecord] = {}
+
+    def ingest(self, collection: str, candidate: dict[str, Any]) -> CandidateRecord:
+        """Store a fetched canonical candidate after enforcing provenance invariants."""
+
+        if collection not in self.VALID_COLLECTIONS:
+            raise ValueError(f"unsupported candidate collection: {collection}")
+        provenance = candidate.get("provenance")
+        if not isinstance(provenance, dict) and collection in {"restaurants", "hotels"}:
+            provenance = candidate.get("place", {}).get("provenance")
+        retrieved_at = _parse_retrieved_at(provenance)
+        if not isinstance(provenance.get("provider"), str) or not provenance["provider"]:
+            raise ValueError("candidate provenance requires a provider")
+        record = CandidateRecord(collection, candidate, CandidateState.FETCHED, self._now)
+        self._records[record.candidate_id] = record
+        return record
+
+    def normalize(self, candidate_id: str) -> CandidateRecord:
+        return self._transition(candidate_id, {CandidateState.FETCHED}, CandidateState.NORMALIZED)
+
+    def select(self, candidate_id: str) -> CandidateRecord:
+        return self._transition(candidate_id, {CandidateState.NORMALIZED}, CandidateState.SELECTED)
+
+    def reject(self, candidate_id: str) -> CandidateRecord:
+        return self._transition(candidate_id, {CandidateState.FETCHED, CandidateState.NORMALIZED}, CandidateState.REJECTED)
+
+    def fresh(self, max_age: timedelta, now: datetime | None = None) -> list[CandidateRecord]:
+        """Return non-rejected records whose canonical provenance is still fresh."""
+
+        reference = now or datetime.now(timezone.utc)
+        records = []
+        for record in self._records.values():
+            if record.state is CandidateState.REJECTED:
+                continue
+            retrieved_at = _parse_retrieved_at(_provenance_for(record))
+            if reference - retrieved_at <= max_age:
+                records.append(record)
+        return records
+
+    def require_fresh(self, candidate_id: str, max_age: timedelta, now: datetime | None = None) -> CandidateRecord:
+        record = self._records[candidate_id]
+        reference = now or datetime.now(timezone.utc)
+        if reference - _parse_retrieved_at(_provenance_for(record)) > max_age:
+            raise StaleCandidateError(f"candidate {candidate_id} exceeds freshness limit")
+        return record
+
+    def records(self) -> Iterable[CandidateRecord]:
+        return tuple(self._records.values())
+
+    def _transition(self, candidate_id: str, allowed: set[CandidateState], target: CandidateState) -> CandidateRecord:
+        record = self._records[candidate_id]
+        if record.state not in allowed:
+            raise ValueError(f"cannot transition {candidate_id} from {record.state} to {target}")
+        updated = CandidateRecord(record.collection, record.candidate, target, record.stored_at)
+        self._records[candidate_id] = updated
+        return updated
+
+
+def _provenance_for(record: CandidateRecord) -> dict[str, Any]:
+    return record.candidate.get("provenance") or record.candidate["place"]["provenance"]
+
+
+def _parse_retrieved_at(provenance: Any) -> datetime:
+    if not isinstance(provenance, dict) or not provenance.get("retrieved_at"):
+        raise ValueError("candidate provenance requires retrieved_at")
+    try:
+        parsed = datetime.fromisoformat(provenance["retrieved_at"])
+    except (TypeError, ValueError) as exc:
+        raise ValueError("candidate provenance retrieved_at must be ISO 8601") from exc
+    if parsed.tzinfo is None:
+        raise ValueError("candidate provenance retrieved_at must include a timezone offset")
+    return parsed

--- a/src/sources/routing/__init__.py
+++ b/src/sources/routing/__init__.py
@@ -1,0 +1,14 @@
+from .matrix import RouteMatrix
+from .models import PlaceRef, Route, RouteMode, RouteProvenance, RouteStatus
+from .provider import FixtureRoutingProvider, RoutingProvider
+
+__all__ = [
+    "FixtureRoutingProvider",
+    "PlaceRef",
+    "Route",
+    "RouteMatrix",
+    "RouteMode",
+    "RouteProvenance",
+    "RouteStatus",
+    "RoutingProvider",
+]

--- a/src/sources/routing/matrix.py
+++ b/src/sources/routing/matrix.py
@@ -1,0 +1,47 @@
+"""Shared route matrix with a cache for planner, optimizer and validator reuse."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Callable
+
+from .models import PlaceRef, Route, RouteMode
+from .provider import RoutingProvider
+
+
+class RouteMatrix:
+    """Cache every provider response, including UNKNOWN, by mode and canonical place IDs.
+
+    A finite TTL can be supplied for dynamic providers. A single matrix instance is passed
+    through pipeline stages so validation observes exactly the route result used by planning.
+    """
+
+    def __init__(
+        self,
+        provider: RoutingProvider,
+        *,
+        ttl: timedelta | None = None,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.provider = provider
+        self.ttl = ttl
+        self._now = now or (lambda: datetime.now(timezone.utc))
+        self._cache: dict[tuple[str, str, str], tuple[Route, datetime]] = {}
+
+    def route(self, origin: PlaceRef, destination: PlaceRef, mode: RouteMode) -> Route:
+        key = (mode.value, origin.place_id, destination.place_id)
+        cached = self._cache.get(key)
+        if cached is not None and not self._expired(cached[1]):
+            return cached[0]
+        route = self.provider.fetch(origin, destination, mode)
+        if route.cache_key != key:
+            raise ValueError("routing provider returned a route for a different request")
+        self._cache[key] = (route, self._now())
+        return route
+
+    def _expired(self, stored_at: datetime) -> bool:
+        return self.ttl is not None and self._now() - stored_at >= self.ttl
+
+    @property
+    def cached_routes(self) -> tuple[Route, ...]:
+        return tuple(item[0] for item in self._cache.values())

--- a/src/sources/routing/models.py
+++ b/src/sources/routing/models.py
@@ -1,0 +1,66 @@
+"""Provider-neutral route records used by planning, optimisation and validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+
+class RouteMode(str, Enum):
+    DRIVING = "driving"
+    TRANSIT = "transit"
+    WALKING = "walking"
+
+
+class RouteStatus(str, Enum):
+    AVAILABLE = "available"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class PlaceRef:
+    """A canonical place ID, optionally accompanied by coordinates for a provider."""
+
+    place_id: str
+    latitude: float | None = None
+    longitude: float | None = None
+
+    def __post_init__(self) -> None:
+        if (self.latitude is None) != (self.longitude is None):
+            raise ValueError("latitude and longitude must be provided together")
+
+
+@dataclass(frozen=True)
+class RouteProvenance:
+    provider: str
+    retrieved_at: datetime
+    source_type: str = "provider"
+    source_url: str | None = None
+    note: str | None = None
+
+
+@dataclass(frozen=True)
+class Route:
+    """A route result. Unknown results deliberately have no invented cost."""
+
+    origin: PlaceRef
+    destination: PlaceRef
+    mode: RouteMode
+    status: RouteStatus
+    provenance: RouteProvenance
+    duration_seconds: int | None = None
+    distance_meters: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.status is RouteStatus.AVAILABLE:
+            if self.duration_seconds is None or self.distance_meters is None:
+                raise ValueError("available routes require duration_seconds and distance_meters")
+            if self.duration_seconds < 0 or self.distance_meters < 0:
+                raise ValueError("route costs cannot be negative")
+        elif self.duration_seconds is not None or self.distance_meters is not None:
+            raise ValueError("unknown routes cannot contain guessed duration or distance")
+
+    @property
+    def cache_key(self) -> tuple[str, str, str]:
+        return (self.mode.value, self.origin.place_id, self.destination.place_id)

--- a/src/sources/routing/provider.py
+++ b/src/sources/routing/provider.py
@@ -1,0 +1,45 @@
+"""Routing provider contract and a fixture-backed deterministic implementation."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from typing import Iterable
+
+from .models import PlaceRef, Route, RouteMode, RouteProvenance, RouteStatus
+
+
+class RoutingProvider(ABC):
+    """Provider SDKs stay behind this contract."""
+
+    @abstractmethod
+    def fetch(self, origin: PlaceRef, destination: PlaceRef, mode: RouteMode) -> Route:
+        """Fetch one route. Implementations must return UNKNOWN on an unavailable route."""
+
+
+class FixtureRoutingProvider(RoutingProvider):
+    """In-memory provider stub for tests and repeatable local planning."""
+
+    def __init__(self, routes: Iterable[Route], provider_name: str = "fixture-routing") -> None:
+        self._routes = {route.cache_key: route for route in routes}
+        self.provider_name = provider_name
+        self.calls = 0
+
+    def fetch(self, origin: PlaceRef, destination: PlaceRef, mode: RouteMode) -> Route:
+        self.calls += 1
+        key = (mode.value, origin.place_id, destination.place_id)
+        route = self._routes.get(key)
+        if route is not None:
+            return route
+        return Route(
+            origin=origin,
+            destination=destination,
+            mode=mode,
+            status=RouteStatus.UNKNOWN,
+            provenance=RouteProvenance(
+                provider=self.provider_name,
+                retrieved_at=datetime.now(timezone.utc),
+                source_type="provider",
+                note="No fixture route is available",
+            ),
+        )

--- a/src/validator/__init__.py
+++ b/src/validator/__init__.py
@@ -1,0 +1,25 @@
+"""Public deterministic itinerary validation API."""
+
+from .itinerary import (
+    DEFAULT_RULES,
+    BudgetLimit,
+    OpeningInterval,
+    Outcome,
+    RuleRegistry,
+    ValidationContext,
+    ValidationResult,
+    Violation,
+    validate_itinerary,
+)
+
+__all__ = [
+    "DEFAULT_RULES",
+    "BudgetLimit",
+    "OpeningInterval",
+    "Outcome",
+    "RuleRegistry",
+    "ValidationContext",
+    "ValidationResult",
+    "Violation",
+    "validate_itinerary",
+]

--- a/src/validator/__init__.py
+++ b/src/validator/__init__.py
@@ -11,6 +11,7 @@ from .itinerary import (
     Violation,
     validate_itinerary,
 )
+from .routing import validate_route_availability
 
 __all__ = [
     "DEFAULT_RULES",
@@ -22,4 +23,5 @@ __all__ = [
     "ValidationResult",
     "Violation",
     "validate_itinerary",
+    "validate_route_availability",
 ]

--- a/src/validator/itinerary.py
+++ b/src/validator/itinerary.py
@@ -1,0 +1,215 @@
+"""Deterministic validation rules for Canonical Trip V1 itineraries.
+
+The validator deliberately does not enrich a trip or call external services.
+Facts that are not part of Trip V1 (routing results and opening hours) are
+passed in as a :class:`ValidationContext`, making every result reproducible.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, time
+from enum import Enum
+from typing import Callable, Mapping, Sequence
+
+
+class Outcome(str, Enum):
+    VALID = "valid"
+    INVALID = "invalid"
+    INCOMPLETE = "incomplete"
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A stable, machine-readable result emitted by one validation rule."""
+
+    code: str
+    severity: str
+    message: str
+    path: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "path": self.path,
+        }
+
+
+@dataclass(frozen=True)
+class OpeningInterval:
+    """A local opening interval; weekday uses Python's Monday=0 convention."""
+
+    weekday: int
+    opens_at: time
+    closes_at: time
+
+
+@dataclass(frozen=True)
+class BudgetLimit:
+    amount: float
+    currency: str
+
+
+@dataclass(frozen=True)
+class ValidationContext:
+    """Explicit derived inputs needed by rules which Trip V1 does not contain.
+
+    ``travel_minutes`` is keyed by ``(from_place_id, to_place_id)``. Omit a
+    route when it is unknown; the travel rule will emit an unverified warning.
+    ``opening_hours`` is keyed by place ID and lists local weekly intervals.
+    Omit a scheduled place when its hours are unknown.
+    """
+
+    travel_minutes: Mapping[tuple[str, str], int] = field(default_factory=dict)
+    opening_hours: Mapping[str, Sequence[OpeningInterval]] = field(default_factory=dict)
+    budget_limit: BudgetLimit | None = None
+
+
+Rule = Callable[[dict, ValidationContext], Sequence[Violation]]
+
+
+class RuleRegistry:
+    """Ordered registry so callers can add deterministic rules without forking."""
+
+    def __init__(self, rules: Sequence[Rule] = ()) -> None:
+        self._rules = list(rules)
+
+    def register(self, rule: Rule) -> Rule:
+        self._rules.append(rule)
+        return rule
+
+    def run(self, trip: dict, context: ValidationContext) -> list[Violation]:
+        return [violation for rule in self._rules for violation in rule(trip, context)]
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    outcome: Outcome
+    violations: tuple[Violation, ...]
+
+    @property
+    def is_valid(self) -> bool:
+        return self.outcome is Outcome.VALID
+
+    def as_dict(self) -> dict[str, object]:
+        return {"outcome": self.outcome.value, "violations": [v.as_dict() for v in self.violations]}
+
+
+def validate_itinerary(
+    trip: dict, context: ValidationContext | None = None, registry: RuleRegistry | None = None
+) -> ValidationResult:
+    """Run deterministic itinerary rules against an already canonical Trip V1 model."""
+
+    violations = tuple((registry or DEFAULT_RULES).run(trip, context or ValidationContext()))
+    if any(item.severity == "error" for item in violations):
+        outcome = Outcome.INVALID
+    elif violations:
+        outcome = Outcome.INCOMPLETE
+    else:
+        outcome = Outcome.VALID
+    return ValidationResult(outcome, violations)
+
+
+def time_overlap_rule(trip: dict, _: ValidationContext) -> Sequence[Violation]:
+    violations: list[Violation] = []
+    for day_index, day in enumerate(trip.get("days", [])):
+        scheduled = sorted(enumerate(day.get("items", [])), key=lambda pair: pair[1]["start_at"])
+        previous_index: int | None = None
+        previous_end: datetime | None = None
+        for item_index, item in scheduled:
+            start, end = _timestamps(item)
+            path = _item_path(day_index, item_index)
+            if end <= start:
+                violations.append(_error("time.invalid_interval", "item end must be after its start", path))
+            if previous_end is not None and start < previous_end:
+                violations.append(_error("time.overlap", "item overlaps the preceding scheduled item", path))
+            if previous_end is None or end > previous_end:
+                previous_index, previous_end = item_index, end
+    return violations
+
+
+def travel_time_rule(trip: dict, context: ValidationContext) -> Sequence[Violation]:
+    violations: list[Violation] = []
+    for day_index, day in enumerate(trip.get("days", [])):
+        scheduled = sorted(enumerate(day.get("items", [])), key=lambda pair: pair[1]["start_at"])
+        for (previous_index, previous), (item_index, item) in zip(scheduled, scheduled[1:]):
+            if previous["place_id"] == item["place_id"]:
+                continue
+            path = _item_path(day_index, item_index)
+            route = (previous["place_id"], item["place_id"])
+            minutes = context.travel_minutes.get(route)
+            if minutes is None:
+                violations.append(_warning("travel_time.unverified", f"travel time for {route[0]} to {route[1]} is unknown", path))
+                continue
+            if minutes < 0:
+                violations.append(_error("travel_time.invalid", "travel duration cannot be negative", path))
+                continue
+            available_minutes = (_timestamps(item)[0] - _timestamps(previous)[1]).total_seconds() / 60
+            if available_minutes < minutes:
+                violations.append(_error("travel_time.insufficient", f"requires {minutes} minutes but only {available_minutes:g} minutes are scheduled", path))
+    return violations
+
+
+def opening_hours_rule(trip: dict, context: ValidationContext) -> Sequence[Violation]:
+    violations: list[Violation] = []
+    for day_index, day in enumerate(trip.get("days", [])):
+        for item_index, item in enumerate(day.get("items", [])):
+            if item.get("kind") not in {"visit", "meal"}:
+                continue
+            path = _item_path(day_index, item_index)
+            intervals = context.opening_hours.get(item["place_id"])
+            if not intervals:
+                violations.append(_warning("opening_hours.unverified", "opening hours are unknown", path))
+                continue
+            start, end = _timestamps(item)
+            if start.date() != end.date() or not any(
+                interval.weekday == start.weekday()
+                and interval.opens_at <= start.timetz().replace(tzinfo=None)
+                and end.timetz().replace(tzinfo=None) <= interval.closes_at
+                for interval in intervals
+            ):
+                violations.append(_error("opening_hours.closed", "scheduled time falls outside opening hours", path))
+    return violations
+
+
+def budget_rule(trip: dict, context: ValidationContext) -> Sequence[Violation]:
+    budget = trip.get("budget", {})
+    path = "/budget"
+    total = budget.get("total", {})
+    currency = budget.get("currency")
+    category_values = budget.get("categories", {}).values()
+    if not total or currency is None:
+        return [_warning("budget.unverified", "budget data is incomplete", path)]
+    if total.get("currency") != currency or any(value.get("currency") != currency for value in category_values):
+        return [_error("budget.currency_mismatch", "budget values must use the trip budget currency", path)]
+    category_total = sum(value["amount"] for value in category_values)
+    if category_total != total["amount"]:
+        return [_error("budget.total_mismatch", "budget total does not equal category total", path)]
+    if context.budget_limit is None:
+        return []
+    if context.budget_limit.currency != currency:
+        return [_warning("budget.unverified", "budget limit currency differs from trip budget currency", path)]
+    if total["amount"] > context.budget_limit.amount:
+        return [_error("budget.exceeded", "budget total exceeds the supplied budget limit", path)]
+    return []
+
+
+DEFAULT_RULES = RuleRegistry((time_overlap_rule, travel_time_rule, opening_hours_rule, budget_rule))
+
+
+def _timestamps(item: dict) -> tuple[datetime, datetime]:
+    return datetime.fromisoformat(item["start_at"]), datetime.fromisoformat(item["end_at"])
+
+
+def _item_path(day_index: int, item_index: int) -> str:
+    return f"/days/{day_index}/items/{item_index}"
+
+
+def _error(code: str, message: str, path: str) -> Violation:
+    return Violation(code, "error", message, path)
+
+
+def _warning(code: str, message: str, path: str) -> Violation:
+    return Violation(code, "warning", message, path)

--- a/src/validator/routing.py
+++ b/src/validator/routing.py
@@ -1,0 +1,14 @@
+"""Machine-readable route availability checks reusable by a trip validator."""
+
+from __future__ import annotations
+
+from src.optimizer import OptimizationResult
+from .itinerary import Violation
+
+
+def validate_route_availability(result: OptimizationResult, path: str = "/days") -> list[Violation]:
+    """Expose unknown routing as a validator warning; never silently zero-cost it."""
+    return [
+        Violation("route_unknown", "warning", f"Route is unavailable for {origin} -> {destination} ({mode})", path)
+        for mode, origin, destination in result.unknown_route_keys
+    ]

--- a/tests/fixtures/planner/normal.json
+++ b/tests/fixtures/planner/normal.json
@@ -1,0 +1,1 @@
+{"name": "normal", "expected_state": "ready"}

--- a/tests/fixtures/planner/strict-budget.json
+++ b/tests/fixtures/planner/strict-budget.json
@@ -1,0 +1,1 @@
+{"name": "strict-budget", "limit": 100000, "expected_state": "failed"}

--- a/tests/fixtures/planner/time-conflict.json
+++ b/tests/fixtures/planner/time-conflict.json
@@ -1,0 +1,1 @@
+{"name": "time-conflict", "item_id": "d4-beppu", "start_at": "2026-04-13T11:30:00+09:00", "expected_state": "repaired"}

--- a/tests/test_itinerary_validator.py
+++ b/tests/test_itinerary_validator.py
@@ -1,0 +1,68 @@
+import copy
+import json
+from datetime import time
+from pathlib import Path
+import unittest
+
+from src.validator import BudgetLimit, OpeningInterval, Outcome, RuleRegistry, ValidationContext, validate_itinerary
+
+
+FIXTURE = Path(__file__).parents[1] / "fixtures/trips/japan-5-day-trip-v1.json"
+
+
+def verified_context() -> ValidationContext:
+    hours = {}
+    for place_id in ("ohori-park", "dazaifu", "yufuin", "beppu", "canal-city"):
+        hours[place_id] = [OpeningInterval(weekday, time(8), time(22)) for weekday in range(7)]
+    return ValidationContext(
+        travel_minutes={
+            ("fuk", "hakata-hotel"): 180,
+            ("yufuin", "beppu"): 60,
+        },
+        opening_hours=hours,
+        budget_limit=BudgetLimit(200000, "JPY"),
+    )
+
+
+class ItineraryValidatorTests(unittest.TestCase):
+    def setUp(self):
+        self.trip = json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+    def test_complete_fixture_passes(self):
+        result = validate_itinerary(self.trip, verified_context())
+        self.assertEqual(result.outcome, Outcome.VALID)
+        self.assertEqual(result.violations, ())
+        self.assertEqual(result.as_dict(), {"outcome": "valid", "violations": []})
+
+    def test_overlap_and_insufficient_travel_fail(self):
+        trip = copy.deepcopy(self.trip)
+        trip["days"][3]["items"][1]["start_at"] = "2026-04-13T11:30:00+09:00"
+        result = validate_itinerary(trip, verified_context())
+        self.assertEqual(result.outcome, Outcome.INVALID)
+        self.assertEqual({item.code for item in result.violations}, {"time.overlap", "travel_time.insufficient"})
+
+    def test_closed_and_over_budget_fail(self):
+        context = verified_context()
+        context = ValidationContext(
+            travel_minutes=context.travel_minutes,
+            opening_hours={**context.opening_hours, "ohori-park": [OpeningInterval(5, time(8), time(9))]},
+            budget_limit=BudgetLimit(100000, "JPY"),
+        )
+        result = validate_itinerary(self.trip, context)
+        self.assertEqual(result.outcome, Outcome.INVALID)
+        self.assertEqual({item.code for item in result.violations}, {"opening_hours.closed", "budget.exceeded"})
+
+    def test_unknown_derived_facts_are_incomplete(self):
+        result = validate_itinerary(self.trip)
+        self.assertEqual(result.outcome, Outcome.INCOMPLETE)
+        self.assertIn("travel_time.unverified", {item.code for item in result.violations})
+        self.assertIn("opening_hours.unverified", {item.code for item in result.violations})
+
+    def test_registry_accepts_extension(self):
+        registry = RuleRegistry()
+        registry.register(lambda trip, context: [])
+        self.assertEqual(validate_itinerary(self.trip, registry=registry).outcome, Outcome.VALID)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,91 @@
+import copy
+import json
+from datetime import time
+from pathlib import Path
+import unittest
+
+from src.planner import HardConstraint, PlanState, PlannerInput, SoftPreference, plan
+from src.validator import BudgetLimit, OpeningInterval, ValidationContext
+
+
+ROOT = Path(__file__).parents[1]
+TRIP_FIXTURE = ROOT / "fixtures/trips/japan-5-day-trip-v1.json"
+SCENARIOS = ROOT / "tests/fixtures/planner"
+
+
+def verified_context(limit=200000):
+    hours = {
+        place_id: [OpeningInterval(weekday, time(8), time(22)) for weekday in range(7)]
+        for place_id in ("ohori-park", "dazaifu", "yufuin", "beppu", "canal-city")
+    }
+    return ValidationContext(
+        travel_minutes={("fuk", "hakata-hotel"): 180, ("yufuin", "beppu"): 60},
+        opening_hours=hours,
+        budget_limit=BudgetLimit(limit, "JPY"),
+    )
+
+
+class PlannerTests(unittest.TestCase):
+    def setUp(self):
+        self.trip = json.loads(TRIP_FIXTURE.read_text(encoding="utf-8"))
+
+    def _scenario(self, name):
+        return json.loads((SCENARIOS / f"{name}.json").read_text(encoding="utf-8"))
+
+    def test_normal_fixture_is_ready_and_ranked_by_soft_preference(self):
+        scenario = self._scenario("normal")
+        result = plan(PlannerInput([self.trip], verified_context(), soft_preferences=[SoftPreference("low-fatigue", "low_fatigue")]))
+        candidate = result.best_plan
+        self.assertEqual(candidate.state.value, scenario["expected_state"])
+        self.assertLess(candidate.score, 0)
+        self.assertEqual(candidate.violations, ())
+
+    def test_time_conflict_fixture_repairs_only_violating_item_and_revalidates(self):
+        scenario = self._scenario("time-conflict")
+        trip = copy.deepcopy(self.trip)
+        item = trip["days"][3]["items"][1]
+        item["start_at"] = scenario["start_at"]
+        result = plan(PlannerInput([trip], verified_context(), max_repair_iterations=2))
+        candidate = result.best_plan
+        repaired = candidate.trip["days"][3]["items"][1]
+        self.assertEqual(candidate.state.value, scenario["expected_state"])
+        self.assertEqual(candidate.repair_iterations, 1)
+        self.assertEqual(repaired["start_at"], "2026-04-13T13:00:00+09:00")
+        self.assertEqual(repaired["end_at"], "2026-04-13T17:30:00+09:00")
+        self.assertEqual(candidate.violations, ())
+
+    def test_strict_budget_fixture_returns_explicit_failure(self):
+        scenario = self._scenario("strict-budget")
+        result = plan(PlannerInput([self.trip], verified_context(scenario["limit"])))
+        candidate = result.plans[0]
+        self.assertEqual(candidate.state.value, scenario["expected_state"])
+        self.assertIsNone(result.best_plan)
+        self.assertIn("budget.exceeded", {violation.code for violation in candidate.violations})
+
+    def test_hard_constraints_precede_soft_scoring(self):
+        constraints = [
+            HardConstraint("must-visit", "required_location", "ohori-park"),
+            HardConstraint("no-shopping", "forbidden_location", "canal-city"),
+        ]
+        result = plan(PlannerInput([self.trip], verified_context(), hard_constraints=constraints))
+        self.assertEqual(result.plans[0].state, PlanState.FAILED)
+        self.assertIn("constraint.forbidden_location", {v.code for v in result.plans[0].violations})
+
+    def test_preserved_override_wins_over_candidate_mutation(self):
+        trip = copy.deepcopy(self.trip)
+        trip["selected"]["hotel_place_ids"] = []
+        result = plan(PlannerInput([trip], verified_context()))
+        self.assertEqual(result.best_plan.trip["selected"]["hotel_place_ids"], ["hakata-hotel"])
+
+    def test_fixed_and_daily_duration_constraints_are_checked(self):
+        constraints = [
+            HardConstraint("arrival", "fixed_time", {"item_id": "d1-arrival", "start_at": "2026-04-10T11:00:00+09:00", "end_at": "2026-04-10T12:00:00+09:00"}),
+            HardConstraint("short-day", "max_daily_duration", 30),
+        ]
+        result = plan(PlannerInput([self.trip], verified_context(), hard_constraints=constraints))
+        self.assertEqual(result.plans[0].state, PlanState.FAILED)
+        self.assertEqual({v.code for v in result.plans[0].violations}, {"constraint.fixed_time", "constraint.max_daily_duration"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+from src.renderer.build_site import build_site
+
+
+FIXTURE = Path("fixtures/trips/japan-5-day-trip-v1.json")
+
+
+def test_renderer_shows_core_views_and_provenance_state():
+    html = build_site(json.loads(FIXTURE.read_text(encoding="utf-8")))
+    assert "總覽" in html and "行程" in html and "預算" in html
+    assert "博多家庭飯店" in html
+    assert "JPY 169,000" in html
+    assert "reported" in html
+    assert "source freshness:" in html
+    assert "目前沒有上游 validation warning" in html
+
+
+def test_renderer_displays_upstream_validation_without_evaluating_it():
+    trip = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    trip["validation"] = [{"code": "schedule_conflict", "message": "由 validator 提供"}]
+    assert "schedule_conflict" in build_site(trip)

--- a/tests/test_routing_optimizer.py
+++ b/tests/test_routing_optimizer.py
@@ -1,0 +1,86 @@
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from src.optimizer import RouteOptimizer, Stop
+from src.sources.routing import (
+    FixtureRoutingProvider,
+    PlaceRef,
+    Route,
+    RouteMatrix,
+    RouteMode,
+    RouteProvenance,
+    RouteStatus,
+)
+from src.validator import validate_route_availability
+
+
+NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def route(origin: str, destination: str, seconds: int, meters: int | None = None) -> Route:
+    return Route(
+        PlaceRef(origin), PlaceRef(destination), RouteMode.DRIVING, RouteStatus.AVAILABLE,
+        RouteProvenance("fixture-routing", NOW), seconds, meters if meters is not None else seconds * 10,
+    )
+
+
+class RoutingAndOptimizerTests(unittest.TestCase):
+    def test_matrix_caches_provider_result_including_unknown(self):
+        provider = FixtureRoutingProvider([route("a", "b", 120)])
+        matrix = RouteMatrix(provider)
+        self.assertEqual(matrix.route(PlaceRef("a"), PlaceRef("b"), RouteMode.DRIVING).duration_seconds, 120)
+        self.assertEqual(matrix.route(PlaceRef("a"), PlaceRef("b"), RouteMode.DRIVING).duration_seconds, 120)
+        self.assertEqual(provider.calls, 1)
+        self.assertEqual(matrix.route(PlaceRef("b"), PlaceRef("missing"), RouteMode.DRIVING).status, RouteStatus.UNKNOWN)
+        self.assertEqual(matrix.route(PlaceRef("b"), PlaceRef("missing"), RouteMode.DRIVING).status, RouteStatus.UNKNOWN)
+        self.assertEqual(provider.calls, 2)
+
+    def test_matrix_refreshes_after_ttl(self):
+        clock = [NOW]
+        provider = FixtureRoutingProvider([route("a", "b", 120)])
+        matrix = RouteMatrix(provider, ttl=timedelta(minutes=5), now=lambda: clock[0])
+        matrix.route(PlaceRef("a"), PlaceRef("b"), RouteMode.DRIVING)
+        clock[0] += timedelta(minutes=5)
+        matrix.route(PlaceRef("a"), PlaceRef("b"), RouteMode.DRIVING)
+        self.assertEqual(provider.calls, 2)
+
+    def test_four_poi_ordering_clusters_low_travel_route(self):
+        # a -> c -> b -> d is 3 minutes total; the input deliberately is scrambled.
+        routes = [
+            route("a", "c", 60), route("c", "b", 60), route("b", "d", 60),
+            route("a", "b", 600), route("a", "d", 900), route("b", "c", 600),
+            route("c", "d", 600), route("d", "b", 900), route("d", "c", 900),
+        ]
+        optimizer = RouteOptimizer(RouteMatrix(FixtureRoutingProvider(routes)), RouteMode.DRIVING)
+        result = optimizer.optimize([Stop(PlaceRef("a")), Stop(PlaceRef("d")), Stop(PlaceRef("b")), Stop(PlaceRef("c"))])
+        self.assertEqual([stop.place.place_id for stop in result.stops], ["a", "c", "b", "d"])
+        self.assertEqual(result.travel_seconds, 180)
+        self.assertEqual(result.travel_meters, 1800)
+
+    def test_fixed_time_anchor_is_not_moved_or_rescheduled(self):
+        fixed_start = datetime(2026, 4, 10, 12, tzinfo=timezone.utc)
+        fixed_end = datetime(2026, 4, 10, 13, tzinfo=timezone.utc)
+        anchor = Stop(PlaceRef("reservation"), fixed_start, fixed_end)
+        routes = [
+            route("a", "b", 60), route("b", "reservation", 60), route("a", "reservation", 500),
+            route("reservation", "c", 60), route("reservation", "d", 500), route("c", "d", 60),
+        ]
+        optimizer = RouteOptimizer(RouteMatrix(FixtureRoutingProvider(routes)), RouteMode.DRIVING)
+        result = optimizer.optimize([Stop(PlaceRef("b")), Stop(PlaceRef("a")), anchor, Stop(PlaceRef("d")), Stop(PlaceRef("c"))])
+        self.assertEqual([stop.place.place_id for stop in result.stops], ["a", "b", "reservation", "c", "d"])
+        optimized_anchor = result.stops[2]
+        self.assertEqual((optimized_anchor.fixed_start_at, optimized_anchor.fixed_end_at), (fixed_start, fixed_end))
+
+    def test_unknown_route_reaches_validator_without_zero_cost(self):
+        optimizer = RouteOptimizer(RouteMatrix(FixtureRoutingProvider([])), RouteMode.WALKING)
+        result = optimizer.optimize([Stop(PlaceRef("a")), Stop(PlaceRef("b"))])
+        self.assertTrue(result.has_unknown_routes)
+        self.assertIsNone(result.travel_seconds)
+        self.assertIsNone(result.travel_meters)
+        violations = validate_route_availability(result, "/days/0/items")
+        self.assertEqual(violations[0].code, "route_unknown")
+        self.assertEqual(violations[0].path, "/days/0/items")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from src.sources import (
+    CandidateState,
+    CandidateStore,
+    FixtureCommunityRestaurantAdapter,
+    FixtureOfficialPoiAdapter,
+    SourceAdapter,
+    SourceQuery,
+    StaleCandidateError,
+    collect_from_adapters,
+)
+
+
+NOW = datetime(2026, 8, 10, 8, 0, tzinfo=timezone.utc)
+QUERY = SourceQuery(destination="福岡", categories=("pois", "restaurants"))
+
+
+class BrokenAdapter(SourceAdapter):
+    name = "broken-fixture"
+
+    def fetch(self, query):
+        raise RuntimeError("provider timeout")
+
+
+class SourceAdapterTests(unittest.TestCase):
+    def test_fixture_adapters_emit_canonical_provenance(self):
+        candidates, failures = collect_from_adapters(
+            [FixtureOfficialPoiAdapter(NOW), FixtureCommunityRestaurantAdapter(NOW)], QUERY
+        )
+        self.assertEqual([], failures)
+        self.assertEqual({"places", "restaurants"}, {collection for collection, _ in candidates})
+        for _, candidate in candidates:
+            provenance = candidate["provenance"]
+            self.assertEqual(NOW.isoformat(), provenance["retrieved_at"])
+            self.assertIn(provenance["source_type"], {"official", "community"})
+
+    def test_adapter_failure_is_isolated(self):
+        candidates, failures = collect_from_adapters(
+            [BrokenAdapter(), FixtureOfficialPoiAdapter(NOW)], QUERY
+        )
+        self.assertEqual(1, len(candidates))
+        self.assertEqual("places", candidates[0][0])
+        self.assertEqual(["broken-fixture"], [failure.adapter for failure in failures])
+
+
+class CandidateStoreTests(unittest.TestCase):
+    def setUp(self):
+        self.store = CandidateStore(now=NOW)
+        self.poi = list(FixtureOfficialPoiAdapter(NOW).fetch(QUERY))[0]
+
+    def test_lifecycle_does_not_mutate_canonical_candidate(self):
+        collection, candidate = self.poi
+        fetched = self.store.ingest(collection, candidate)
+        normalized = self.store.normalize(fetched.candidate_id)
+        selected = self.store.select(fetched.candidate_id)
+        self.assertEqual(CandidateState.FETCHED, fetched.state)
+        self.assertEqual(CandidateState.NORMALIZED, normalized.state)
+        self.assertEqual(CandidateState.SELECTED, selected.state)
+        self.assertNotIn("state", candidate)
+        self.assertNotIn("selected", candidate)
+
+    def test_retrieved_at_is_required_and_staleness_is_enforced(self):
+        collection, candidate = self.poi
+        self.store.ingest(collection, candidate)
+        self.assertEqual(1, len(self.store.fresh(timedelta(hours=1), now=NOW + timedelta(minutes=59))))
+        with self.assertRaises(StaleCandidateError):
+            self.store.require_fresh("ohori-park", timedelta(hours=1), now=NOW + timedelta(hours=1, seconds=1))
+        invalid = {**candidate, "provenance": {**candidate["provenance"]}}
+        del invalid["provenance"]["retrieved_at"]
+        with self.assertRaisesRegex(ValueError, "retrieved_at"):
+            CandidateStore(now=NOW).ingest(collection, invalid)
+
+    def test_community_candidate_preserves_reported_provenance(self):
+        collection, candidate = list(FixtureCommunityRestaurantAdapter(NOW).fetch(QUERY))[0]
+        record = self.store.ingest(collection, candidate)
+        self.assertEqual("community", record.candidate["provenance"]["source_type"])
+        self.assertEqual("reported", record.candidate["provenance"]["status"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
Integrates the already-merged M1 feature branches into `main`:

- source adapters and candidate store (#2)
- deterministic itinerary validation (#4)
- constrained planner and bounded repair loop (#3)
- provider-neutral routing and optimizer (#5)
- mobile static renderer and GitHub Pages workflow (#6)

## Why
The original implementation PRs were merged into stacked feature branches. This integration PR carries their final combined state to `main`.

## Validation
- `python3 -m unittest discover -s tests -v` — 25 passed
- `python3 -m pytest -q` — 27 passed
- `git diff --check origin/main...HEAD` — passed