### PR TITLE
[M3/P06] 實作 route-aware multi-day scheduler 與 fixed-anchor itinerary synthesis

### DIFF
--- a/src/application/production.py
+++ b/src/application/production.py
@@ -16,6 +16,7 @@ from zoneinfo import ZoneInfo
 
 from src.intent import TravelIntent
 from src.orchestrator import OrchestrationResult, TravelOrchestrator, TravelOrchestratorConfig
+from src.planner import SchedulingInput, schedule
 from src.restaurant_intelligence import eligible_restaurants, reconcile_restaurant_candidates, validation_opening_hours
 from src.sources import (
     AdapterFailure, AmadeusClient, AmadeusFlightAdapter, AmadeusHotelAdapter, FlightSearchQuery,
@@ -23,7 +24,7 @@ from src.sources import (
     YouTubeEvidenceAdapter, collect_from_adapters,
 )
 from src.sources.routing import OpenRouteServiceProvider, PlaceRef, RouteMatrix, RouteMode, RouteStatus
-from src.validator import ValidationContext
+from src.validator import OpeningInterval, ValidationContext
 
 
 REQUIRED_ENVIRONMENT = (
@@ -189,7 +190,7 @@ class _IntentBoundRunner(ProductionPlanningRunner):
         research = _ProductionResearchAdapter(intent, self.google, self.youtube, self.amadeus, self.optional_restaurants)
         config = TravelOrchestratorConfig(
             adapters=(research,),
-            candidate_trip_factory=lambda current, store: _candidate_trips(self.trip_id, current, store.records()),
+            candidate_trip_factory=lambda current, store: _candidate_trips(self.trip_id, current, store.records(), _routing_context(store.records(), self.routing_provider, current)),
             routing_context_factory=lambda current, store: _routing_context(store.records(), self.routing_provider, current),
             optimizer=lambda candidates, context: tuple(candidates),
             output_directory=self.site_directory,
@@ -204,7 +205,7 @@ class _IntentBoundRunner(ProductionPlanningRunner):
         return result
 
 
-def _candidate_trips(trip_id: str, intent: TravelIntent, records: Iterable[object]) -> Sequence[dict]:
+def _candidate_trips(trip_id: str, intent: TravelIntent, records: Iterable[object], routing: ValidationContext) -> Sequence[dict]:
     collections: dict[str, list[dict]] = {name: [] for name in ("places", "restaurants", "hotels", "flights", "transport_legs")}
     for record in records:
         collection, candidate = record.collection, record.candidate  # CandidateRecord protocol; no raw payload crosses here.
@@ -217,53 +218,69 @@ def _candidate_trips(trip_id: str, intent: TravelIntent, records: Iterable[objec
     if len(places) < days_count or not restaurants or not hotels or not flights:
         raise ProductionIncompleteError("live provider results are insufficient for a complete trip (need POIs, restaurants, hotel, and flight)")
 
-    tz = ZoneInfo("Asia/Tokyo")
-    itinerary_days = []
-    selected_meals: list[dict] = []
-    for index in range(days_count):
-        current_date = start + timedelta(days=index)
-        visit_start = datetime.combine(current_date, time(10), tz)
-        visit_end = datetime.combine(current_date, time(12), tz)
-        meal_start = datetime.combine(current_date, time(12, 30), tz)
-        meal_end = datetime.combine(current_date, time(13, 30), tz)
-        eligible = eligible_restaurants(restaurants, meal_start, meal_end)
-        if not eligible:
-            raise ProductionIncompleteError(f"no restaurant has fresh verified opening hours for {current_date.isoformat()} lunch")
-        poi, restaurant = places[index], eligible[index % len(eligible)]
-        selected_meals.append(restaurant)
-        itinerary_days.append({"date": current_date.isoformat(), "summary": poi["name"], "items": [
-            {"id": f"day{index + 1}-visit", "kind": "visit", "place_id": poi["id"], "start_at": visit_start.isoformat(), "end_at": visit_end.isoformat(), "selection_status": "selected"},
-            {"id": f"day{index + 1}-meal", "kind": "meal", "place_id": restaurant["place"]["id"], "start_at": meal_start.isoformat(), "end_at": meal_end.isoformat(), "selection_status": "selected"},
-        ]})
-
     all_places = [*collections["places"], *(hotel["place"] for hotel in hotels)]
-    # De-duplicate the restaurant place if Google returned it in both collections.
     seen: set[str] = set()
     canonical_places = []
     for place in [*all_places, *(restaurant["place"] for restaurant in restaurants)]:
         if place["id"] not in seen:
             seen.add(place["id"]); canonical_places.append(place)
+
+    if any(not candidate.get("schedule") for candidate in [*places, *restaurants]):
+        # Backward-compatible path for normalized providers that predate the
+        # scheduler metadata contract.  New production candidates take the
+        # route-aware branch below; this path remains only until those source
+        # adapters publish explicit visit-duration facts.
+        tz = ZoneInfo("Asia/Tokyo")
+        itinerary_days = []
+        for index in range(days_count):
+            current_date = start + timedelta(days=index)
+            visit_start = datetime.combine(current_date, time(10), tz)
+            visit_end = datetime.combine(current_date, time(12), tz)
+            meal_start = datetime.combine(current_date, time(12, 30), tz)
+            meal_end = datetime.combine(current_date, time(13, 30), tz)
+            eligible = eligible_restaurants(restaurants, meal_start, meal_end)
+            if not eligible:
+                raise ProductionIncompleteError(f"no restaurant has fresh verified opening hours for {current_date.isoformat()} lunch")
+            poi, restaurant = places[index], eligible[index % len(eligible)]
+            itinerary_days.append({"date": current_date.isoformat(), "summary": poi["name"], "items": [
+                {"id": f"day{index + 1}-visit", "kind": "visit", "place_id": poi["id"], "start_at": visit_start.isoformat(), "end_at": visit_end.isoformat(), "selection_status": "selected"},
+                {"id": f"day{index + 1}-meal", "kind": "meal", "place_id": restaurant["place"]["id"], "start_at": meal_start.isoformat(), "end_at": meal_end.isoformat(), "selection_status": "selected"},
+            ]})
+        return [_legacy_trip(trip_id, intent, collections, canonical_places, start, end, hotels, flights, itinerary_days)]
+
     currency = _budget_currency(intent, flights[0], hotels[0])
     flight_cost = _money_amount(flights[0].get("cost"), currency)
     hotel_cost = _money_amount(hotels[0].get("total_cost"), currency)
     categories = {"flights": {"amount": flight_cost, "currency": currency}, "hotel": {"amount": hotel_cost, "currency": currency}}
-    return [{
+    shell = {
         "schema_version": "trip-v1", "id": trip_id, "title": " + ".join(intent.destinations) + " 行程",
         "local_timezone": "Asia/Tokyo", "date_range": {"start_date": start.isoformat(), "end_date": end.isoformat()},
         "traveler_profile": {"adults": _adults(intent), "children": [{"age": age} for age in intent.travelers.child_ages]},
         "preferences": {"hard_constraints": [], "soft_preferences": []},
         "candidate_sets": {**collections, "places": canonical_places},
         "selected": {"hotel_place_ids": [hotels[0]["place"]["id"]], "flight_ids": [flights[0]["id"]]},
-        "days": itinerary_days,
+        "days": [],
         "budget": {"currency": currency, "categories": categories, "total": {"amount": flight_cost + hotel_cost, "currency": currency}},
         "validation": [],
         "provenance": {"source_type": "derived", "provider": "production composition", "retrieved_at": datetime.now(timezone.utc).isoformat(), "status": "estimated", "note": "Built only from normalized provider candidates; availability requires provider confirmation."},
-    }]
+    }
+    scheduled = schedule(SchedulingInput(shell, routing)).best_trip
+    if scheduled is None:
+        raise ProductionIncompleteError("no feasible route-aware schedule from normalized candidates")
+    return [scheduled.trip]
+
+
+def _legacy_trip(trip_id, intent, collections, canonical_places, start, end, hotels, flights, days):
+    currency = _budget_currency(intent, flights[0], hotels[0])
+    flight_cost = _money_amount(flights[0].get("cost"), currency)
+    hotel_cost = _money_amount(hotels[0].get("total_cost"), currency)
+    return {"schema_version": "trip-v1", "id": trip_id, "title": " + ".join(intent.destinations) + " 行程", "local_timezone": "Asia/Tokyo", "date_range": {"start_date": start.isoformat(), "end_date": end.isoformat()}, "traveler_profile": {"adults": _adults(intent), "children": [{"age": age} for age in intent.travelers.child_ages]}, "preferences": {"hard_constraints": [], "soft_preferences": []}, "candidate_sets": {**collections, "places": canonical_places}, "selected": {"hotel_place_ids": [hotels[0]["place"]["id"]], "flight_ids": [flights[0]["id"]]}, "days": days, "budget": {"currency": currency, "categories": {"flights": {"amount": flight_cost, "currency": currency}, "hotel": {"amount": hotel_cost, "currency": currency}}, "total": {"amount": flight_cost + hotel_cost, "currency": currency}}, "validation": [], "provenance": {"source_type": "derived", "provider": "production composition", "retrieved_at": datetime.now(timezone.utc).isoformat(), "status": "estimated", "note": "Built only from normalized provider candidates; availability requires provider confirmation."}}
 
 
 def _routing_context(records: Iterable[object], routing_provider: object, intent: TravelIntent) -> ValidationContext:
     places = []
     restaurants = []
+    opening_hours = {}
     for record in records:
         candidate = record.candidate
         if record.collection == "restaurants":
@@ -275,6 +292,12 @@ def _routing_context(records: Iterable[object], routing_provider: object, intent
         coordinates = place.get("coordinates", {})
         if isinstance(coordinates, Mapping) and isinstance(coordinates.get("latitude"), (int, float)) and isinstance(coordinates.get("longitude"), (int, float)):
             places.append(PlaceRef(place["id"], coordinates["latitude"], coordinates["longitude"]))
+        hours = candidate.get("opening_hours")
+        if record.collection == "places" and isinstance(hours, Mapping) and hours.get("status") == "fresh":
+            try:
+                opening_hours[place["id"]] = tuple(OpeningInterval(int(entry["weekday"]), time.fromisoformat(entry["opens_at"]), time.fromisoformat(entry["closes_at"])) for entry in hours["intervals"])
+            except (KeyError, TypeError, ValueError):
+                pass
     # ORS has a 50-location request limit; a bounded planning snapshot avoids
     # hidden batching/guessing and makes omitted routes unverified downstream.
     unique = list({place.place_id: place for place in places}.values())[:50]
@@ -285,7 +308,7 @@ def _routing_context(records: Iterable[object], routing_provider: object, intent
         for route in matrix.routes(unique, mode):
             if route.status is RouteStatus.AVAILABLE and route.duration_seconds is not None:
                 minutes[(route.origin.place_id, route.destination.place_id)] = max(1, round(route.duration_seconds / 60))
-    return ValidationContext(travel_minutes=minutes, opening_hours=validation_opening_hours(restaurants))
+    return ValidationContext(travel_minutes=minutes, opening_hours={**validation_opening_hours(restaurants), **opening_hours})
 
 
 def _require_plannable_intent(intent: TravelIntent) -> None:

--- a/src/planner/__init__.py
+++ b/src/planner/__init__.py
@@ -1,23 +1,15 @@
 """Planner public API."""
 
 from .contracts import (
-    CandidatePlan,
-    HardConstraint,
-    PlanState,
-    PlannerInput,
-    PlannerOutput,
-    SoftPreference,
-    UnverifiedRestaurantHoursPolicy,
+    CandidatePlan, HardConstraint, PlanState, PlannerInput, PlannerOutput,
+    ScheduledTrip, ScheduleState, SchedulingInput, SchedulingOutput,
+    SoftPreference, UnverifiedRestaurantHoursPolicy,
 )
 from .planner import plan
+from .scheduler import schedule
 
 __all__ = [
-    "CandidatePlan",
-    "HardConstraint",
-    "PlanState",
-    "PlannerInput",
-    "PlannerOutput",
-    "SoftPreference",
-    "UnverifiedRestaurantHoursPolicy",
-    "plan",
+    "CandidatePlan", "HardConstraint", "PlanState", "PlannerInput", "PlannerOutput",
+    "ScheduledTrip", "ScheduleState", "SchedulingInput", "SchedulingOutput",
+    "SoftPreference", "UnverifiedRestaurantHoursPolicy", "plan", "schedule",
 ]

--- a/src/planner/contracts.py
+++ b/src/planner/contracts.py
@@ -22,6 +22,13 @@ class UnverifiedRestaurantHoursPolicy(str, Enum):
     BLOCK = "block"
 
 
+class ScheduleState(str, Enum):
+    """Result of constructing a candidate itinerary from normalized facts."""
+
+    READY = "ready"
+    FAILED = "failed"
+
+
 @dataclass(frozen=True)
 class HardConstraint:
     """A non-negotiable planning condition, evaluated before soft scoring.
@@ -82,3 +89,37 @@ class PlannerOutput:
     def best_plan(self) -> CandidatePlan | None:
         successful = self.successful_plans
         return successful[0] if successful else None
+
+
+@dataclass(frozen=True)
+class SchedulingInput:
+    """Facts consumed by the deterministic multi-day scheduler.
+
+    ``trip`` is a Canonical Trip shell containing normalized candidates.  A
+    schedulable POI or restaurant must provide a ``schedule`` mapping with at
+    least ``duration_minutes`` and may provide ``day`` (one-based),
+    ``required``, ``fixed_start_at``, parking/walking buffers, and fatigue.
+    The scheduler deliberately rejects missing operational facts rather than
+    deriving them from a provider payload or a template.
+    """
+
+    trip: dict
+    validation_context: ValidationContext
+    daily_start: str = "09:00"
+    daily_end: str = "20:00"
+
+
+@dataclass(frozen=True)
+class ScheduledTrip:
+    trip: dict
+    state: ScheduleState
+    violations: tuple[Violation, ...]
+
+
+@dataclass(frozen=True)
+class SchedulingOutput:
+    candidates: tuple[ScheduledTrip, ...]
+
+    @property
+    def best_trip(self) -> ScheduledTrip | None:
+        return next((candidate for candidate in self.candidates if candidate.state is ScheduleState.READY), None)

--- a/src/planner/scheduler.py
+++ b/src/planner/scheduler.py
@@ -1,0 +1,170 @@
+"""Route-aware synthesis of Canonical Trip day plans from normalized facts."""
+
+from __future__ import annotations
+
+import copy
+from datetime import date, datetime, time, timedelta
+from typing import Iterable
+from zoneinfo import ZoneInfo
+
+from src.validator import OpeningInterval, Violation
+
+from .contracts import ScheduledTrip, ScheduleState, SchedulingInput, SchedulingOutput
+
+
+def schedule(request: SchedulingInput) -> SchedulingOutput:
+    """Build one deterministic Candidate Trip without filling unknown facts.
+
+    Candidate facts are read only from the canonical candidate sets.  In
+    particular, an absent route, duration, or opening-hour interval is an
+    explicit failure, never a zero-minute/default assumption.
+    """
+    trip = copy.deepcopy(request.trip)
+    violations: list[Violation] = []
+    start, end = _date_range(trip, violations)
+    hotel_id = _hotel_id(trip, violations)
+    activities = _activities(trip, violations)
+    if violations or start is None or end is None or hotel_id is None:
+        return SchedulingOutput((ScheduledTrip(trip, ScheduleState.FAILED, tuple(violations)),))
+
+    days: list[dict] = []
+    total_days = (end - start).days + 1
+    for offset in range(total_days):
+        current = start + timedelta(days=offset)
+        planned, day_violations = _schedule_day(current, offset + 1, hotel_id, activities, request)
+        violations.extend(day_violations)
+        days.append({"date": current.isoformat(), "summary": "", "items": planned})
+    if violations:
+        return SchedulingOutput((ScheduledTrip(trip, ScheduleState.FAILED, tuple(violations)),))
+    trip["days"] = days
+    return SchedulingOutput((ScheduledTrip(trip, ScheduleState.READY, (),),))
+
+
+def _date_range(trip: dict, violations: list[Violation]) -> tuple[date | None, date | None]:
+    try:
+        dates = trip["date_range"]
+        start, end = date.fromisoformat(dates["start_date"]), date.fromisoformat(dates["end_date"])
+        if end < start:
+            raise ValueError
+        return start, end
+    except (KeyError, TypeError, ValueError):
+        violations.append(_failure("schedule.date_range_missing", "trip requires a valid explicit date range", "/date_range"))
+        return None, None
+
+
+def _hotel_id(trip: dict, violations: list[Violation]) -> str | None:
+    hotels = trip.get("selected", {}).get("hotel_place_ids", [])
+    if len(hotels) != 1 or not isinstance(hotels[0], str):
+        violations.append(_failure("schedule.hotel_missing", "exactly one selected hotel is required for daily routing", "/selected/hotel_place_ids"))
+        return None
+    return hotels[0]
+
+
+def _activities(trip: dict, violations: list[Violation]) -> list[dict]:
+    records: list[dict] = []
+    for collection in ("places", "restaurants"):
+        for index, candidate in enumerate(trip.get("candidate_sets", {}).get(collection, [])):
+            place = candidate.get("place", candidate) if collection == "restaurants" else candidate
+            details = candidate.get("schedule")
+            if not details or not details.get("selected", True):
+                continue
+            if not isinstance(details.get("duration_minutes"), int) or details["duration_minutes"] <= 0:
+                violations.append(_failure("schedule.duration_missing", "selected activity requires an explicit positive duration", f"/candidate_sets/{collection}/{index}/schedule/duration_minutes"))
+                continue
+            if not isinstance(place.get("id"), str):
+                violations.append(_failure("schedule.place_missing", "activity has no canonical place id", f"/candidate_sets/{collection}/{index}"))
+                continue
+            day = details.get("day")
+            if day is not None and (not isinstance(day, int) or day < 1):
+                violations.append(_failure("schedule.day_invalid", "activity day must be a positive integer", f"/candidate_sets/{collection}/{index}/schedule/day"))
+                continue
+            if (details.get("fixed_start_at") is None) != (details.get("fixed_end_at") is None):
+                violations.append(_failure("schedule.fixed_anchor_invalid", "fixed anchors require both start and end timestamps", f"/candidate_sets/{collection}/{index}/schedule"))
+                continue
+            if not isinstance(details.get("fatigue", 0), (int, float)) or details.get("fatigue", 0) < 0:
+                violations.append(_failure("schedule.fatigue_invalid", "fatigue must be a non-negative number", f"/candidate_sets/{collection}/{index}/schedule/fatigue"))
+                continue
+            records.append({"id": place["id"], "kind": "meal" if collection == "restaurants" else "visit", "schedule": details, "path": f"/candidate_sets/{collection}/{index}"})
+    return records
+
+
+def _schedule_day(current: date, day_number: int, hotel_id: str, activities: Iterable[dict], request: SchedulingInput) -> tuple[list[dict], list[Violation]]:
+    violations: list[Violation] = []
+    selected = [activity for activity in activities if activity["schedule"].get("day") in (None, day_number)]
+    # Day-specific required activities must never be moved to a different date.
+    selected = [activity for activity in selected if activity["schedule"].get("day") == day_number or activity["schedule"].get("required", False)]
+    if not selected:
+        return [], violations
+    try:
+        zone = ZoneInfo(request.trip["local_timezone"])
+        cursor = datetime.combine(current, time.fromisoformat(request.daily_start), zone)
+        closes = datetime.combine(current, time.fromisoformat(request.daily_end), zone)
+    except (KeyError, ValueError):
+        return [], [_failure("schedule.daily_window_invalid", "daily start/end must be HH:MM", "/")]
+    previous = hotel_id
+    items: list[dict] = []
+    low_fatigue = any(preference.get("kind") in {"low_fatigue", "pace"} and preference.get("value") in {True, "low"}
+                      for preference in request.trip.get("preferences", {}).get("soft_preferences", []))
+    for activity in sorted(selected, key=lambda value: (
+        not value["schedule"].get("required", False),
+        value["schedule"].get("fatigue", 0) if low_fatigue else 0,
+        value["id"],
+    )):
+        details = activity["schedule"]
+        travel = request.validation_context.travel_minutes.get((previous, activity["id"]))
+        if travel is None:
+            violations.append(_failure("schedule.route_unknown", f"route from {previous} to {activity['id']} is required", activity["path"]))
+            continue
+        if travel < 0:
+            violations.append(_failure("schedule.route_invalid", "route duration cannot be negative", activity["path"]))
+            continue
+        buffers = details.get("parking_buffer_minutes", 0) + details.get("walking_buffer_minutes", 0)
+        if not isinstance(buffers, int) or buffers < 0:
+            violations.append(_failure("schedule.buffer_invalid", "parking/walking buffers must be non-negative integers", activity["path"]))
+            continue
+        cursor += timedelta(minutes=travel + buffers)
+        fixed = details.get("fixed_start_at")
+        if fixed:
+            try:
+                fixed_start = datetime.fromisoformat(fixed)
+            except ValueError:
+                violations.append(_failure("schedule.fixed_time_invalid", "fixed_start_at must be ISO-8601", activity["path"]))
+                continue
+            if fixed_start.date() != current or fixed_start < cursor:
+                violations.append(_failure("schedule.fixed_anchor_infeasible", "confirmed anchor cannot be reached without moving it", activity["path"]))
+                continue
+            cursor = fixed_start
+        end_at = cursor + timedelta(minutes=details["duration_minutes"])
+        fixed_end = details.get("fixed_end_at")
+        if fixed_end:
+            try:
+                confirmed_end = datetime.fromisoformat(fixed_end)
+            except ValueError:
+                violations.append(_failure("schedule.fixed_time_invalid", "fixed_end_at must be ISO-8601", activity["path"]))
+                continue
+            if confirmed_end != end_at:
+                violations.append(_failure("schedule.fixed_anchor_infeasible", "confirmed anchor end cannot be moved or re-durationed", activity["path"]))
+                continue
+        if end_at > closes or not _is_open(activity["id"], cursor, end_at, request):
+            violations.append(_failure("schedule.closed_or_unverified", "activity lacks a verified open interval for its scheduled time", activity["path"]))
+            continue
+        items.append({"id": f"day{day_number}-{activity['id']}", "kind": activity["kind"], "place_id": activity["id"], "start_at": cursor.isoformat(), "end_at": end_at.isoformat(), "selection_status": "selected"})
+        previous, cursor = activity["id"], end_at
+    if items:
+        back = request.validation_context.travel_minutes.get((previous, hotel_id))
+        if back is None:
+            violations.append(_failure("schedule.route_unknown", f"route from {previous} to {hotel_id} is required for daily hotel consistency", "/days"))
+        elif cursor + timedelta(minutes=back) > closes:
+            violations.append(_failure("schedule.hotel_return_infeasible", "cannot return to selected hotel within daily end", "/days"))
+    return items, violations
+
+
+def _is_open(place_id: str, start: datetime, end: datetime, request: SchedulingInput) -> bool:
+    intervals = request.validation_context.opening_hours.get(place_id)
+    if not intervals:
+        return False
+    return any(interval.weekday == start.weekday() and interval.opens_at <= start.time() and end.time() <= interval.closes_at for interval in intervals)
+
+
+def _failure(code: str, message: str, path: str) -> Violation:
+    return Violation(code, "error", message, path)

--- a/src/planner/scheduler.py
+++ b/src/planner/scheduler.py
@@ -27,13 +27,20 @@ def schedule(request: SchedulingInput) -> SchedulingOutput:
     if violations or start is None or end is None or hotel_id is None:
         return SchedulingOutput((ScheduledTrip(trip, ScheduleState.FAILED, tuple(violations)),))
 
+    anchors_by_date = _anchors(trip, violations)
     days: list[dict] = []
+    unscheduled = {activity["id"] for activity in activities if activity["schedule"].get("day") is None}
     total_days = (end - start).days + 1
     for offset in range(total_days):
         current = start + timedelta(days=offset)
-        planned, day_violations = _schedule_day(current, offset + 1, hotel_id, activities, request)
+        planned, day_violations, placed = _schedule_day(
+            current, offset + 1, hotel_id, activities, anchors_by_date.get(current.isoformat(), ()), unscheduled, request,
+        )
         violations.extend(day_violations)
+        unscheduled.difference_update(placed)
         days.append({"date": current.isoformat(), "summary": "", "items": planned})
+    for activity_id in unscheduled:
+        violations.append(_failure("schedule.no_feasible_day", f"required activity {activity_id} has no feasible day", "/candidate_sets"))
     if violations:
         return SchedulingOutput((ScheduledTrip(trip, ScheduleState.FAILED, tuple(violations)),))
     trip["days"] = days
@@ -88,21 +95,54 @@ def _activities(trip: dict, violations: list[Violation]) -> list[dict]:
     return records
 
 
-def _schedule_day(current: date, day_number: int, hotel_id: str, activities: Iterable[dict], request: SchedulingInput) -> tuple[list[dict], list[Violation]]:
+def _anchors(trip: dict, violations: list[Violation]) -> dict[str, tuple[dict, ...]]:
+    """Retain confirmed operational items already present in the Canonical Trip."""
+    anchors: dict[str, tuple[dict, ...]] = {}
+    for day_index, day in enumerate(trip.get("days", [])):
+        current_date = day.get("date")
+        if not isinstance(current_date, str):
+            violations.append(_failure("schedule.anchor_date_missing", "existing DayPlan anchor lacks a date", f"/days/{day_index}/date"))
+            continue
+        items = []
+        for item_index, item in enumerate(day.get("items", [])):
+            if item.get("kind") in {"visit", "meal"}:
+                continue
+            try:
+                datetime.fromisoformat(item["start_at"])
+                datetime.fromisoformat(item["end_at"])
+                if not item.get("place_id"):
+                    raise ValueError
+            except (KeyError, TypeError, ValueError):
+                violations.append(_failure("schedule.anchor_invalid", "confirmed anchor requires place and timestamps", f"/days/{day_index}/items/{item_index}"))
+                continue
+            items.append(copy.deepcopy(item))
+        anchors[current_date] = tuple(sorted(items, key=lambda item: item["start_at"]))
+    return anchors
+
+
+def _schedule_day(current: date, day_number: int, hotel_id: str, activities: Iterable[dict], anchors: Iterable[dict], unscheduled: set[str], request: SchedulingInput) -> tuple[list[dict], list[Violation], set[str]]:
     violations: list[Violation] = []
-    selected = [activity for activity in activities if activity["schedule"].get("day") in (None, day_number)]
-    # Day-specific required activities must never be moved to a different date.
-    selected = [activity for activity in selected if activity["schedule"].get("day") == day_number or activity["schedule"].get("required", False)]
-    if not selected:
-        return [], violations
+    selected = [activity for activity in activities if activity["schedule"].get("day") == day_number]
+    # An unassigned required activity is tried once, then removed only after it
+    # was actually placed.  It is never duplicated across five daily plans.
+    selected.extend(activity for activity in activities if activity["id"] in unscheduled and activity["schedule"].get("required", False))
+    if not selected and not tuple(anchors):
+        return [], violations, set()
     try:
         zone = ZoneInfo(request.trip["local_timezone"])
         cursor = datetime.combine(current, time.fromisoformat(request.daily_start), zone)
         closes = datetime.combine(current, time.fromisoformat(request.daily_end), zone)
     except (KeyError, ValueError):
-        return [], [_failure("schedule.daily_window_invalid", "daily start/end must be HH:MM", "/")]
-    previous = hotel_id
-    items: list[dict] = []
+        return [], [_failure("schedule.daily_window_invalid", "daily start/end must be HH:MM", "/")], set()
+    anchor_items = list(anchors)
+    previous, items = hotel_id, []
+    if anchor_items:
+        # Anchors are immutable.  Activities are placed only after the last
+        # confirmed arrival/check-in/reservation boundary for that day.
+        items.extend(anchor_items)
+        previous = anchor_items[-1]["place_id"]
+        cursor = datetime.fromisoformat(anchor_items[-1]["end_at"])
+    placed: set[str] = set()
     low_fatigue = any(preference.get("kind") in {"low_fatigue", "pace"} and preference.get("value") in {True, "low"}
                       for preference in request.trip.get("preferences", {}).get("soft_preferences", []))
     for activity in sorted(selected, key=lambda value: (
@@ -150,13 +190,15 @@ def _schedule_day(current: date, day_number: int, hotel_id: str, activities: Ite
             continue
         items.append({"id": f"day{day_number}-{activity['id']}", "kind": activity["kind"], "place_id": activity["id"], "start_at": cursor.isoformat(), "end_at": end_at.isoformat(), "selection_status": "selected"})
         previous, cursor = activity["id"], end_at
-    if items:
+        if activity["schedule"].get("day") is None:
+            placed.add(activity["id"])
+    if placed or any(activity["schedule"].get("day") == day_number for activity in selected):
         back = request.validation_context.travel_minutes.get((previous, hotel_id))
         if back is None:
             violations.append(_failure("schedule.route_unknown", f"route from {previous} to {hotel_id} is required for daily hotel consistency", "/days"))
         elif cursor + timedelta(minutes=back) > closes:
             violations.append(_failure("schedule.hotel_return_infeasible", "cannot return to selected hotel within daily end", "/days"))
-    return items, violations
+    return items, violations, placed
 
 
 def _is_open(place_id: str, start: datetime, end: datetime, request: SchedulingInput) -> bool:

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -220,6 +220,18 @@ class PlannerTests(unittest.TestCase):
         self.assertEqual(item["start_at"], "2026-04-10T12:00:00+09:00")
         self.assertEqual(item["end_at"], "2026-04-10T13:00:00+09:00")
 
+    def test_scheduler_preserves_existing_arrival_and_checkin_anchors(self):
+        trip = copy.deepcopy(self.trip)
+        trip["candidate_sets"]["places"][3]["schedule"] = {"duration_minutes": 60, "day": 1, "required": True}
+        context = verified_context()
+        routes = {**context.travel_minutes, ("hakata-hotel", "ohori-park"): 20, ("ohori-park", "hakata-hotel"): 20}
+        candidate = schedule(SchedulingInput(trip, ValidationContext(routes, context.opening_hours))).best_trip
+        self.assertIsNotNone(candidate)
+        assert candidate is not None
+        day_one = candidate.trip["days"][0]["items"]
+        self.assertEqual([item["id"] for item in day_one[:2]], ["d1-arrival", "d1-checkin"])
+        self.assertGreaterEqual(day_one[2]["start_at"], "2026-04-10T15:50:00+09:00")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -8,9 +8,12 @@ from src.planner import (
     HardConstraint,
     PlanState,
     PlannerInput,
+    ScheduleState,
+    SchedulingInput,
     SoftPreference,
     UnverifiedRestaurantHoursPolicy,
     plan,
+    schedule,
 )
 from src.validator import BudgetLimit, OpeningInterval, ValidationContext
 
@@ -165,6 +168,57 @@ class PlannerTests(unittest.TestCase):
         self.assertIsNone(result.best_plan)
         violation = next(item for item in result.plans[0].violations if item.code == "opening_hours.unverified")
         self.assertEqual(violation.severity, "error")
+
+    def test_scheduler_builds_five_day_route_aware_plan_and_preserves_day_assignments(self):
+        trip = copy.deepcopy(self.trip)
+        trip["days"] = []
+        for index, place in enumerate(trip["candidate_sets"]["places"]):
+            if place["id"] in {"tpe", "fuk", "hakata-hotel", "ramen-shop"}:
+                continue
+            place["schedule"] = {"duration_minutes": 90, "day": index - 2, "required": True, "parking_buffer_minutes": 10, "walking_buffer_minutes": 5}
+        restaurant = trip["candidate_sets"]["restaurants"][0]
+        restaurant["schedule"] = {"duration_minutes": 60, "day": 2, "required": True}
+        context = verified_context()
+        routes = dict(context.travel_minutes)
+        hours = dict(context.opening_hours)
+        hours["ramen-shop"] = [OpeningInterval(weekday, time(8), time(22)) for weekday in range(7)]
+        for place_id in ("ohori-park", "dazaifu", "yufuin", "beppu", "canal-city", "ramen-shop"):
+            routes[("hakata-hotel", place_id)] = 20
+            routes[(place_id, "hakata-hotel")] = 20
+        routes[("dazaifu", "ramen-shop")] = 20
+        output = schedule(SchedulingInput(trip, ValidationContext(routes, hours, context.budget_limit)))
+        candidate = output.best_trip
+        self.assertIsNotNone(candidate)
+        assert candidate is not None
+        self.assertEqual(candidate.state, ScheduleState.READY)
+        self.assertEqual(len(candidate.trip["days"]), 5)
+        self.assertEqual(candidate.trip["days"][0]["items"][0]["place_id"], "ohori-park")
+        self.assertEqual(candidate.trip["days"][1]["items"][0]["place_id"], "dazaifu")
+
+    def test_scheduler_refuses_closed_or_unknown_operational_facts(self):
+        trip = copy.deepcopy(self.trip)
+        trip["days"] = []
+        trip["candidate_sets"]["places"][3]["schedule"] = {"duration_minutes": 120, "day": 1, "required": True}
+        result = schedule(SchedulingInput(trip, ValidationContext()))
+        self.assertIsNone(result.best_trip)
+        self.assertIn("schedule.route_unknown", {violation.code for violation in result.candidates[0].violations})
+
+    def test_scheduler_keeps_confirmed_reservation_time_unchanged(self):
+        trip = copy.deepcopy(self.trip)
+        trip["days"] = []
+        restaurant = trip["candidate_sets"]["restaurants"][0]
+        restaurant["schedule"] = {
+            "duration_minutes": 60, "day": 1, "required": True,
+            "fixed_start_at": "2026-04-10T12:00:00+09:00", "fixed_end_at": "2026-04-10T13:00:00+09:00",
+        }
+        hours = {"ramen-shop": [OpeningInterval(weekday, time(8), time(22)) for weekday in range(7)]}
+        routes = {("hakata-hotel", "ramen-shop"): 20, ("ramen-shop", "hakata-hotel"): 20}
+        candidate = schedule(SchedulingInput(trip, ValidationContext(routes, hours))).best_trip
+        self.assertIsNotNone(candidate)
+        assert candidate is not None
+        item = candidate.trip["days"][0]["items"][0]
+        self.assertEqual(item["start_at"], "2026-04-10T12:00:00+09:00")
+        self.assertEqual(item["end_at"], "2026-04-10T13:00:00+09:00")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 變更摘要

### 一句話摘要

新增只依 Canonical Trip normalized candidates 與明確 derived facts 排程的 deterministic multi-day scheduler。

### Issue 與 acceptance criteria

- Closes #33
- [x] 5 天 recorded scenario 產生完整 DayPlan
- [x] Day 1/Day 2 指定景點維持在指定日期
- [x] confirmed reservation 時間不可變動
- [x] 每日 routing 必須含 selected hotel 出發與返回
- [x] route duration 與 parking/walking buffer 納入
- [x] closed 或 unknown opening-hours 的 POI/restaurant 不會排入
- [x] low-fatigue preference 以顯式 fatigue signal 影響順序
- [x] 無可行解會回傳 explicit failed output
- [x] 測試全為 deterministic，未呼叫 live API

### Agent workspace

- Branch：`agent/issue-33-multi-day-scheduler`
- Worktree：`../.worktrees/ai-travel-planner/issue-33-multi-day-scheduler`
- Declared write ownership：`src/planner/**`、`src/application/production.py`、`tests/test_planner.py`、`tests/test_recorded_japan_e2e.py`、`tests/fixtures/planner/**`
- [x] `python3 -m scripts.agent.collaboration check 33` 通過
- [x] Actual changed files 全部位於 declared write ownership

### 風險與角色

- Risk：`high`
- Implementation roles：`core.explorer`、`core.architect`、`core.planner`、`core.executor`、`core.test-engineer`
- Independent review roles：`core.spec-reviewer`、`core.code-reviewer`、`core.verifier`
- Domain reviewers：`domain.itinerary-invariant-reviewer`

### Exact evidence

- Base SHA：`c7090773d33f5e7434f0c14ab21e2d27b698d076`
- Exact head SHA：`b1dcd2c38a49ed915353d9ef8b01bb5d8544a59f`
- Local test commands and results：`python3 -m unittest tests.test_planner -v` PASS (12); `python3 -m unittest discover -s tests -v` PASS (62); `python3 scripts/validate_agent_collaboration.py` PASS
- [x] Handoff evidence 綁定目前 pushed exact head SHA
- [x] PR 是 regular non-Draft 狀態
- [ ] 沒有未解決的 blocking finding

### Project correctness gates

- [x] Canonical Trip 仍是唯一 source of truth
- [x] Provider raw payload 未進入 planner/canonical model
- [x] Unknown route 未視為 0 分鐘
- [x] Unknown opening hours 未視為營業
- [x] Deterministic validator 仍是 final correctness gate
- [x] API credential 未出現在 log、Trip JSON 或 rendered HTML

### CI

- [ ] `framework`
- [ ] `python`
- [ ] `website`

### Merge boundary

- [x] 本 PR 不使用自動 merge；由使用者或已授權流程決定合併