### PR TITLE
feat: add Japan-first research providers

### DIFF
--- a/docs/source-evidence-priority.md
+++ b/docs/source-evidence-priority.md
@@ -25,3 +25,34 @@ Use `place.name` and `place.address` as Unicode strings, preserving Japanese plu
 1. Store each independently sourced candidate with its own provenance; do not overwrite a higher-priority fact.
 2. Planner may use `confirmed` official/provider facts for hard constraints. `reported` community facts are soft signals.
 3. Mark a candidate selected only after it has been normalized; the planner then writes the final Trip selection through existing IDs, not by mutating research evidence.
+
+## Production research adapters (Issue #16)
+
+`src.sources.GooglePlacesAdapter` uses the documented Google Places API (New)
+Text Search endpoint for both POI discovery and restaurant discovery. This is the
+compliant Japan-first replacement for any Tabelog-like web scraping dependency:
+it yields canonical place/restaurant candidates only, and deliberately omits
+provider-specific ratings and reviews. Set `GOOGLE_MAPS_API_KEY`; enable Places
+API (New), restrict the key, and set Google Cloud quotas/billing appropriate to
+the deployment. Google may rate-limit or bill requests; adapter failures are
+isolated by `collect_from_adapters`, so fixtures or other providers can still
+return results.
+
+`YouTubeEvidenceAdapter` uses the documented YouTube Data API Search endpoint.
+Set `YOUTUBE_API_KEY` with a restricted API key. It emits `ResearchEvidence`,
+not candidates: title/description-derived signals such as queue, parking, or
+stroller are community `reported` evidence and cannot become confirmed operating
+facts. Respect YouTube Data API quota and display/storage terms; the adapter does
+not scrape pages, comments, or transcripts.
+
+Never commit either key. CI injects recorded JSON through `JsonHttpClient` and
+does not access a live network. If credentials are absent, adapters fail with a
+configuration error that is isolated per provider. If either commercial API is
+unavailable, retain existing official-source candidates and fixture/recorded
+research, then explicitly surface missing coverage rather than inventing facts.
+
+For closures, hours, entry rules, fares, reservations, and temporary controls,
+record the responsible operator or tourism authority URL as an `official` source.
+`prioritize_by_authority` returns independent records in official → provider →
+community order without overwriting lower-priority evidence; consumers must keep
+the provenance record and use official facts for hard constraints.

--- a/src/sources/__init__.py
+++ b/src/sources/__init__.py
@@ -2,6 +2,11 @@
 
 from .adapters import AdapterFailure, FixtureCommunityRestaurantAdapter, FixtureOfficialPoiAdapter, SourceAdapter, SourceQuery, collect_from_adapters
 from .candidate_store import CandidateRecord, CandidateState, CandidateStore, StaleCandidateError
+from .providers import (
+    GooglePlacesAdapter, JsonHttpClient, ProviderConfigurationError,
+    ProviderRequestError, ResearchEvidence, UrllibJsonHttpClient,
+    YouTubeEvidenceAdapter, authority_rank, prioritize_by_authority,
+)
 
 __all__ = [
     "AdapterFailure",
@@ -10,8 +15,17 @@ __all__ = [
     "CandidateStore",
     "FixtureCommunityRestaurantAdapter",
     "FixtureOfficialPoiAdapter",
+    "GooglePlacesAdapter",
+    "JsonHttpClient",
+    "ProviderConfigurationError",
+    "ProviderRequestError",
+    "ResearchEvidence",
     "SourceAdapter",
     "SourceQuery",
     "StaleCandidateError",
+    "UrllibJsonHttpClient",
+    "YouTubeEvidenceAdapter",
+    "authority_rank",
     "collect_from_adapters",
+    "prioritize_by_authority",
 ]

--- a/src/sources/providers.py
+++ b/src/sources/providers.py
@@ -1,0 +1,186 @@
+"""Production HTTP adapters for Japan-first place and travel research.
+
+Only documented provider APIs are used here.  Provider payloads stop at this
+module; callers receive the existing candidate-store contract or evidence
+records.  ``http_client`` injection keeps CI fully offline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import os
+from typing import Any, Iterable, Mapping, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from .adapters import SourceAdapter, SourceQuery
+
+
+class ProviderConfigurationError(RuntimeError):
+    """A required credential or provider configuration is absent."""
+
+
+class ProviderRequestError(RuntimeError):
+    """A documented provider API could not complete a request."""
+
+
+class JsonHttpClient(Protocol):
+    def request_json(
+        self, method: str, url: str, *, headers: Mapping[str, str], body: Mapping[str, Any] | None = None
+    ) -> Mapping[str, Any]: ...
+
+
+class UrllibJsonHttpClient:
+    """Small dependency-free JSON client with bounded request timeouts."""
+
+    def __init__(self, timeout_seconds: float = 10) -> None:
+        self.timeout_seconds = timeout_seconds
+
+    def request_json(self, method: str, url: str, *, headers: Mapping[str, str], body: Mapping[str, Any] | None = None) -> Mapping[str, Any]:
+        data = json.dumps(body).encode("utf-8") if body is not None else None
+        request = Request(url, data=data, method=method, headers={**headers, "Accept": "application/json"})
+        try:
+            with urlopen(request, timeout=self.timeout_seconds) as response:
+                decoded = json.loads(response.read().decode("utf-8"))
+        except (HTTPError, URLError, TimeoutError, json.JSONDecodeError) as exc:
+            raise ProviderRequestError(str(exc)) from exc
+        if not isinstance(decoded, dict):
+            raise ProviderRequestError("provider response must be a JSON object")
+        return decoded
+
+
+@dataclass(frozen=True)
+class ResearchEvidence:
+    """Non-decisive travel evidence; it cannot overwrite operational facts."""
+
+    subject: str
+    summary: str
+    provenance: dict[str, Any]
+    signals: tuple[str, ...] = ()
+
+
+def authority_rank(provenance: Mapping[str, Any]) -> int:
+    """Rank evidence without silently merging or overwriting independent facts."""
+
+    return {"official": 0, "provider": 1, "community": 2, "derived": 3, "user_input": 4}.get(
+        str(provenance.get("source_type")), 99
+    )
+
+
+def prioritize_by_authority(candidates: Iterable[tuple[str, dict[str, Any]]]) -> list[tuple[str, dict[str, Any]]]:
+    """Return stable authority order; all source records remain present."""
+
+    return sorted(candidates, key=lambda item: authority_rank(_provenance(item[1])))
+
+
+class GooglePlacesAdapter(SourceAdapter):
+    """Google Places API (New) text search adapter for POI and restaurants.
+
+    The adapter intentionally requests a narrow published field mask and never
+    exports Google-specific rating/review fields into the canonical schema.
+    """
+
+    name = "google-places"
+    endpoint = "https://places.googleapis.com/v1/places:searchText"
+
+    def __init__(
+        self, api_key: str | None = None, *, http_client: JsonHttpClient | None = None, now: datetime | None = None
+    ) -> None:
+        self.api_key = api_key or os.getenv("GOOGLE_MAPS_API_KEY")
+        self.http_client = http_client or UrllibJsonHttpClient()
+        self.now = now
+
+    def fetch(self, query: SourceQuery) -> Iterable[tuple[str, dict[str, Any]]]:
+        if not self.api_key:
+            raise ProviderConfigurationError("GOOGLE_MAPS_API_KEY is required for Google Places")
+        result: list[tuple[str, dict[str, Any]]] = []
+        for category, text in (("pois", "tourist attractions"), ("restaurants", "restaurants")):
+            if category not in query.categories:
+                continue
+            payload = self.http_client.request_json(
+                "POST", self.endpoint,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Goog-Api-Key": self.api_key,
+                    "X-Goog-FieldMask": "places.id,places.displayName,places.formattedAddress,places.location,places.googleMapsUri,places.regularOpeningHours,places.websiteUri",
+                },
+                body={"textQuery": f"{text} in {query.destination}", "languageCode": "ja"},
+            )
+            for place in result_or_empty(payload, "places"):
+                candidate = self._candidate(place, restaurant=(category == "restaurants"))
+                if candidate is not None:
+                    result.append(("restaurants" if category == "restaurants" else "places", candidate))
+        return result
+
+    def _candidate(self, raw: Mapping[str, Any], *, restaurant: bool) -> dict[str, Any] | None:
+        place_id = raw.get("id")
+        display_name = raw.get("displayName")
+        if not isinstance(place_id, str) or not isinstance(display_name, Mapping) or not isinstance(display_name.get("text"), str):
+            return None
+        retrieved_at = (self.now or datetime.now(timezone.utc)).isoformat()
+        provenance = {
+            "source_type": "provider", "provider": "Google Places API (New)",
+            "source_url": raw.get("googleMapsUri") or raw.get("websiteUri") or f"https://www.google.com/maps/place/?q=place_id:{place_id}",
+            "retrieved_at": retrieved_at, "status": "confirmed", "confidence": 0.85,
+        }
+        candidate: dict[str, Any] = {"id": f"google-{place_id}", "name": display_name["text"], "kind": "restaurant" if restaurant else "poi", "provenance": provenance}
+        if isinstance(raw.get("formattedAddress"), str):
+            candidate["address"] = raw["formattedAddress"]
+        location = raw.get("location")
+        if isinstance(location, Mapping) and isinstance(location.get("latitude"), (int, float)) and isinstance(location.get("longitude"), (int, float)):
+            candidate["coordinates"] = {"latitude": location["latitude"], "longitude": location["longitude"]}
+        hours = raw.get("regularOpeningHours")
+        if isinstance(hours, Mapping) and isinstance(hours.get("weekdayDescriptions"), list):
+            candidate["opening_hours_note"] = "; ".join(value for value in hours["weekdayDescriptions"] if isinstance(value, str))
+        return {"place": candidate, "provenance": provenance, "wait_risk": "unknown"} if restaurant else candidate
+
+
+class YouTubeEvidenceAdapter:
+    """YouTube Data API search adapter for community/practical travel evidence.
+
+    It returns evidence only, never a confirmed place or operating-hours fact.
+    """
+
+    name = "youtube-data"
+    endpoint = "https://www.googleapis.com/youtube/v3/search"
+
+    def __init__(self, api_key: str | None = None, *, http_client: JsonHttpClient | None = None, now: datetime | None = None) -> None:
+        self.api_key = api_key or os.getenv("YOUTUBE_API_KEY")
+        self.http_client = http_client or UrllibJsonHttpClient()
+        self.now = now
+
+    def fetch_evidence(self, query: SourceQuery) -> list[ResearchEvidence]:
+        if not self.api_key:
+            raise ProviderConfigurationError("YOUTUBE_API_KEY is required for YouTube research")
+        encoded_query = f"{query.destination} travel parking queue stroller"
+        from urllib.parse import urlencode
+        payload = self.http_client.request_json("GET", f"{self.endpoint}?{urlencode({'part': 'snippet', 'type': 'video', 'maxResults': 10, 'q': encoded_query, 'key': self.api_key})}", headers={})
+        evidence: list[ResearchEvidence] = []
+        for item in result_or_empty(payload, "items"):
+            video_id = item.get("id", {}).get("videoId") if isinstance(item.get("id"), Mapping) else None
+            snippet = item.get("snippet")
+            if not isinstance(video_id, str) or not isinstance(snippet, Mapping):
+                continue
+            title, description = snippet.get("title"), snippet.get("description", "")
+            if not isinstance(title, str) or not isinstance(description, str):
+                continue
+            text = f"{title}\n{description}".lower()
+            signals = tuple(signal for signal in ("queue", "parking", "stroller", "crowding") if signal in text)
+            if "child" in text or "親子" in text:
+                signals += ("child",)
+            evidence.append(ResearchEvidence(
+                subject=title, summary=description[:500], signals=signals,
+                provenance={"source_type": "community", "provider": "YouTube Data API", "source_url": f"https://www.youtube.com/watch?v={video_id}", "retrieved_at": (self.now or datetime.now(timezone.utc)).isoformat(), "status": "reported", "confidence": 0.45, "note": "Community evidence only; verify operational facts with an official source."},
+            ))
+        return evidence
+
+
+def result_or_empty(payload: Mapping[str, Any], key: str) -> list[Mapping[str, Any]]:
+    value = payload.get(key, [])
+    return [item for item in value if isinstance(item, Mapping)] if isinstance(value, list) else []
+
+
+def _provenance(candidate: Mapping[str, Any]) -> Mapping[str, Any]:
+    return candidate.get("provenance") or candidate.get("place", {}).get("provenance", {})

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -11,6 +11,13 @@ from src.sources import (
     StaleCandidateError,
     collect_from_adapters,
 )
+from src.sources.providers import (
+    GooglePlacesAdapter,
+    ProviderConfigurationError,
+    ProviderRequestError,
+    YouTubeEvidenceAdapter,
+    prioritize_by_authority,
+)
 
 
 NOW = datetime(2026, 8, 10, 8, 0, tzinfo=timezone.utc)
@@ -43,6 +50,73 @@ class SourceAdapterTests(unittest.TestCase):
         self.assertEqual(1, len(candidates))
         self.assertEqual("places", candidates[0][0])
         self.assertEqual(["broken-fixture"], [failure.adapter for failure in failures])
+
+
+class RecordedHttpClient:
+    """Recorded API responses: tests must never depend on a live provider."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def request_json(self, method, url, *, headers, body=None):
+        self.calls.append((method, url, headers, body))
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class ProductionProviderAdapterTests(unittest.TestCase):
+    google_recording = {
+        "places": [{
+            "id": "ChIJ-place", "displayName": {"text": "大濠公園"},
+            "formattedAddress": "福岡市中央区", "googleMapsUri": "https://maps.google.test/place",
+            "location": {"latitude": 33.586, "longitude": 130.378},
+            "regularOpeningHours": {"weekdayDescriptions": ["Monday: 24 hours"]},
+        }]
+    }
+
+    def test_google_places_normalizes_poi_and_restaurant_without_raw_fields(self):
+        client = RecordedHttpClient([self.google_recording, self.google_recording])
+        adapter = GooglePlacesAdapter("test-key", http_client=client, now=NOW)
+        candidates = list(adapter.fetch(QUERY))
+        self.assertEqual(["places", "restaurants"], [item[0] for item in candidates])
+        poi = candidates[0][1]
+        restaurant = candidates[1][1]
+        self.assertEqual("provider", poi["provenance"]["source_type"])
+        self.assertEqual(NOW.isoformat(), poi["provenance"]["retrieved_at"])
+        self.assertNotIn("rating", poi)
+        self.assertEqual("restaurant", restaurant["place"]["kind"])
+        self.assertEqual("unknown", restaurant["wait_risk"])
+        self.assertEqual("POST", client.calls[0][0])
+        self.assertNotIn("test-key", str(client.calls[0][3]))
+
+    def test_missing_credentials_and_provider_errors_are_isolated(self):
+        with self.assertRaises(ProviderConfigurationError):
+            list(GooglePlacesAdapter(api_key="").fetch(QUERY))
+        adapter = GooglePlacesAdapter("test-key", http_client=RecordedHttpClient([ProviderRequestError("quota")]))
+        candidates, failures = collect_from_adapters([adapter, FixtureOfficialPoiAdapter(NOW)], SourceQuery("福岡", ("pois",)))
+        self.assertEqual(1, len(candidates))
+        self.assertEqual("google-places", failures[0].adapter)
+
+    def test_youtube_extracts_reported_evidence_not_operational_candidates(self):
+        client = RecordedHttpClient([{"items": [{"id": {"videoId": "abc"}, "snippet": {"title": "福岡 親子旅", "description": "Parking is easy; stroller friendly. Queue after lunch."}}]}])
+        evidence = YouTubeEvidenceAdapter("youtube-key", http_client=client, now=NOW).fetch_evidence(QUERY)
+        self.assertEqual(1, len(evidence))
+        self.assertEqual(("queue", "parking", "stroller", "child"), evidence[0].signals)
+        self.assertEqual("community", evidence[0].provenance["source_type"])
+        self.assertEqual("reported", evidence[0].provenance["status"])
+        self.assertIn("abc", evidence[0].provenance["source_url"])
+        self.assertEqual("GET", client.calls[0][0])
+        self.assertIn("key=youtube-key", client.calls[0][1])
+
+    def test_authority_priority_preserves_independent_records(self):
+        community = list(FixtureCommunityRestaurantAdapter(NOW).fetch(QUERY))[0]
+        official = list(FixtureOfficialPoiAdapter(NOW).fetch(QUERY))[0]
+        ordered = prioritize_by_authority([community, official])
+        self.assertEqual(["places", "restaurants"], [collection for collection, _ in ordered])
+        self.assertEqual(2, len(ordered))
 
 
 class CandidateStoreTests(unittest.TestCase):


### PR DESCRIPTION
Resolves #16

Adds production-capable Google Places and YouTube Data API adapters with injected HTTP clients, normalized provenance, authority priority, error isolation, and recorded-fixture tests. Documents credentials, quotas, terms, and compliant restaurant-research fallback behavior.

Validation: `python3 -m unittest discover -s tests -v` (29 passed); `python3 -m pytest -q` (31 passed); `git diff --check`.