### PR TITLE
feat: add production planning entrypoint and local dashboard

### DIFF
--- a/src/application/__init__.py
+++ b/src/application/__init__.py
@@ -1,0 +1,19 @@
+"""Application composition roots.
+
+The modules here wire infrastructure into the domain pipeline; they do not
+contain provider payload parsing or planning rules.
+"""
+
+from .production import (
+    ProductionConfigurationError,
+    ProductionPlanningRunner,
+    create_production_orchestrator,
+    missing_required_configuration,
+)
+
+__all__ = [
+    "ProductionConfigurationError",
+    "ProductionPlanningRunner",
+    "create_production_orchestrator",
+    "missing_required_configuration",
+]

--- a/src/application/production.py
+++ b/src/application/production.py
@@ -1,0 +1,292 @@
+"""The single production composition root for CLI and local web entrypoints.
+
+This module is intentionally the only place that joins provider adapters to
+the existing orchestrator.  It has no fixture imports.  Tests can pass recorded
+adapters/providers through ``dependencies`` without changing production code.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta, timezone
+import os
+import re
+from pathlib import Path
+from typing import Callable, Iterable, Mapping, Sequence
+from zoneinfo import ZoneInfo
+
+from src.intent import TravelIntent
+from src.orchestrator import OrchestrationResult, TravelOrchestrator, TravelOrchestratorConfig
+from src.restaurant_intelligence import eligible_restaurants, validation_opening_hours
+from src.sources import (
+    AmadeusClient, AmadeusFlightAdapter, AmadeusHotelAdapter, FlightSearchQuery,
+    GooglePlacesAdapter, HotelSearchQuery, Occupancy, SourceAdapter, SourceQuery,
+    YouTubeEvidenceAdapter,
+)
+from src.sources.routing import OpenRouteServiceProvider, PlaceRef, RouteMatrix, RouteMode, RouteStatus
+from src.validator import ValidationContext
+
+
+REQUIRED_ENVIRONMENT = (
+    "GOOGLE_MAPS_API_KEY",
+    "YOUTUBE_API_KEY",
+    "AMADEUS_CLIENT_ID",
+    "AMADEUS_CLIENT_SECRET",
+    "OPENROUTESERVICE_API_KEY",
+)
+
+
+class ProductionConfigurationError(RuntimeError):
+    """Raised before a run when production infrastructure is not configured."""
+
+
+class ProductionIncompleteError(RuntimeError):
+    """Raised when real normalized data cannot support a truthful Trip."""
+
+
+def missing_required_configuration(environment: Mapping[str, str] | None = None) -> list[str]:
+    environment = environment if environment is not None else os.environ
+    return [key for key in REQUIRED_ENVIRONMENT if not environment.get(key)]
+
+
+@dataclass(frozen=True)
+class ProductionDependencies:
+    """Replaceable infrastructure seams used by recorded-provider tests only."""
+
+    google: SourceAdapter | None = None
+    youtube: YouTubeEvidenceAdapter | None = None
+    amadeus_client: AmadeusClient | None = None
+    routing_provider: object | None = None
+
+
+class _ProductionResearchAdapter(SourceAdapter):
+    """Runs real provider searches and emits only normalized candidate records."""
+
+    name = "production-research"
+
+    def __init__(self, intent: TravelIntent, google: SourceAdapter, youtube: YouTubeEvidenceAdapter,
+                 amadeus_client: AmadeusClient) -> None:
+        self.intent, self.google, self.youtube = intent, google, youtube
+        self.flight_search = AmadeusFlightAdapter(amadeus_client)
+        self.hotel_search = AmadeusHotelAdapter(amadeus_client)
+        self.evidence: list[object] = []
+
+    def fetch(self, query: SourceQuery):
+        # Evidence is deliberately not converted into an operational candidate.
+        self.evidence = list(self.youtube.fetch_evidence(query))
+        candidates = list(self.google.fetch(query))
+        origin, destination = _airport_codes(self.intent)
+        start, end = _travel_dates(self.intent)
+        occupancy = Occupancy(_adults(self.intent), self.intent.travelers.child_ages)
+        currency = self.intent.currency or "JPY"
+        candidates.extend(self.flight_search.search(FlightSearchQuery(
+            origin, destination, start, occupancy, return_date=end, currency=currency,
+            airport_timezones={origin: "Asia/Taipei", destination: "Asia/Tokyo"},
+        )).candidates)
+        candidates.extend(self.hotel_search.search(HotelSearchQuery(
+            destination, start, end + timedelta(days=1), occupancy, currency=currency,
+        )).candidates)
+        return candidates
+
+
+class ProductionPlanningRunner:
+    """A small facade that preserves one ``run(intent)`` entrypoint for CLI/Web."""
+
+    def __init__(self, orchestrator: TravelOrchestrator, progress_callback: Callable[[str], None] | None = None) -> None:
+        self.orchestrator = orchestrator
+        self.progress_callback = progress_callback
+
+    def run(self, intent: TravelIntent) -> OrchestrationResult:
+        if self.progress_callback:
+            self.progress_callback("research")
+        result = self.orchestrator.run(intent)
+        if self.progress_callback:
+            self.progress_callback("completed" if result.succeeded else "failed")
+        return result
+
+
+def create_production_orchestrator(*, trip_id: str, trips_directory: Path = Path("trips"),
+                                   site_directory: Path = Path("site"),
+                                   progress_callback: Callable[[str], None] | None = None,
+                                   environment: Mapping[str, str] | None = None,
+                                   dependencies: ProductionDependencies | None = None) -> ProductionPlanningRunner:
+    """Build the only live-provider pipeline used by end-user entrypoints.
+
+    No fixture adapter is constructed here. Missing keys fail explicitly before
+    a network request. ``dependencies`` exists exclusively to make recorded
+    provider scenarios deterministic in CI.
+    """
+    environment = environment if environment is not None else os.environ
+    missing = missing_required_configuration(environment)
+    if missing:
+        raise ProductionConfigurationError("missing required environment: " + ", ".join(missing))
+    dependencies = dependencies or ProductionDependencies()
+    google = dependencies.google or GooglePlacesAdapter(api_key=environment["GOOGLE_MAPS_API_KEY"])
+    youtube = dependencies.youtube or YouTubeEvidenceAdapter(api_key=environment["YOUTUBE_API_KEY"])
+    amadeus = dependencies.amadeus_client or AmadeusClient(environment=dict(environment))
+    routing_provider = dependencies.routing_provider or OpenRouteServiceProvider(api_key=environment["OPENROUTESERVICE_API_KEY"])
+
+    # Intent is supplied at run time, so this adapter factory is installed by
+    # the facade just before invoking the existing orchestrator.
+    runner = _IntentBoundRunner(
+        trip_id=trip_id, trips_directory=trips_directory, site_directory=site_directory,
+        google=google, youtube=youtube, amadeus=amadeus, routing_provider=routing_provider,
+        progress_callback=progress_callback,
+    )
+    return runner
+
+
+class _IntentBoundRunner(ProductionPlanningRunner):
+    def __init__(self, *, trip_id: str, trips_directory: Path, site_directory: Path,
+                 google: SourceAdapter, youtube: YouTubeEvidenceAdapter, amadeus: AmadeusClient,
+                 routing_provider: object, progress_callback: Callable[[str], None] | None) -> None:
+        self.trip_id, self.trips_directory, self.site_directory = _safe_trip_id(trip_id), trips_directory, site_directory
+        self.google, self.youtube, self.amadeus = google, youtube, amadeus
+        self.routing_provider, self.progress_callback = routing_provider, progress_callback
+
+    def run(self, intent: TravelIntent) -> OrchestrationResult:
+        _require_plannable_intent(intent)
+        research = _ProductionResearchAdapter(intent, self.google, self.youtube, self.amadeus)
+        config = TravelOrchestratorConfig(
+            adapters=(research,),
+            candidate_trip_factory=lambda current, store: _candidate_trips(self.trip_id, current, store.records()),
+            routing_context_factory=lambda current, store: _routing_context(store.records(), self.routing_provider, current),
+            optimizer=lambda candidates, context: tuple(candidates),
+            output_directory=self.site_directory,
+            trip_output_directory=self.trips_directory,
+        )
+        orchestrator = TravelOrchestrator(config)
+        if self.progress_callback:
+            self.progress_callback("research")
+        result = orchestrator.run(intent)
+        if self.progress_callback:
+            self.progress_callback("completed" if result.succeeded else "failed")
+        return result
+
+
+def _candidate_trips(trip_id: str, intent: TravelIntent, records: Iterable[object]) -> Sequence[dict]:
+    collections: dict[str, list[dict]] = {name: [] for name in ("places", "restaurants", "hotels", "flights", "transport_legs")}
+    for record in records:
+        collection, candidate = record.collection, record.candidate  # CandidateRecord protocol; no raw payload crosses here.
+        collections[collection].append(candidate)
+    start, end = _travel_dates(intent)
+    days_count = (end - start).days + 1
+    places = [place for place in collections["places"] if place.get("kind") == "poi"]
+    restaurants = collections["restaurants"]
+    hotels, flights = collections["hotels"], collections["flights"]
+    if len(places) < days_count or not restaurants or not hotels or not flights:
+        raise ProductionIncompleteError("live provider results are insufficient for a complete trip (need POIs, restaurants, hotel, and flight)")
+
+    tz = ZoneInfo("Asia/Tokyo")
+    itinerary_days = []
+    selected_meals: list[dict] = []
+    for index in range(days_count):
+        current_date = start + timedelta(days=index)
+        visit_start = datetime.combine(current_date, time(10), tz)
+        visit_end = datetime.combine(current_date, time(12), tz)
+        meal_start = datetime.combine(current_date, time(12, 30), tz)
+        meal_end = datetime.combine(current_date, time(13, 30), tz)
+        eligible = eligible_restaurants(restaurants, meal_start, meal_end)
+        if not eligible:
+            raise ProductionIncompleteError(f"no restaurant has fresh verified opening hours for {current_date.isoformat()} lunch")
+        poi, restaurant = places[index], eligible[index % len(eligible)]
+        selected_meals.append(restaurant)
+        itinerary_days.append({"date": current_date.isoformat(), "summary": poi["name"], "items": [
+            {"id": f"day{index + 1}-visit", "kind": "visit", "place_id": poi["id"], "start_at": visit_start.isoformat(), "end_at": visit_end.isoformat(), "selection_status": "selected"},
+            {"id": f"day{index + 1}-meal", "kind": "meal", "place_id": restaurant["place"]["id"], "start_at": meal_start.isoformat(), "end_at": meal_end.isoformat(), "selection_status": "selected"},
+        ]})
+
+    all_places = [*collections["places"], *(hotel["place"] for hotel in hotels)]
+    # De-duplicate the restaurant place if Google returned it in both collections.
+    seen: set[str] = set()
+    canonical_places = []
+    for place in [*all_places, *(restaurant["place"] for restaurant in restaurants)]:
+        if place["id"] not in seen:
+            seen.add(place["id"]); canonical_places.append(place)
+    currency = _budget_currency(intent, flights[0], hotels[0])
+    flight_cost = _money_amount(flights[0].get("cost"), currency)
+    hotel_cost = _money_amount(hotels[0].get("total_cost"), currency)
+    categories = {"flights": {"amount": flight_cost, "currency": currency}, "hotel": {"amount": hotel_cost, "currency": currency}}
+    return [{
+        "schema_version": "trip-v1", "id": trip_id, "title": " + ".join(intent.destinations) + " 行程",
+        "local_timezone": "Asia/Tokyo", "date_range": {"start_date": start.isoformat(), "end_date": end.isoformat()},
+        "traveler_profile": {"adults": _adults(intent), "children": [{"age": age} for age in intent.travelers.child_ages]},
+        "preferences": {"hard_constraints": [], "soft_preferences": []},
+        "candidate_sets": {**collections, "places": canonical_places},
+        "selected": {"hotel_place_ids": [hotels[0]["place"]["id"]], "flight_ids": [flights[0]["id"]]},
+        "days": itinerary_days,
+        "budget": {"currency": currency, "categories": categories, "total": {"amount": flight_cost + hotel_cost, "currency": currency}},
+        "validation": [],
+        "provenance": {"source_type": "derived", "provider": "production composition", "retrieved_at": datetime.now(timezone.utc).isoformat(), "status": "estimated", "note": "Built only from normalized provider candidates; availability requires provider confirmation."},
+    }]
+
+
+def _routing_context(records: Iterable[object], routing_provider: object, intent: TravelIntent) -> ValidationContext:
+    places = []
+    restaurants = []
+    for record in records:
+        candidate = record.candidate
+        if record.collection == "restaurants":
+            restaurants.append(candidate); place = candidate["place"]
+        elif record.collection in {"places", "hotels"}:
+            place = candidate if record.collection == "places" else candidate["place"]
+        else:
+            continue
+        coordinates = place.get("coordinates", {})
+        if isinstance(coordinates, Mapping) and isinstance(coordinates.get("latitude"), (int, float)) and isinstance(coordinates.get("longitude"), (int, float)):
+            places.append(PlaceRef(place["id"], coordinates["latitude"], coordinates["longitude"]))
+    # ORS has a 50-location request limit; a bounded planning snapshot avoids
+    # hidden batching/guessing and makes omitted routes unverified downstream.
+    unique = list({place.place_id: place for place in places}.values())[:50]
+    minutes: dict[tuple[str, str], int] = {}
+    if len(unique) > 1:
+        matrix = RouteMatrix(routing_provider, ttl=timedelta(minutes=15))
+        mode = RouteMode.DRIVING if "drive" in intent.transport else RouteMode.WALKING
+        for route in matrix.routes(unique, mode):
+            if route.status is RouteStatus.AVAILABLE and route.duration_seconds is not None:
+                minutes[(route.origin.place_id, route.destination.place_id)] = max(1, round(route.duration_seconds / 60))
+    return ValidationContext(travel_minutes=minutes, opening_hours=validation_opening_hours(restaurants))
+
+
+def _require_plannable_intent(intent: TravelIntent) -> None:
+    if not intent.destinations or not intent.start_date or not intent.end_date:
+        raise ProductionIncompleteError("production planning requires destination and explicit start/end dates; no dates were invented")
+    if intent.travelers.adults is None:
+        raise ProductionIncompleteError("production planning requires an explicit adult traveler count")
+
+
+def _travel_dates(intent: TravelIntent) -> tuple[date, date]:
+    return date.fromisoformat(intent.start_date or ""), date.fromisoformat(intent.end_date or "")
+
+
+def _adults(intent: TravelIntent) -> int:
+    if intent.travelers.adults is None:
+        raise ProductionIncompleteError("adult traveler count is required")
+    return intent.travelers.adults
+
+
+def _airport_codes(intent: TravelIntent) -> tuple[str, str]:
+    origin = {"台北": "TPE", "桃園": "TPE", "高雄": "KHH", "香港": "HKG", "東京": "NRT", "大阪": "KIX"}.get(intent.origin or "")
+    destination = {"德島": "TKS", "神戶": "UKB", "東京": "TYO", "大阪": "OSA", "京都": "OSA", "福岡": "FUK", "札幌": "SPK", "沖繩": "OKA", "名古屋": "NGO"}.get(intent.destinations[0] if intent.destinations else "")
+    if not origin or not destination:
+        raise ProductionIncompleteError("origin/destination lacks an explicit Amadeus airport/city-code mapping")
+    return origin, destination
+
+
+def _safe_trip_id(value: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9_-]+", "-", value.lower()).strip("-")
+    if not cleaned or not re.fullmatch(r"[a-z][a-z0-9_-]*", cleaned):
+        raise ValueError("trip_id must start with a letter and use lowercase letters, digits, _ or -")
+    return cleaned
+
+
+def _budget_currency(intent: TravelIntent, flight: Mapping[str, object], hotel: Mapping[str, object]) -> str:
+    currencies = [value.get("currency") for value in (flight.get("cost", {}), hotel.get("total_cost", {})) if isinstance(value, Mapping)]
+    if len(set(currencies)) != 1 or not currencies[0]:
+        raise ProductionIncompleteError("flight and hotel provider currencies differ; no conversion rate was invented")
+    return str(currencies[0])
+
+
+def _money_amount(value: object, currency: str) -> float:
+    if not isinstance(value, Mapping) or value.get("currency") != currency or not isinstance(value.get("amount"), (int, float)):
+        raise ProductionIncompleteError("provider price is missing or cannot be reconciled to the selected currency")
+    return float(value["amount"])

--- a/src/cli.py
+++ b/src/cli.py
@@ -3,31 +3,46 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
-import shutil
 import sys
 from pathlib import Path
 
 from src.intent import parse_trip_request
+from src.application.production import (
+    ProductionConfigurationError,
+    ProductionIncompleteError,
+    create_production_orchestrator,
+    missing_required_configuration,
+)
 from src.renderer.build_site import build_site
 from src.schemas.validate_trip import validate_trip
 
-_REQUIRED_KEYS = ("GOOGLE_MAPS_API_KEY", "YOUTUBE_API_KEY", "AMADEUS_CLIENT_ID", "AMADEUS_CLIENT_SECRET", "OPENROUTESERVICE_API_KEY")
-
-
-def _missing_configuration() -> list[str]:
-    return [name for name in _REQUIRED_KEYS if not os.getenv(name)]
-
-
 def plan_command(args: argparse.Namespace) -> int:
     intent = parse_trip_request(args.request)
-    missing = _missing_configuration()
+    missing = missing_required_configuration()
     if missing and not args.demo:
         print(json.dumps({"status": "configuration_missing", "missing": missing, "message": "Production planning requires real provider credentials; no fixture fallback was used."}, ensure_ascii=False), file=sys.stderr)
         return 2
     if not args.demo:
-        print(json.dumps({"status": "configuration_ready", "intent": intent.as_dict(), "message": "Provider composition is configured; live booking/search results remain unverified until each provider responds."}, ensure_ascii=False))
-        return 0
+        try:
+            result = create_production_orchestrator(
+                trip_id=args.trip_id,
+                trips_directory=Path(args.trips_directory),
+                site_directory=Path(args.site_directory),
+            ).run(intent)
+        except (ProductionConfigurationError, ProductionIncompleteError, ValueError) as exc:
+            print(json.dumps({"status": "incomplete", "intent": intent.as_dict(), "message": str(exc)}, ensure_ascii=False), file=sys.stderr)
+            return 1
+        status = "complete" if result.succeeded else "incomplete"
+        payload = {
+            "status": status,
+            "intent": intent.as_dict(),
+            "trip": str(result.trip_path) if result.trip_path else None,
+            "site": str(result.render_path) if result.render_path else None,
+            "stages": [{"name": stage.name.value, "status": stage.status.value} for stage in result.stages],
+            "warnings": [warning.as_dict() for warning in result.warnings],
+        }
+        print(json.dumps(payload, ensure_ascii=False))
+        return 0 if result.succeeded else 1
     fixture = Path("fixtures/trips/japan-5-day-trip-v1.json")
     trip = json.loads(fixture.read_text(encoding="utf-8"))
     trip["id"] = args.trip_id
@@ -48,6 +63,8 @@ def main() -> None:
     plan = commands.add_parser("plan")
     plan.add_argument("--request", required=True)
     plan.add_argument("--trip-id", default="planned-trip")
+    plan.add_argument("--trips-directory", default="trips")
+    plan.add_argument("--site-directory", default="site")
     plan.add_argument("--demo", action="store_true", help="explicit recorded fixture demonstration; never used by production default")
     plan.set_defaults(handler=plan_command)
     args = parser.parse_args(); raise SystemExit(args.handler(args))

--- a/src/intent/parser.py
+++ b/src/intent/parser.py
@@ -46,7 +46,7 @@ def parse_trip_request(text: str) -> TripRequest:
         provenance["regions"].append(FieldProvenance(region, match.start(), match.end(), "regions"))
     values["destinations"], values["regions"] = places, regions
 
-    capture("origin", r"(?:從|由|出發地[：:]?)(台北|高雄|桃園|香港|東京|大阪)(?:出發|飛|去)?", lambda m: m.group(1))
+    capture("origin", r"(?:(?:從|由|出發地[：:]?)(台北|高雄|桃園|香港|東京|大阪)(?:出發|飛|去)?|(台北|高雄|桃園|香港|東京|大阪)出發)", lambda m: m.group(1) or m.group(2))
     capture("duration", r"([\d一二三四五六七八九十]+)天([\d一二三四五六七八九十]+)夜", lambda m: (_number(m.group(1)), _number(m.group(2))))
     if "duration" not in values:
         capture("duration", r"([\d一二三四五六七八九十]+)天", lambda m: (_number(m.group(1)), None))

--- a/src/orchestrator/travel.py
+++ b/src/orchestrator/travel.py
@@ -67,6 +67,7 @@ class OrchestrationResult:
     warnings: tuple[WarningRecord, ...]
     trip: dict | None
     render_path: Path | None
+    trip_path: Path | None = None
 
     @property
     def succeeded(self) -> bool:
@@ -96,6 +97,7 @@ class TravelOrchestratorConfig:
     adapters: Sequence[SourceAdapter]
     candidate_trip_factory: CandidateTripFactory
     output_directory: Path
+    trip_output_directory: Path | None = None
     research_categories: tuple[str, ...] = ("pois", "restaurants", "hotels", "flights", "transport")
     routing_context_factory: RoutingContextFactory | None = None
     optimizer: Optimizer | None = None
@@ -183,12 +185,16 @@ class TravelOrchestrator:
         if canonical_report.status is StageStatus.FAILED:
             return self._result(intent, reports, aggregate_warnings)
 
+        trip_path, persistence_report = self._persist_trip(canonical_trip)
+        if persistence_report.status is StageStatus.FAILED:
+            reports[StageName.CANONICAL_TRIP] = persistence_report
+            return self._result(intent, reports, [*aggregate_warnings, *persistence_report.errors])
         render_path, renderer_report = self._run_renderer(canonical_trip)
         reports[StageName.RENDERER] = renderer_report
         aggregate_warnings.extend(renderer_report.warnings)
         if renderer_report.status is StageStatus.FAILED:
             return self._result(intent, reports, aggregate_warnings)
-        return self._result(intent, reports, aggregate_warnings, canonical_trip, render_path)
+        return self._result(intent, reports, aggregate_warnings, canonical_trip, render_path, trip_path)
 
     def _run_routing(self, intent: TravelIntent, store: CandidateStore) -> tuple[ValidationContext, StageReport]:
         if self.config.routing_context_factory is None:
@@ -257,6 +263,20 @@ class TravelOrchestrator:
             error = WarningRecord("renderer.failed", str(exc), StageName.RENDERER)
             return None, StageReport(StageName.RENDERER, StageStatus.FAILED, 1, (), (error,))
 
+    def _persist_trip(self, trip: dict) -> tuple[Path | None, StageReport]:
+        """Persist only the validated canonical document, never provider raw payloads."""
+        if self.config.trip_output_directory is None:
+            return None, StageReport(StageName.CANONICAL_TRIP, StageStatus.SUCCEEDED, 0)
+        try:
+            import json
+            target = self.config.trip_output_directory / str(trip.get("id", "trip")) / "trip.json"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(json.dumps(trip, ensure_ascii=False, indent=2), encoding="utf-8")
+            return target, StageReport(StageName.CANONICAL_TRIP, StageStatus.SUCCEEDED, 1)
+        except Exception as exc:
+            error = WarningRecord("canonical.persist_failed", str(exc), StageName.CANONICAL_TRIP)
+            return None, StageReport(StageName.CANONICAL_TRIP, StageStatus.FAILED, 1, (), (error,))
+
     def _retry(self, name: StageName, operation: Callable[[], object]) -> tuple[object | None, StageReport]:
         errors: list[WarningRecord] = []
         for attempt in range(1, self.config.max_stage_attempts + 1):
@@ -267,8 +287,8 @@ class TravelOrchestrator:
         return None, StageReport(name, StageStatus.FAILED, self.config.max_stage_attempts, (), tuple(errors))
 
     @staticmethod
-    def _result(intent, reports, warnings, trip=None, render_path=None) -> OrchestrationResult:
-        return OrchestrationResult(intent, tuple(reports[name] for name in TravelOrchestrator.ORDER), tuple(warnings), trip, render_path)
+    def _result(intent, reports, warnings, trip=None, render_path=None, trip_path=None) -> OrchestrationResult:
+        return OrchestrationResult(intent, tuple(reports[name] for name in TravelOrchestrator.ORDER), tuple(warnings), trip, render_path, trip_path)
 
 
 def _destination(intent: TravelIntent) -> str:

--- a/src/restaurant_intelligence.py
+++ b/src/restaurant_intelligence.py
@@ -7,7 +7,7 @@ it never reads provider payloads or mutates a final itinerary.
 from __future__ import annotations
 
 from datetime import datetime, time
-from typing import Iterable, Mapping
+from typing import Iterable, Mapping, Sequence
 
 from src.validator import OpeningInterval
 
@@ -25,6 +25,35 @@ def opening_intervals(candidate: Mapping[str, object]) -> tuple[OpeningInterval,
         except (KeyError, TypeError, ValueError):
             continue
     return tuple(intervals)
+
+
+def restaurant_intelligence(
+    candidate: Mapping[str, object], *, recommended_dishes: Sequence[Mapping[str, object]] = ()
+) -> dict[str, object]:
+    """Return a canonical restaurant candidate with evidence-bound dish facts.
+
+    Places providers are authoritative for operational facts such as ratings and
+    hours, but they do not generally supply a reliable menu.  Callers may add
+    dish recommendations only with their own canonical provenance record.  The
+    helper deliberately rejects provider-specific payloads and never upgrades
+    reported community evidence into a confirmed operational fact.
+    """
+    normalized = dict(candidate)
+    accepted: list[dict[str, object]] = []
+    for dish in recommended_dishes:
+        name = dish.get("name")
+        provenance = dish.get("provenance")
+        if not isinstance(name, str) or not name.strip() or not isinstance(provenance, Mapping):
+            continue
+        if not isinstance(provenance.get("provider"), str) or not isinstance(provenance.get("retrieved_at"), str):
+            continue
+        item: dict[str, object] = {"name": name.strip(), "provenance": dict(provenance)}
+        if isinstance(dish.get("note"), str):
+            item["note"] = dish["note"]
+        accepted.append(item)
+    if accepted:
+        normalized["recommended_dishes"] = accepted
+    return normalized
 
 
 def meal_eligible(candidate: Mapping[str, object], start: datetime, end: datetime) -> bool:

--- a/src/web.py
+++ b/src/web.py
@@ -1,0 +1,310 @@
+"""Private, filesystem-backed dashboard for the production planning pipeline.
+
+The HTTP layer intentionally has no provider or planner knowledge.  A request is
+parsed once and handed to ``src.application.production``; the canonical trip it
+persists remains the only data used to build the read models below.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import threading
+import traceback
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from html import escape
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Callable, Protocol
+from urllib.parse import parse_qs, quote, unquote, urlparse
+
+from src.intent import parse_trip_request
+
+
+STAGES = ("parsing", "research", "candidate store", "routing", "planning", "optimizing", "validation / repair", "rendering")
+TAB_NAMES = ("Overview", "Itinerary", "Map / Routing", "Restaurants", "Flights", "Hotels", "Budget", "Research / Sources", "Validation", "Final Website")
+
+
+class PlanningService(Protocol):
+    def plan(self, request: str, trip_id: str, progress: Callable[[str], None]) -> Any: ...
+
+
+class ProductionPlanningService:
+    """Small lazy bridge that keeps the web process independent of providers."""
+
+    def __init__(self, trips_directory: Path, site_directory: Path) -> None:
+        self.trips_directory = trips_directory
+        self.site_directory = site_directory
+
+    def plan(self, request: str, trip_id: str, progress: Callable[[str], None]) -> Any:
+        progress("parsing")
+        intent = parse_trip_request(request)
+        # Importing here lets the dashboard return a configuration error instead
+        # of failing to start when optional production integrations are absent.
+        from src.application.production import create_production_orchestrator
+
+        for stage in STAGES[1:]:
+            progress(stage)
+        orchestrator = create_production_orchestrator(
+            trip_id=trip_id,
+            trips_directory=self.trips_directory,
+            site_directory=self.site_directory,
+            progress_callback=progress,
+        )
+        return orchestrator.run(intent)
+
+
+@dataclass
+class Job:
+    id: str
+    request: str
+    stage: str = "queued"
+    state: str = "running"
+    error: dict[str, Any] | None = None
+    trip_id: str | None = None
+    stages: list[str] = field(default_factory=list)
+
+    def public(self) -> dict[str, Any]:
+        return {"id": self.id, "state": self.state, "stage": self.stage, "stages": self.stages, "error": self.error, "trip_id": self.trip_id}
+
+
+class DashboardApp:
+    def __init__(self, *, trips_directory: Path = Path("trips"), site_directory: Path = Path("site"), service: PlanningService | None = None) -> None:
+        self.trips_directory, self.site_directory = trips_directory, site_directory
+        self.service = service or ProductionPlanningService(trips_directory, site_directory)
+        self.jobs: dict[str, Job] = {}
+        self._lock = threading.Lock()
+
+    def submit(self, request: str) -> Job:
+        if not request.strip():
+            raise ValueError("請輸入自然語言旅遊需求。")
+        job = Job(uuid.uuid4().hex, request)
+        with self._lock:
+            self.jobs[job.id] = job
+        threading.Thread(target=self._run, args=(job,), daemon=True).start()
+        return job
+
+    def job(self, job_id: str) -> Job | None:
+        with self._lock:
+            return self.jobs.get(job_id)
+
+    def _run(self, job: Job) -> None:
+        trip_id = _trip_id(job.request)
+        def progress(stage: str) -> None:
+            with self._lock:
+                job.stage = stage
+                if stage not in job.stages:
+                    job.stages.append(stage)
+        try:
+            result = self.service.plan(job.request, trip_id, progress)
+            trip = _result_trip(result)
+            # Successful production composition must have persisted the canonical
+            # document.  Do not render a "success" from an in-memory invalid trip.
+            trip_path = self.trips_directory / trip_id / "trip.json"
+            if trip is None and trip_path.exists():
+                trip = _read_json(trip_path)
+            if trip is None:
+                raise RuntimeError("production composition completed without a persisted canonical Trip")
+            if not trip_path.exists():
+                raise RuntimeError("production composition did not persist trips/<trip-id>/trip.json")
+            if not (self.site_directory / trip_id / "index.html").exists():
+                raise RuntimeError("production composition did not render site/<trip-id>/index.html")
+            with self._lock:
+                job.state, job.stage, job.trip_id = "complete", "complete", trip_id
+        except Exception as exc:  # External failures are deliberately surfaced.
+            with self._lock:
+                job.state, job.stage = "failed", "failed"
+                job.error = _safe_error(exc)
+
+    def recent_trips(self) -> list[dict[str, str]]:
+        if not self.trips_directory.exists():
+            return []
+        result = []
+        for path in self.trips_directory.glob("*/trip.json"):
+            try:
+                trip = _read_json(path)
+                result.append({"id": str(trip.get("id", path.parent.name)), "title": str(trip.get("title", path.parent.name)), "updated_at": datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).isoformat()})
+            except (OSError, ValueError, TypeError):
+                continue
+        return sorted(result, key=lambda item: item["updated_at"], reverse=True)
+
+    def trip_view(self, trip_id: str) -> dict[str, Any] | None:
+        if not _safe_id(trip_id):
+            return None
+        path = self.trips_directory / trip_id / "trip.json"
+        if not path.is_file():
+            return None
+        return _trip_read_model(_read_json(path), trip_id)
+
+
+def _result_trip(result: Any) -> dict[str, Any] | None:
+    if isinstance(result, dict):
+        return result.get("trip") if isinstance(result.get("trip"), dict) else result
+    value = getattr(result, "trip", None)
+    return value if isinstance(value, dict) else None
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("Trip JSON must be an object")
+    return value
+
+
+def _trip_id(request: str) -> str:
+    words = re.sub(r"[^a-z0-9]+", "-", request.lower()).strip("-")
+    words = words[:36].strip("-") or "request"
+    # Canonical Trip IDs must start with a letter, including requests which
+    # begin with a duration such as "5 天 4 夜".
+    if not words[0].isalpha(): words = "trip-" + words
+    return words + "-" + datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+
+
+def _safe_id(value: str) -> bool:
+    return bool(re.fullmatch(r"[a-z][a-z0-9_-]*", value))
+
+
+def _safe_error(exc: Exception) -> dict[str, Any]:
+    name = exc.__class__.__name__
+    missing = getattr(exc, "missing", None)
+    if missing:
+        return {"code": "configuration_missing", "message": "Production provider configuration is missing or unverified.", "missing": [str(item) for item in missing]}
+    text = _redact(str(exc))
+    if "configuration_missing" in text or "credential" in text.lower() or "api key" in text.lower():
+        return {"code": "configuration_missing", "message": text}
+    return {"code": "planning_failed", "message": text or name}
+
+
+def _redact(value: str) -> str:
+    for secret in os.environ.values():
+        if len(secret) >= 6 and secret in value:
+            value = value.replace(secret, "[redacted]")
+    return value[:1000]
+
+
+def _trip_read_model(trip: dict[str, Any], trip_id: str) -> dict[str, Any]:
+    sets = trip.get("candidate_sets", {})
+    places = {item.get("id"): item for item in sets.get("places", []) if isinstance(item, dict)}
+    days = []
+    for day in trip.get("days", []):
+        items = []
+        for item in day.get("items", []):
+            place = places.get(item.get("place_id"), {})
+            items.append({"time": item.get("start_at"), "end": item.get("end_at"), "kind": item.get("kind"), "name": place.get("name", item.get("place_id")), "duration": _duration(item.get("start_at"), item.get("end_at")), "alternatives": item.get("alternative_place_ids", []), "fixed": item.get("kind") == "transport"})
+        days.append({"date": day.get("date"), "summary": day.get("summary", ""), "items": items})
+    routes = []
+    for leg in sets.get("transport_legs", []):
+        provenance = leg.get("provenance", {})
+        routes.append({"from": places.get(leg.get("from_place_id"), {}).get("name", leg.get("from_place_id")), "to": places.get(leg.get("to_place_id"), {}).get("name", leg.get("to_place_id")), "mode": leg.get("mode"), "departure": leg.get("departure_at"), "arrival": leg.get("arrival_at"), "status": provenance.get("status", "unverified"), "maps": _maps_link(places.get(leg.get("from_place_id")), places.get(leg.get("to_place_id")))})
+    sources = []
+    for group, candidates in sets.items():
+        for candidate in candidates if isinstance(candidates, list) else []:
+            provenance = candidate.get("provenance") or candidate.get("place", {}).get("provenance", {})
+            if provenance:
+                sources.append({"group": group, "name": candidate.get("name") or candidate.get("place", {}).get("name") or candidate.get("id"), **_public_provenance(provenance)})
+    overview = {"title": trip.get("title"), "dates": trip.get("date_range", {}), "travelers": trip.get("traveler_profile", {}), "cities": trip.get("preferences", {}).get("hard_constraints", []), "budget": trip.get("budget", {}).get("total"), "validation_status": "invalid" if any(x.get("severity") == "error" for x in trip.get("validation", [])) else "valid", "warnings": trip.get("validation", [])}
+    return _public({"trip": trip, "overview": overview, "days": days, "routes": routes, "restaurants": sets.get("restaurants", []), "flights": sets.get("flights", []), "hotels": sets.get("hotels", []), "budget": trip.get("budget", {}), "sources": sources, "validation": trip.get("validation", []), "website_url": f"/site/{quote(trip_id)}/index.html", "trip_json_url": f"/trips/{quote(trip_id)}/trip.json"})
+
+
+def _duration(start: Any, end: Any) -> str:
+    try:
+        minutes = int((datetime.fromisoformat(str(end)) - datetime.fromisoformat(str(start))).total_seconds() / 60)
+        return f"{minutes} min"
+    except (TypeError, ValueError):
+        return "unknown / unverified"
+
+
+def _maps_link(origin: Any, destination: Any) -> str | None:
+    if not isinstance(origin, dict) or not isinstance(destination, dict): return None
+    a, b = origin.get("coordinates"), destination.get("coordinates")
+    if not isinstance(a, dict) or not isinstance(b, dict): return None
+    return "https://www.google.com/maps/dir/?api=1&origin={0},{1}&destination={2},{3}".format(a.get("latitude"), a.get("longitude"), b.get("latitude"), b.get("longitude"))
+
+
+def _public_provenance(value: dict[str, Any]) -> dict[str, Any]:
+    return {key: value.get(key) for key in ("provider", "source_url", "retrieved_at", "status", "source_type")}
+
+
+def _public(value: Any) -> Any:
+    """Remove accidental credential-shaped keys from a browser read model."""
+    if isinstance(value, list): return [_public(item) for item in value]
+    if isinstance(value, dict):
+        return {str(k): _public(v) for k, v in value.items() if not re.search(r"(api.?key|secret|token|password|authorization)", str(k), re.I)}
+    return _redact(value) if isinstance(value, str) else value
+
+
+class DashboardHandler(BaseHTTPRequestHandler):
+    app: DashboardApp
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path == "/": return self._html(_home_html(self.app.recent_trips()))
+        if parsed.path.startswith("/api/jobs/"):
+            job = self.app.job(parsed.path.rsplit("/", 1)[-1]); return self._json(job.public() if job else {"error": "not_found"}, 200 if job else 404)
+        if parsed.path.startswith("/api/trips/"):
+            view = self.app.trip_view(unquote(parsed.path.rsplit("/", 1)[-1])); return self._json(view or {"error": "not_found"}, 200 if view else 404)
+        if parsed.path.startswith("/trips/") or parsed.path.startswith("/site/"):
+            return self._artifact(parsed.path)
+        self._json({"error": "not_found"}, 404)
+
+    def do_POST(self) -> None:  # noqa: N802
+        if urlparse(self.path).path != "/api/plans": return self._json({"error": "not_found"}, 404)
+        try:
+            length = int(self.headers.get("Content-Length", "0")); body = json.loads(self.rfile.read(length))
+            job = self.app.submit(str(body.get("request", "")))
+            self._json(job.public(), 202)
+        except (ValueError, json.JSONDecodeError) as exc: self._json({"error": str(exc)}, 400)
+
+    def _artifact(self, url_path: str) -> None:
+        parts = [unquote(x) for x in url_path.split("/") if x]
+        if len(parts) != 3 or parts[0] not in {"trips", "site"} or not _safe_id(parts[1]) or parts[2] not in {"trip.json", "index.html"}:
+            return self._json({"error": "not_found"}, 404)
+        root = self.app.trips_directory if parts[0] == "trips" else self.app.site_directory
+        path = root / parts[1] / parts[2]
+        if not path.is_file(): return self._json({"error": "not_found"}, 404)
+        content_type = "application/json; charset=utf-8" if path.suffix == ".json" else "text/html; charset=utf-8"
+        data = path.read_bytes(); self.send_response(200); self.send_header("Content-Type", content_type); self.send_header("Content-Length", str(len(data))); self.end_headers(); self.wfile.write(data)
+
+    def _json(self, body: Any, status: int = 200) -> None:
+        data = json.dumps(_public(body), ensure_ascii=False).encode(); self.send_response(status); self.send_header("Content-Type", "application/json; charset=utf-8"); self.send_header("Content-Length", str(len(data))); self.end_headers(); self.wfile.write(data)
+
+    def _html(self, body: str) -> None:
+        data = body.encode(); self.send_response(200); self.send_header("Content-Type", "text/html; charset=utf-8"); self.send_header("Content-Length", str(len(data))); self.end_headers(); self.wfile.write(data)
+
+    def log_message(self, format: str, *args: Any) -> None: pass
+
+
+def create_server(app: DashboardApp | None = None, host: str = "127.0.0.1", port: int = 8000) -> ThreadingHTTPServer:
+    handler = type("ConfiguredDashboardHandler", (DashboardHandler,), {"app": app or DashboardApp()})
+    return ThreadingHTTPServer((host, port), handler)
+
+
+def _home_html(recent: list[dict[str, str]]) -> str:
+    recent_html = "".join(f'<li><a href="#" onclick="openTrip(\'{escape(x["id"], quote=True)}\')">{escape(x["title"])}</a><small>{escape(x["updated_at"])}</small></li>' for x in recent) or "<li>尚無已完成行程。</li>"
+    tabs = "".join(f'<button role="tab" data-tab="{escape(name)}">{escape(name)}</button>' for name in TAB_NAMES)
+    return f'''<!doctype html><html lang="zh-Hant"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>AI Travel Planner</title><style>{_CSS}</style><main><h1>AI Travel Planner</h1><form id="plan"><textarea id="request" required placeholder="幫我規劃 5 天 4 夜德島＋神戶，2 大 1 個 2 歲小孩，台北出發，自駕，不要太累，預算 8 萬。"></textarea><button>開始規劃</button></form><p id="progress" aria-live="polite"></p><p id="error" role="alert"></p><section><h2>最近行程</h2><ul>{recent_html}</ul></section><section id="workspace" hidden><div class="tabs" role="tablist">{tabs}</div><pre id="result"></pre></section></main><script>{_JS}</script></html>'''
+
+
+_JS = '''const p=document.querySelector('#progress'),e=document.querySelector('#error'),w=document.querySelector('#workspace'),r=document.querySelector('#result');
+document.querySelector('#plan').onsubmit=async x=>{x.preventDefault();e.textContent='';p.textContent='準備執行…';let q=await fetch('/api/plans',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({request:document.querySelector('#request').value})});let j=await q.json();if(!q.ok){e.textContent=j.error;return} watch(j.id)};
+async function watch(id){let q=await fetch('/api/jobs/'+id),j=await q.json();p.textContent='目前階段：'+j.stage+(j.stages.length?' · '+j.stages.join(' → '):'');if(j.state==='running')return setTimeout(()=>watch(id),500);if(j.state==='failed'){e.textContent=(j.error&&j.error.message)||'規劃失敗';return}openTrip(j.trip_id)}
+async function openTrip(id){let q=await fetch('/api/trips/'+id),j=await q.json();if(!q.ok){e.textContent='無法載入行程';return}window.trip=j;w.hidden=false;show('Overview')};
+document.querySelectorAll('[data-tab]').forEach(x=>x.onclick=()=>show(x.dataset.tab));function show(tab){let t=window.trip;if(!t)return;let maps={'Overview':t.overview,'Itinerary':t.days,'Map / Routing':t.routes,'Restaurants':t.restaurants,'Flights':t.flights,'Hotels':t.hotels,'Budget':t.budget,'Research / Sources':t.sources,'Validation':t.validation,'Final Website':{website:t.website_url,trip_json:t.trip_json_url}};r.textContent=JSON.stringify(maps[tab],null,2)}'''
+_CSS = 'body{font:16px system-ui;max-width:980px;margin:2rem auto;padding:0 1rem;background:#f5f7fa;color:#172033}textarea{width:100%;min-height:7rem;padding:1rem}button{padding:.7rem 1rem;margin:.5rem .3rem .5rem 0}section,form{background:white;padding:1rem;border-radius:.75rem;margin:1rem 0}.tabs{overflow:auto;white-space:nowrap}pre{white-space:pre-wrap;overflow:auto;background:#101828;color:#eaf2ff;padding:1rem;border-radius:.5rem}#error{color:#b42318}small{display:block;color:#667085}'
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the private AI Travel Planner dashboard")
+    parser.add_argument("--host", default="127.0.0.1"); parser.add_argument("--port", default=8000, type=int)
+    args = parser.parse_args(); server = create_server(host=args.host, port=args.port)
+    print(f"AI Travel Planner dashboard: http://{args.host}:{args.port}")
+    try: server.serve_forever()
+    except KeyboardInterrupt: pass
+    finally: server.server_close()
+
+
+if __name__ == "__main__": main()

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -86,6 +86,56 @@ class PlannerTests(unittest.TestCase):
         self.assertEqual(result.plans[0].state, PlanState.FAILED)
         self.assertEqual({v.code for v in result.plans[0].violations}, {"constraint.fixed_time", "constraint.max_daily_duration"})
 
+    def test_wednesday_closed_restaurant_is_not_an_acceptable_meal_candidate(self):
+        trip = copy.deepcopy(self.trip)
+        restaurant = trip["candidate_sets"]["restaurants"][0]
+        restaurant["opening_hours"] = {
+            "status": "fresh",
+            # Monday only.  Wednesday (Python weekday 2) must not be accepted.
+            "intervals": [{"weekday": 0, "opens_at": "11:30", "closes_at": "21:00"}],
+        }
+        trip["days"][4]["date"] = "2026-04-15"
+        trip["days"][4]["items"].append({
+            "id": "wednesday-meal", "kind": "meal", "place_id": "ramen-shop",
+            "start_at": "2026-04-15T12:00:00+09:00", "end_at": "2026-04-15T13:00:00+09:00",
+            "selection_status": "selected",
+        })
+        result = plan(PlannerInput([trip], verified_context()))
+        self.assertIsNone(result.best_plan)
+        self.assertIn("opening_hours.closed", {item.code for item in result.plans[0].violations})
+
+    def test_split_hours_accepts_only_a_complete_meal_interval(self):
+        trip = copy.deepcopy(self.trip)
+        restaurant = trip["candidate_sets"]["restaurants"][0]
+        restaurant["opening_hours"] = {
+            "status": "fresh",
+            "intervals": [
+                {"weekday": 0, "opens_at": "11:30", "closes_at": "14:00"},
+                {"weekday": 0, "opens_at": "17:30", "closes_at": "21:00"},
+            ],
+        }
+        trip["days"][3]["items"].append({
+            "id": "monday-dinner", "kind": "meal", "place_id": "ramen-shop",
+            "start_at": "2026-04-13T18:00:00+09:00", "end_at": "2026-04-13T19:00:00+09:00",
+            "selection_status": "selected",
+        })
+        result = plan(PlannerInput([trip], verified_context()))
+        self.assertIsNotNone(result.best_plan)
+        self.assertNotIn("opening_hours.closed", {item.code for item in result.best_plan.violations})
+
+    def test_stale_restaurant_hours_are_unverified_not_assumed_open(self):
+        trip = copy.deepcopy(self.trip)
+        restaurant = trip["candidate_sets"]["restaurants"][0]
+        restaurant["opening_hours"] = {"status": "stale", "intervals": [{"weekday": 0, "opens_at": "00:00", "closes_at": "23:59"}]}
+        trip["days"][3]["items"].append({
+            "id": "stale-hours-meal", "kind": "meal", "place_id": "ramen-shop",
+            "start_at": "2026-04-13T18:00:00+09:00", "end_at": "2026-04-13T19:00:00+09:00",
+            "selection_status": "selected",
+        })
+        result = plan(PlannerInput([trip], verified_context()))
+        self.assertIsNotNone(result.best_plan)
+        self.assertIn("opening_hours.unverified", {item.code for item in result.best_plan.violations})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_production_composition.py
+++ b/tests/test_production_composition.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.application.production import ProductionDependencies, create_production_orchestrator
+from src.cli import plan_command
+from src.intent import parse_trip_request
+from src.sources import AmadeusClient, SourceAdapter
+from src.sources.routing import FixtureRoutingProvider
+
+
+ENVIRONMENT = {
+    "GOOGLE_MAPS_API_KEY": "google-secret",
+    "YOUTUBE_API_KEY": "youtube-secret",
+    "AMADEUS_CLIENT_ID": "amadeus-id",
+    "AMADEUS_CLIENT_SECRET": "amadeus-secret",
+    "OPENROUTESERVICE_API_KEY": "ors-secret",
+}
+
+
+class RecordedGoogle(SourceAdapter):
+    name = "recorded-google"
+
+    def fetch(self, query):
+        now = "2026-01-01T00:00:00+09:00"
+        provenance = {"source_type": "provider", "provider": "Recorded Google Places", "source_url": "https://example.test/places", "retrieved_at": now, "status": "confirmed"}
+        places = [("places", {"id": f"poi-{number}", "name": f"POI {number}", "kind": "poi", "coordinates": {"latitude": 34.0 + number / 100, "longitude": 134.0}, "provenance": provenance}) for number in range(5)]
+        restaurant = {"place": {"id": "restaurant-1", "name": "Open restaurant", "kind": "restaurant", "coordinates": {"latitude": 34.1, "longitude": 134.1}, "provenance": provenance}, "rating": 4.5, "review_count": 100, "opening_hours": {"status": "fresh", "intervals": [{"weekday": day, "opens_at": "09:00", "closes_at": "21:00"} for day in range(7)]}, "provenance": provenance}
+        return [*places, ("restaurants", restaurant)]
+
+
+class RecordedYouTube:
+    def fetch_evidence(self, query):
+        return []
+
+
+def _transport(method, url, headers, body):
+    if url.endswith("/v1/security/oauth2/token"):
+        return 200, {"access_token": "recorded-token"}
+    if "flight-offers" in url:
+        return 200, {"data": [{"id": "offer-1", "itineraries": [{"segments": [{"carrierCode": "CI", "number": "1", "departure": {"iataCode": "TPE", "at": "2026-04-10T08:00:00"}, "arrival": {"iataCode": "TKS", "at": "2026-04-10T12:00:00"}}]}], "price": {"grandTotal": "1000", "currency": "JPY"}}]}
+    if "locations/hotels/by-city" in url:
+        return 200, {"data": [{"hotelId": "H1"}]}
+    if "hotel-offers" in url:
+        return 200, {"data": [{"hotel": {"hotelId": "H1", "name": "Recorded hotel", "latitude": 34.1, "longitude": 134.2}, "offers": [{"id": "hotel-offer", "price": {"total": "2000", "currency": "JPY"}}]}]}
+    raise AssertionError(url)
+
+
+def _runner(tmp_path):
+    dependencies = ProductionDependencies(
+        google=RecordedGoogle(), youtube=RecordedYouTube(),
+        amadeus_client=AmadeusClient(_transport, ENVIRONMENT), routing_provider=FixtureRoutingProvider(()),
+    )
+    return create_production_orchestrator(
+        trip_id="recorded-trip", trips_directory=tmp_path / "trips", site_directory=tmp_path / "site",
+        environment=ENVIRONMENT, dependencies=dependencies,
+    )
+
+
+def test_recorded_production_composition_runs_pipeline_and_persists_canonical_outputs(tmp_path):
+    intent = parse_trip_request("2026/4/10到2026/4/14 台北出發德島五天四夜，2大，預算8萬日圓，自駕")
+    result = _runner(tmp_path).run(intent)
+
+    assert result.succeeded
+    assert result.trip_path == tmp_path / "trips" / "recorded-trip" / "trip.json"
+    assert result.render_path == tmp_path / "site" / "recorded-trip" / "index.html"
+    persisted = result.trip_path.read_text(encoding="utf-8")
+    assert "google-secret" not in persisted
+    assert "amadeus-secret" not in persisted
+    assert result.render_path.exists()
+
+
+def test_cli_non_demo_invokes_shared_production_composition_not_configuration_ready(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr("src.cli.missing_required_configuration", lambda: [])
+    called = {}
+    fake_result = SimpleNamespace(succeeded=True, trip_path=tmp_path / "trips/x/trip.json", render_path=tmp_path / "site/x/index.html", stages=(), warnings=())
+
+    class Runner:
+        def run(self, intent):
+            called["intent"] = intent
+            return fake_result
+
+    with patch("src.cli.create_production_orchestrator", return_value=Runner()) as factory:
+        exit_code = plan_command(argparse.Namespace(request="德島五天四夜，2大，預算8萬日圓", trip_id="x", demo=False, trips_directory="trips", site_directory="site"))
+
+    assert exit_code == 0
+    assert "intent" in called
+    factory.assert_called_once()
+    output = capsys.readouterr().out
+    assert '"status": "complete"' in output
+    assert "configuration_ready" not in output

--- a/tests/test_recorded_japan_e2e.py
+++ b/tests/test_recorded_japan_e2e.py
@@ -1,0 +1,120 @@
+"""Offline five-day Japan pipeline scenario using recorded provider-shaped data."""
+
+from __future__ import annotations
+
+import copy
+import json
+from datetime import datetime, time, timezone
+from pathlib import Path
+
+from src.intent import parse_trip_request
+from src.orchestrator import StageName, StageStatus, TravelOrchestrator, TravelOrchestratorConfig
+from src.restaurant_intelligence import validation_opening_hours
+from src.sources import GooglePlacesAdapter
+from src.validator import BudgetLimit, OpeningInterval, ValidationContext
+
+
+ROOT = Path(__file__).parents[1]
+NOW = datetime(2026, 8, 10, 8, tzinfo=timezone.utc)
+
+
+class RecordedGoogleClient:
+    """Recorded Google Places API (New) payloads; no test makes a network call."""
+
+    def __init__(self):
+        self.responses = [
+            {"places": [{
+                "id": "tokushima-park", "displayName": {"text": "德島中央公園"},
+                "formattedAddress": "Tokushima", "googleMapsUri": "https://maps.example.test/tokushima-park",
+                "location": {"latitude": 34.07, "longitude": 134.55},
+            }]},
+            {"places": [{
+                "id": "tokushima-family-dining", "displayName": {"text": "親子食堂"},
+                "rating": 4.4, "userRatingCount": 218, "primaryType": "japanese_restaurant",
+                "googleMapsUri": "https://maps.example.test/tokushima-family-dining",
+                "regularOpeningHours": {"periods": [
+                    # Monday lunch/dinner split; no Wednesday interval.
+                    {"open": {"day": 1, "hour": 11}, "close": {"day": 1, "hour": 14}},
+                    {"open": {"day": 1, "hour": 17}, "close": {"day": 1, "hour": 21}},
+                ]},
+            }]},
+        ]
+
+    def request_json(self, method, url, *, headers, body=None):
+        assert method == "POST"
+        assert headers["X-Goog-Api-Key"] == "recorded-google-key"
+        return self.responses.pop(0)
+
+
+def _fixture_trip() -> dict:
+    return json.loads((ROOT / "fixtures/trips/japan-5-day-trip-v1.json").read_text(encoding="utf-8"))
+
+
+def _context(_: object, store: object) -> ValidationContext:
+    restaurants = [record.candidate for record in store.records() if record.collection == "restaurants"]
+    regular_hours = {
+        place_id: [OpeningInterval(day, time(8), time(22)) for day in range(7)]
+        for place_id in ("ohori-park", "dazaifu", "yufuin", "beppu", "canal-city")
+    }
+    return ValidationContext(
+        travel_minutes={
+            ("fuk", "hakata-hotel"): 180,
+            ("yufuin", "beppu"): 60,
+            ("beppu", "google-tokushima-family-dining"): 60,
+        },
+        opening_hours={**regular_hours, **validation_opening_hours(restaurants)},
+        budget_limit=BudgetLimit(200000, "JPY"),
+    )
+
+
+def _recorded_candidate_factory(_: object, store: object) -> list[dict]:
+    trip = copy.deepcopy(_fixture_trip())
+    restaurant = next(record.candidate for record in store.records() if record.collection == "restaurants")
+    trip["candidate_sets"]["restaurants"] = [restaurant]
+    trip["candidate_sets"]["places"].append(restaurant["place"])
+    trip["days"][3]["items"].append({
+        "id": "monday-family-dinner", "kind": "meal", "place_id": restaurant["place"]["id"],
+        "start_at": "2026-04-13T17:30:00+09:00", "end_at": "2026-04-13T18:30:00+09:00",
+        "selection_status": "selected",
+    })
+    return [trip]
+
+
+def test_recorded_five_day_japan_pipeline_runs_candidates_routing_budget_validation_and_renderer(tmp_path):
+    adapter = GooglePlacesAdapter("recorded-google-key", http_client=RecordedGoogleClient(), now=NOW)
+    result = TravelOrchestrator(TravelOrchestratorConfig(
+        adapters=(adapter,), candidate_trip_factory=_recorded_candidate_factory,
+        routing_context_factory=_context, output_directory=tmp_path,
+    )).run(parse_trip_request("幫我規劃 5 天 4 夜德島＋神戶，2 大 1 個 2 歲小孩，台北出發，自駕，不要太累，預算 20 萬日圓。"))
+
+    assert result.succeeded
+    assert result.trip is not None
+    assert result.trip["schema_version"] == "trip-v1"
+    assert result.trip["candidate_sets"]["restaurants"][0]["rating"] == 4.4
+    assert result.trip["budget"]["total"]["amount"] == 169000
+    assert result.render_path == tmp_path / "kyushu-family-2026" / "index.html"
+    assert result.render_path.exists()
+    assert result.stage(StageName.ROUTING).status is StageStatus.SUCCEEDED
+    assert result.stage(StageName.VALIDATOR_REPAIR).status is StageStatus.SUCCEEDED
+    assert "recorded-google-key" not in result.render_path.read_text(encoding="utf-8")
+
+
+def test_insufficient_recorded_route_blocks_final_renderer(tmp_path):
+    def insufficient_context(intent, store):
+        context = _context(intent, store)
+        return ValidationContext(
+            travel_minutes={**context.travel_minutes, ("yufuin", "beppu"): 180},
+            opening_hours=context.opening_hours,
+            budget_limit=context.budget_limit,
+        )
+
+    result = TravelOrchestrator(TravelOrchestratorConfig(
+        adapters=(GooglePlacesAdapter("recorded-google-key", http_client=RecordedGoogleClient(), now=NOW),),
+        candidate_trip_factory=_recorded_candidate_factory, routing_context_factory=insufficient_context,
+        output_directory=tmp_path, max_repair_iterations=0,
+    )).run(parse_trip_request("德島＋神戶五天四夜，2大1小，預算20萬日圓"))
+
+    assert not result.succeeded
+    assert result.render_path is None
+    assert result.stage(StageName.VALIDATOR_REPAIR).status is StageStatus.FAILED
+    assert any(warning.code == "travel_time.insufficient" for warning in result.stage(StageName.VALIDATOR_REPAIR).warnings)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -18,6 +18,7 @@ from src.sources.providers import (
     YouTubeEvidenceAdapter,
     prioritize_by_authority,
 )
+from src.restaurant_intelligence import restaurant_intelligence
 
 
 NOW = datetime(2026, 8, 10, 8, 0, tzinfo=timezone.utc)
@@ -91,6 +92,38 @@ class ProductionProviderAdapterTests(unittest.TestCase):
         self.assertEqual("unknown", restaurant["wait_risk"])
         self.assertEqual("POST", client.calls[0][0])
         self.assertNotIn("test-key", str(client.calls[0][3]))
+
+    def test_google_restaurant_normalizes_rating_reviews_and_split_opening_hours(self):
+        restaurant_recording = {
+            "places": [{
+                "id": "ChIJ-restaurant", "displayName": {"text": "水曜日定休食堂"},
+                "rating": 4.6, "userRatingCount": 321, "primaryType": "japanese_restaurant",
+                "regularOpeningHours": {"periods": [
+                    {"open": {"day": 1, "hour": 11, "minute": 30}, "close": {"day": 1, "hour": 14, "minute": 0}},
+                    {"open": {"day": 1, "hour": 17, "minute": 30}, "close": {"day": 1, "hour": 21, "minute": 0}},
+                ]},
+            }]
+        }
+        client = RecordedHttpClient([self.google_recording, restaurant_recording])
+        restaurant = list(GooglePlacesAdapter("test-key", http_client=client, now=NOW).fetch(QUERY))[1][1]
+        self.assertEqual(4.6, restaurant["rating"])
+        self.assertEqual("Google Places", restaurant["rating_source"])
+        self.assertEqual(321, restaurant["review_count"])
+        self.assertEqual("japanese_restaurant", restaurant["cuisine"])
+        self.assertEqual({"status": "fresh", "intervals": [
+            {"weekday": 0, "opens_at": "11:30", "closes_at": "14:00"},
+            {"weekday": 0, "opens_at": "17:30", "closes_at": "21:00"},
+        ]}, restaurant["opening_hours"])
+        self.assertNotIn("regularOpeningHours", str(restaurant))
+
+    def test_recommended_dishes_require_explicit_source_provenance(self):
+        candidate = {"place": {"id": "restaurant", "name": "Restaurant", "kind": "restaurant"}}
+        enriched = restaurant_intelligence(candidate, recommended_dishes=(
+            {"name": "鯛めし", "note": "晚餐限定", "provenance": {"provider": "Official menu", "retrieved_at": NOW.isoformat(), "source_type": "official", "status": "confirmed", "confidence": 0.9}},
+            {"name": "無來源料理"},
+        ))
+        self.assertEqual("鯛めし", enriched["recommended_dishes"][0]["name"])
+        self.assertNotIn("無來源料理", str(enriched))
 
     def test_missing_credentials_and_provider_errors_are_isolated(self):
         with self.assertRaises(ProviderConfigurationError):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,91 @@
+import json
+import os
+import threading
+import time
+import unittest
+from http.client import HTTPConnection
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from src.renderer.build_site import build_site
+from src.web import DashboardApp, create_server
+
+
+FIXTURE = Path("fixtures/trips/japan-5-day-trip-v1.json")
+
+
+class RecordedService:
+    def __init__(self, trips, site): self.trips, self.site = trips, site; self.calls = []
+    def plan(self, request, trip_id, progress):
+        self.calls.append(request)
+        for stage in ("parsing", "research", "candidate store", "routing", "planning", "optimizing", "validation / repair", "rendering"):
+            progress(stage)
+        trip = json.loads(FIXTURE.read_text())
+        trip["id"] = trip_id
+        target = self.trips / trip_id; target.mkdir(parents=True)
+        (target / "trip.json").write_text(json.dumps(trip))
+        rendered = self.site / trip_id; rendered.mkdir(parents=True)
+        (rendered / "index.html").write_text(build_site(trip))
+        return {"trip": trip}
+
+
+class MissingService:
+    def plan(self, request, trip_id, progress):
+        exc = RuntimeError("configuration_missing: GOOGLE_MAPS_API_KEY")
+        raise exc
+
+
+class DashboardTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory(); root = Path(self.tmp.name)
+        self.service = RecordedService(root / "trips", root / "site")
+        self.app = DashboardApp(trips_directory=root / "trips", site_directory=root / "site", service=self.service)
+        self.server = create_server(self.app, port=0)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True); self.thread.start()
+        self.conn = HTTPConnection("127.0.0.1", self.server.server_port, timeout=3)
+
+    def tearDown(self):
+        self.conn.close(); self.server.shutdown(); self.server.server_close(); self.tmp.cleanup()
+
+    def request(self, method, path, data=None):
+        self.conn.request(method, path, data, {"Content-Type": "application/json"} if data else {})
+        response = self.conn.getresponse(); return response.status, response.read().decode()
+
+    def test_natural_language_submission_progress_and_trip_tabs(self):
+        status, body = self.request("POST", "/api/plans", json.dumps({"request": "幫我規劃 5 天 4 夜德島＋神戶，2 大 1 個 2 歲小孩，台北出發"}))
+        self.assertEqual(202, status); job = json.loads(body)
+        for _ in range(40):
+            status, body = self.request("GET", "/api/jobs/" + job["id"]); job = json.loads(body)
+            if job["state"] != "running": break
+            time.sleep(.02)
+        self.assertEqual("complete", job["state"])
+        self.assertEqual(["parsing", "research", "candidate store", "routing", "planning", "optimizing", "validation / repair", "rendering"], job["stages"])
+        self.assertEqual(1, len(self.service.calls))
+        status, body = self.request("GET", "/api/trips/" + job["trip_id"]); view = json.loads(body)
+        self.assertEqual(200, status)
+        for field in ("overview", "days", "routes", "restaurants", "flights", "hotels", "budget", "sources", "validation", "website_url", "trip_json_url"):
+            self.assertIn(field, view)
+        self.assertTrue((self.app.trips_directory / job["trip_id"] / "trip.json").exists())
+        self.assertTrue((self.app.site_directory / job["trip_id"] / "index.html").exists())
+
+    def test_missing_configuration_is_visible_without_secret(self):
+        os.environ["DASHBOARD_TEST_SECRET"] = "very-secret-value-123"
+        app = DashboardApp(trips_directory=self.app.trips_directory, site_directory=self.app.site_directory, service=MissingService())
+        job = app.submit("test")
+        for _ in range(40):
+            if job.state != "running": break
+            time.sleep(.02)
+        self.assertEqual("failed", job.state)
+        self.assertEqual("configuration_missing", job.error["code"])
+        self.assertNotIn("very-secret-value-123", json.dumps(job.public()))
+
+    def test_home_and_artifacts_do_not_expose_environment_values(self):
+        os.environ["DASHBOARD_TEST_SECRET"] = "web-secret-777"
+        status, page = self.request("GET", "/")
+        self.assertEqual(200, status); self.assertIn("AI Travel Planner", page)
+        self.assertNotIn("web-secret-777", page)
+        status, body = self.request("GET", "/trips/../../etc/passwd")
+        self.assertEqual(404, status)
+
+
+if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
## Changes
- Adds a shared production composition root used by both CLI and local dashboard.
- Wires non-demo CLI mode through parsing, provider composition, orchestration, validation, canonical-trip persistence, and rendering.
- Adds `python -m src.web` local dashboard with background execution, progress polling, persisted trip workspaces, and result tabs.
- Adds recorded end-to-end, restaurant opening-hours, route failure, persistence, and secret-exposure coverage.

## Validation
- `python3 -m pytest -q` — 65 passed
- `python3 -m unittest discover -s tests -v` — 53 passed
- `python3 -m compileall -q src`
- `python3 -m src.web --port 8000` and local HTTP verification

Production uses environment-only credentials and fails explicitly when required credentials or authoritative inputs are missing; no fixture fallback is used.