### PR TITLE
feat: add OpenRouteService routing provider

### DIFF
--- a/docs/routing-optimizer-v1.md
+++ b/docs/routing-optimizer-v1.md
@@ -10,6 +10,16 @@ Each route retains `duration_seconds`, `distance_meters`, `RouteStatus`, and `Ro
 
 `FixtureRoutingProvider` is a deterministic provider stub. `fixtures/routes/fukuoka-routing-fixture.json` documents the portable fixture shape; test fixtures can be instantiated directly as `Route` objects to avoid an I/O dependency.
 
+## Live provider: OpenRouteService
+
+`OpenRouteServiceProvider` is the production adapter for the official OpenRouteService Matrix API. It supports `driving` (`driving-car`) and `walking` (`foot-walking`); `transit` returns the machine-readable `unsupported` status and is never silently approximated. Set `OPENROUTESERVICE_API_KEY` in the execution environment (for example, `export OPENROUTESERVICE_API_KEY=...`); do not put a key in a source file, fixture, or CI secret-free test.
+
+The provider sends multi-POI route lookups as one matrix request (up to the service's documented 50-location request limit). It needs latitude and longitude in every `PlaceRef`. OpenRouteService does not consume departure timestamps or timezone, so this adapter does not claim time-dependent routing; callers must keep their own timezone-aware itinerary context.
+
+`RouteMatrix.routes(places, mode)` warms a directed shared snapshot, and `RouteMatrix.invalidate()` removes either an individual cache key or the complete snapshot. A finite matrix TTL refreshes stale entries; without a TTL the snapshot remains stable for the entire pipeline and can be passed unchanged to optimizer and validator. Provider results retain the API timestamp, provider name and documentation URL. `no_route`, `timeout`, `rate_limited`, `unsupported`, and `error` are explicit statuses with no invented duration or distance.
+
+OpenRouteService credentials, quota, pricing and rate limits are account-dependent; consult its current dashboard and API terms before enabling a production key. Configure a short timeout and use an explicit fallback policy at the application boundary (for example, retain `unknown`/unavailable and ask the user to choose another mode), rather than converting provider failures to travel-time estimates. CI uses recorded/mock response fixtures only and must not contact the service.
+
 ## Optimizer boundary
 
 `RouteOptimizer` brute-forces flexible POI order within each segment bounded by fixed-time anchors. It scores available route duration (with distance emitted in its result), keeping anchors in their original sequence and retaining their exact timestamps. The optimizer never creates, shifts, or relaxes schedule times.

--- a/src/optimizer/route_optimizer.py
+++ b/src/optimizer/route_optimizer.py
@@ -80,7 +80,7 @@ class RouteOptimizer:
         total = 0
         for first, second in zip(chain, chain[1:]):
             route = self.matrix.route(first.place, second.place, self.mode)
-            if route.status is RouteStatus.UNKNOWN:
+            if route.status is not RouteStatus.AVAILABLE:
                 return None
             total += route.duration_seconds or 0
         return total
@@ -90,7 +90,7 @@ class RouteOptimizer:
         unknown: list[tuple[str, str, str]] = []
         for first, second in zip(stops, stops[1:]):
             route = self.matrix.route(first.place, second.place, self.mode)
-            if route.status is RouteStatus.UNKNOWN:
+            if route.status is not RouteStatus.AVAILABLE:
                 unknown.append(route.cache_key)
                 continue
             total_seconds += route.duration_seconds or 0

--- a/src/sources/routing/__init__.py
+++ b/src/sources/routing/__init__.py
@@ -1,9 +1,10 @@
 from .matrix import RouteMatrix
 from .models import PlaceRef, Route, RouteMode, RouteProvenance, RouteStatus
-from .provider import FixtureRoutingProvider, RoutingProvider
+from .provider import FixtureRoutingProvider, OpenRouteServiceProvider, RoutingProvider
 
 __all__ = [
     "FixtureRoutingProvider",
+    "OpenRouteServiceProvider",
     "PlaceRef",
     "Route",
     "RouteMatrix",

--- a/src/sources/routing/matrix.py
+++ b/src/sources/routing/matrix.py
@@ -39,6 +39,28 @@ class RouteMatrix:
         self._cache[key] = (route, self._now())
         return route
 
+    def routes(self, places: list[PlaceRef] | tuple[PlaceRef, ...], mode: RouteMode) -> tuple[Route, ...]:
+        """Warm and return a multi-POI directed matrix, using provider batching when possible."""
+        refs = tuple(places)
+        missing = [(origin, destination) for origin in refs for destination in refs if origin != destination
+                   if (mode.value, origin.place_id, destination.place_id) not in self._cache or self._expired(self._cache[(mode.value, origin.place_id, destination.place_id)][1])]
+        if missing:
+            supplied = self.provider.fetch_matrix(refs, mode)
+            for origin, destination in missing:
+                key = (mode.value, origin.place_id, destination.place_id)
+                route = supplied.get(key)
+                if route is None or route.cache_key != key:
+                    raise ValueError("routing provider did not return requested matrix route")
+                self._cache[key] = (route, self._now())
+        return tuple(self.route(origin, destination, mode) for origin in refs for destination in refs if origin != destination)
+
+    def invalidate(self, key: tuple[str, str, str] | None = None) -> None:
+        """Explicitly invalidate one entry or the entire shared route snapshot."""
+        if key is None:
+            self._cache.clear()
+        else:
+            self._cache.pop(key, None)
+
     def _expired(self, stored_at: datetime) -> bool:
         return self.ttl is not None and self._now() - stored_at >= self.ttl
 

--- a/src/sources/routing/models.py
+++ b/src/sources/routing/models.py
@@ -16,6 +16,11 @@ class RouteMode(str, Enum):
 class RouteStatus(str, Enum):
     AVAILABLE = "available"
     UNKNOWN = "unknown"
+    NO_ROUTE = "no_route"
+    TIMEOUT = "timeout"
+    RATE_LIMITED = "rate_limited"
+    UNSUPPORTED = "unsupported"
+    ERROR = "error"
 
 
 @dataclass(frozen=True)
@@ -59,7 +64,7 @@ class Route:
             if self.duration_seconds < 0 or self.distance_meters < 0:
                 raise ValueError("route costs cannot be negative")
         elif self.duration_seconds is not None or self.distance_meters is not None:
-            raise ValueError("unknown routes cannot contain guessed duration or distance")
+            raise ValueError("unavailable routes cannot contain guessed duration or distance")
 
     @property
     def cache_key(self) -> tuple[str, str, str]:

--- a/src/sources/routing/provider.py
+++ b/src/sources/routing/provider.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
-from typing import Iterable
+import json
+import os
+from typing import Callable, Iterable
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 from .models import PlaceRef, Route, RouteMode, RouteProvenance, RouteStatus
 
@@ -15,6 +19,14 @@ class RoutingProvider(ABC):
     @abstractmethod
     def fetch(self, origin: PlaceRef, destination: PlaceRef, mode: RouteMode) -> Route:
         """Fetch one route. Implementations must return UNKNOWN on an unavailable route."""
+
+    def fetch_matrix(self, places: Iterable[PlaceRef], mode: RouteMode) -> dict[tuple[str, str, str], Route]:
+        """Optional batched lookup; the default preserves compatibility with single-route SDKs."""
+        refs = tuple(places)
+        return {
+            (mode.value, origin.place_id, destination.place_id): self.fetch(origin, destination, mode)
+            for origin in refs for destination in refs if origin != destination
+        }
 
 
 class FixtureRoutingProvider(RoutingProvider):
@@ -43,3 +55,83 @@ class FixtureRoutingProvider(RoutingProvider):
                 note="No fixture route is available",
             ),
         )
+
+
+class OpenRouteServiceProvider(RoutingProvider):
+    """OpenRouteService matrix API adapter (driving-car and foot-walking only).
+
+    The key is deliberately read only from ``OPENROUTESERVICE_API_KEY`` unless supplied
+    by the process owner.  No request is made until ``fetch``/``fetch_matrix`` is called.
+    """
+
+    provider_name = "openrouteservice"
+    _PROFILES = {RouteMode.DRIVING: "driving-car", RouteMode.WALKING: "foot-walking"}
+
+    def __init__(self, *, api_key: str | None = None, timeout_seconds: float = 10,
+                 endpoint: str = "https://api.openrouteservice.org/v2/matrix",
+                 opener: Callable[..., object] = urlopen, now: Callable[[], datetime] | None = None) -> None:
+        self.api_key = api_key if api_key is not None else os.environ.get("OPENROUTESERVICE_API_KEY")
+        self.timeout_seconds = timeout_seconds
+        self.endpoint = endpoint.rstrip("/")
+        self._opener = opener
+        self._now = now or (lambda: datetime.now(timezone.utc))
+
+    def fetch(self, origin: PlaceRef, destination: PlaceRef, mode: RouteMode) -> Route:
+        return self.fetch_matrix((origin, destination), mode).get(
+            (mode.value, origin.place_id, destination.place_id), self._unavailable(origin, destination, mode, RouteStatus.NO_ROUTE)
+        )
+
+    def fetch_matrix(self, places: Iterable[PlaceRef], mode: RouteMode) -> dict[tuple[str, str, str], Route]:
+        refs = tuple(places)
+        if mode not in self._PROFILES:
+            return self._all_unavailable(refs, mode, RouteStatus.UNSUPPORTED, "OpenRouteService matrix has no transit profile")
+        if not self.api_key:
+            return self._all_unavailable(refs, mode, RouteStatus.ERROR, "OPENROUTESERVICE_API_KEY is not configured")
+        if len(refs) > 50:
+            raise ValueError("OpenRouteService matrix request supports at most 50 locations; batch at caller")
+        if any(ref.latitude is None for ref in refs):
+            return self._all_unavailable(refs, mode, RouteStatus.ERROR, "coordinates are required by OpenRouteService")
+        payload = json.dumps({"locations": [[ref.longitude, ref.latitude] for ref in refs], "metrics": ["duration", "distance"]}).encode()
+        request = Request(f"{self.endpoint}/{self._PROFILES[mode]}", data=payload, method="POST", headers={"Authorization": self.api_key, "Content-Type": "application/json", "Accept": "application/json"})
+        try:
+            with self._opener(request, timeout=self.timeout_seconds) as response:
+                body = json.loads(response.read().decode())
+        except TimeoutError:
+            return self._all_unavailable(refs, mode, RouteStatus.TIMEOUT, "provider request timed out")
+        except HTTPError as exc:
+            status = RouteStatus.RATE_LIMITED if exc.code == 429 else RouteStatus.ERROR
+            try:
+                return self._all_unavailable(refs, mode, status, f"provider HTTP {exc.code}")
+            finally:
+                exc.close()
+        except URLError as exc:
+            status = RouteStatus.TIMEOUT if "timed out" in str(exc.reason).lower() else RouteStatus.ERROR
+            return self._all_unavailable(refs, mode, status, f"provider network error: {exc.reason}")
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            return self._all_unavailable(refs, mode, RouteStatus.ERROR, f"provider response error: {exc}")
+        durations, distances = body.get("durations"), body.get("distances")
+        if not isinstance(durations, list) or not isinstance(distances, list):
+            return self._all_unavailable(refs, mode, RouteStatus.ERROR, "provider response omitted matrix metrics")
+        result: dict[tuple[str, str, str], Route] = {}
+        for i, origin in enumerate(refs):
+            for j, destination in enumerate(refs):
+                if i == j:
+                    continue
+                duration = durations[i][j] if i < len(durations) and j < len(durations[i]) else None
+                distance = distances[i][j] if i < len(distances) and j < len(distances[i]) else None
+                if duration is None or distance is None:
+                    route = self._unavailable(origin, destination, mode, RouteStatus.NO_ROUTE, "provider returned no route")
+                else:
+                    route = Route(origin, destination, mode, RouteStatus.AVAILABLE, self._provenance(), int(round(duration)), int(round(distance)))
+                result[route.cache_key] = route
+        return result
+
+    def _provenance(self, note: str | None = None) -> RouteProvenance:
+        return RouteProvenance(self.provider_name, self._now(), source_url="https://openrouteservice.org/dev/#/api-docs/matrix", note=note)
+
+    def _unavailable(self, origin: PlaceRef, destination: PlaceRef, mode: RouteMode, status: RouteStatus, note: str | None = None) -> Route:
+        return Route(origin, destination, mode, status, self._provenance(note))
+
+    def _all_unavailable(self, refs: tuple[PlaceRef, ...], mode: RouteMode, status: RouteStatus, note: str) -> dict[tuple[str, str, str], Route]:
+        return {route.cache_key: route for origin in refs for destination in refs if origin != destination
+                for route in (self._unavailable(origin, destination, mode, status, note),)}

--- a/tests/test_openrouteservice_provider.py
+++ b/tests/test_openrouteservice_provider.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timezone
+from io import BytesIO
+import json
+import unittest
+from urllib.error import HTTPError
+
+from src.sources.routing import OpenRouteServiceProvider, PlaceRef, RouteMatrix, RouteMode, RouteStatus
+from src.optimizer import RouteOptimizer, Stop
+
+
+class _Response:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def read(self):
+        return json.dumps(self.payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class OpenRouteServiceProviderTests(unittest.TestCase):
+    def setUp(self):
+        self.places = (PlaceRef("a", 35.0, 139.0), PlaceRef("b", 35.1, 139.1), PlaceRef("c", 35.2, 139.2))
+
+    def test_batched_matrix_maps_duration_distance_and_provenance(self):
+        calls = []
+        def opener(request, timeout):
+            calls.append((request, timeout))
+            return _Response({"durations": [[0, 61.2, None], [60, 0, 120], [None, 121, 0]], "distances": [[0, 501.5, None], [500, 0, 900], [None, 901, 0]]})
+        provider = OpenRouteServiceProvider(api_key="test-key", opener=opener, now=lambda: datetime(2026, 1, 1, tzinfo=timezone.utc))
+        matrix = RouteMatrix(provider)
+        routes = matrix.routes(self.places, RouteMode.DRIVING)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(len(routes), 6)
+        ab = matrix.route(self.places[0], self.places[1], RouteMode.DRIVING)
+        self.assertEqual((ab.duration_seconds, ab.distance_meters, ab.status.value), (61, 502, "available"))
+        self.assertEqual(ab.provenance.provider, "openrouteservice")
+        self.assertEqual(matrix.route(self.places[0], self.places[2], RouteMode.DRIVING).status, RouteStatus.NO_ROUTE)
+
+    def test_transit_is_explicitly_unsupported_without_network(self):
+        provider = OpenRouteServiceProvider(api_key="test-key", opener=lambda *_args, **_kwargs: self.fail("network called"))
+        route = provider.fetch(*self.places[:2], RouteMode.TRANSIT)
+        self.assertEqual(route.status, RouteStatus.UNSUPPORTED)
+
+    def test_rate_limit_and_timeout_have_machine_readable_status(self):
+        limited = OpenRouteServiceProvider(api_key="test-key", opener=lambda *_args, **_kwargs: (_ for _ in ()).throw(HTTPError("x", 429, "limited", {}, BytesIO())))
+        self.assertEqual(limited.fetch(*self.places[:2], RouteMode.WALKING).status, RouteStatus.RATE_LIMITED)
+        timeout = OpenRouteServiceProvider(api_key="test-key", opener=lambda *_args, **_kwargs: (_ for _ in ()).throw(TimeoutError()))
+        self.assertEqual(timeout.fetch(*self.places[:2], RouteMode.WALKING).status, RouteStatus.TIMEOUT)
+
+    def test_invalidation_causes_new_provider_snapshot(self):
+        count = [0]
+        def opener(*_args, **_kwargs):
+            count[0] += 1
+            return _Response({"durations": [[0, 1], [1, 0]], "distances": [[0, 1], [1, 0]]})
+        matrix = RouteMatrix(OpenRouteServiceProvider(api_key="test-key", opener=opener))
+        matrix.route(*self.places[:2], RouteMode.DRIVING)
+        matrix.invalidate(("driving", "a", "b"))
+        matrix.route(*self.places[:2], RouteMode.DRIVING)
+        self.assertEqual(count[0], 2)
+
+    def test_optimizer_does_not_turn_no_route_into_zero_cost(self):
+        provider = OpenRouteServiceProvider(api_key="test-key", opener=lambda *_args, **_kwargs: _Response({"durations": [[0, None], [None, 0]], "distances": [[0, None], [None, 0]]}))
+        result = RouteOptimizer(RouteMatrix(provider), RouteMode.DRIVING).optimize([Stop(self.places[0]), Stop(self.places[1])])
+        self.assertTrue(result.has_unknown_routes)
+        self.assertIsNone(result.travel_seconds)


### PR DESCRIPTION
Resolves #18

Adds an OpenRouteService Matrix API adapter with environment-only credentials, driving and walking support, explicit unsupported transit, TTL cache management, batched warming, and machine-readable unavailable states.

Validation: `python3 -m unittest discover -s tests -v` (30 passed); `git diff --check`.