### PR TITLE
fix: complete restaurant credit and location evidence

### DIFF
--- a/docs/restaurant-intelligence.md
+++ b/docs/restaurant-intelligence.md
@@ -55,6 +55,11 @@ or other quality/discovery scalars; provider/community evidence wins those
 fields and conflicting values remain alternatives. Contradictory facts at the same winning
 authority become `conflicting`, which blocks meal selection.
 
+Legacy aggregate `rating`, `rating_source`, and `review_count` are selected as
+one source bundle so a count can never be attached to another provider's
+rating. Reconciliation is audit-idempotent: existing source provenance is
+expanded and fact alternatives are stable-key deduplicated on repeated runs.
+
 Aggregate restaurant ratings are separate from dish evidence. Every rating
 retains its original minimum/maximum scale; review count is retained when the
 provider supplies it and otherwise remains absent rather than becoming zero.

--- a/docs/restaurant-intelligence.md
+++ b/docs/restaurant-intelligence.md
@@ -50,7 +50,9 @@ place ID; the system never merges by a weak name match. Fresh official
 operational facts take priority over provider facts. Lower-authority facts and
 all source provenance remain auditable. The location-rich place record remains
 source-coherent with its own provenance rather than relabeling copied provider
-coordinates as official. Contradictory facts at the same winning
+coordinates as official. Official priority does not extend to rating, cuisine,
+or other quality/discovery scalars; provider/community evidence wins those
+fields and conflicting values remain alternatives. Contradictory facts at the same winning
 authority become `conflicting`, which blocks meal selection.
 
 Aggregate restaurant ratings are separate from dish evidence. Every rating

--- a/docs/restaurant-intelligence.md
+++ b/docs/restaurant-intelligence.md
@@ -41,12 +41,16 @@ production environment. The adapter maps documented genre, dinner budget,
 open/close note, child, non-smoking, parking, and canonical URL fields. Its
 free-text hours never become structured/fresh. Applications displaying its data
 must show `Powered by ホットペッパーグルメ Webサービス`.
+The text label links to `http://webservice.recruit.co.jp/` as required by the
+provider's published credit HTML.
 
 `OfficialRestaurantFeedAdapter` is the normalized seam for restaurant-operated
 feeds or CMS exports. Every record must declare an existing canonical lowercase
 place ID; the system never merges by a weak name match. Fresh official
 operational facts take priority over provider facts. Lower-authority facts and
-all source provenance remain auditable. Contradictory facts at the same winning
+all source provenance remain auditable. The location-rich place record remains
+source-coherent with its own provenance rather than relabeling copied provider
+coordinates as official. Contradictory facts at the same winning
 authority become `conflicting`, which blocks meal selection.
 
 Aggregate restaurant ratings are separate from dish evidence. Every rating

--- a/src/renderer/build_site.py
+++ b/src/renderer/build_site.py
@@ -28,7 +28,7 @@ def build_site(trip: dict[str, Any], derived: dict[str, Any] | None = None) -> s
     budget = "".join(f"<tr><th>{escape(str(k))}</th><td>{escape(_money(v))}</td></tr>" for k, v in trip.get("budget", {}).get("categories", {}).items())
     total = derived.get("budget", {}).get("total_label") or _money(trip.get("budget", {}).get("total", {}))
     sources = "".join(_render_source(x) for x in _sources(trip)) or '<p class="quiet">沒有未確認來源資料。</p>'
-    attributions = "".join(f'<p class="attribution">{escape(value)}</p>' for value in _attributions(trip))
+    attributions = "".join(_render_attribution(value) for value in _attributions(trip))
     return f'''<!doctype html><html lang="zh-Hant"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>{title}</title><style>{_CSS}</style></head><body><main>
 <header><p class="eyebrow">TRIP · {escape(trip.get("local_timezone", ""))}</p><h1>{title}</h1><div class="stats">{stats}</div></header>
 <nav aria-label="行程區段"><a href="#overview">總覽</a><a href="#itinerary">行程</a><a href="#budget">預算</a></nav>
@@ -56,6 +56,16 @@ def _attributions(trip: dict[str, Any]) -> list[str]:
         if isinstance(candidate_values, list):
             values.extend(value for value in candidate_values if isinstance(value, str) and value)
     return list(dict.fromkeys(values))
+
+
+def _render_attribution(value: str) -> str:
+    if value == _HOTPEPPER_ATTRIBUTION:
+        return (
+            '<p class="attribution">Powered by '
+            '<a href="http://webservice.recruit.co.jp/">'
+            'ホットペッパーグルメ Webサービス</a></p>'
+        )
+    return f'<p class="attribution">{escape(value)}</p>'
 
 
 def _render_source(item: dict[str, Any]) -> str:
@@ -91,6 +101,8 @@ def main() -> None:
 _CSS = '''
 :root{--ink:#172033;--muted:#5d6779;--line:#dce1e9;--accent:#0b6e69}*{box-sizing:border-box}body{margin:0;background:#f3f6f8;color:var(--ink);font:16px/1.5 -apple-system,BlinkMacSystemFont,"Noto Sans TC",sans-serif}main{max-width:680px;margin:auto;padding:20px 16px 48px}header,section,article{background:#fff;border:1px solid var(--line);border-radius:16px}header,section{padding:20px;margin-bottom:14px}h1{font-size:28px;line-height:1.2;margin:4px 0 18px}h2{font-size:21px;margin:0 0 16px}h3{font-size:17px;margin:12px 0 8px}.eyebrow{color:var(--muted);font-size:12px;font-weight:700;letter-spacing:.06em;margin:0}.stats{display:grid;gap:8px}.stat{background:#eaf5f3;border-radius:10px;padding:10px 12px}.stat span,.stat strong{display:block}.stat span,.hint,.quiet,.source p,.attribution{color:var(--muted);font-size:14px}nav{display:flex;gap:8px;overflow:auto;position:sticky;top:0;padding:8px 0;background:#f3f6f8;z-index:1}nav a{background:#fff;border:1px solid var(--line);border-radius:999px;color:var(--ink);padding:7px 13px;text-decoration:none;white-space:nowrap}ul,ol{padding-left:20px}.warnings li{color:#9a5200;margin:6px 0}.warnings .quiet{color:var(--muted)}article{padding:14px;margin:10px 0}article h3{margin-top:3px}ol{list-style:none;padding:0;margin:10px 0 0}ol li{display:grid;grid-template-columns:56px 1fr;gap:3px 10px;border-top:1px solid var(--line);padding:10px 0}ol li:first-child{border-top:0}time,ol span{color:var(--muted);font-size:14px}ol span{grid-column:2}.source{display:grid;grid-template-columns:1fr auto;gap:2px 8px}.source p{grid-column:1/-1;margin:2px 0 0}.attribution{margin:12px 0 0}.badge{color:#704400;background:#fff1d6;border-radius:999px;font-size:12px;font-weight:700;padding:2px 8px}table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid var(--line);padding:10px 0;text-align:left}td{text-align:right}tfoot{font-weight:800}@media(max-width:390px){main{padding:12px 10px 32px}header,section{padding:16px}h1{font-size:25px}}
 '''
+
+_HOTPEPPER_ATTRIBUTION = "Powered by ホットペッパーグルメ Webサービス"
 
 
 if __name__ == "__main__": main()

--- a/src/restaurant_intelligence.py
+++ b/src/restaurant_intelligence.py
@@ -107,15 +107,10 @@ def reconcile_restaurant_candidates(candidates: Iterable[Mapping[str, object]]) 
 def _reconcile_group(group: Sequence[Mapping[str, object]]) -> dict[str, object]:
     ranked = sorted(group, key=lambda item: (_authority(item), _freshness(item)))
     result = _deep_copy_candidate(ranked[0])
-    result_place = result.get("place")
-    if isinstance(result_place, dict):
-        for candidate in ranked[1:]:
-            source_place = candidate.get("place")
-            if not isinstance(source_place, Mapping):
-                continue
-            for field in ("address", "coordinates", "opening_hours_note", "accessibility_notes"):
-                if field not in result_place and field in source_place:
-                    result_place[field] = _copy_value(source_place[field])
+    place_sources = [candidate for candidate in ranked if isinstance(candidate.get("place"), Mapping)]
+    if place_sources:
+        place_source = min(place_sources, key=_place_rank)
+        result["place"] = _copy_value(place_source["place"])
     source_provenance = _unique_provenance(ranked)
     if source_provenance:
         result["source_provenance"] = source_provenance
@@ -177,6 +172,24 @@ def _authority(candidate: Mapping[str, object]) -> int:
     return {"official": 0, "provider": 1, "community": 2, "derived": 3, "user_input": 4}.get(
         str(_provenance(candidate).get("source_type")), 99
     )
+
+
+def _place_rank(candidate: Mapping[str, object]) -> tuple[int, int, int]:
+    """Keep one source-coherent place record, preferring routing coordinates."""
+
+    place = candidate.get("place")
+    if not isinstance(place, Mapping):
+        return 1, 1, _authority(candidate)
+    coordinates = place.get("coordinates")
+    has_coordinates = (
+        isinstance(coordinates, Mapping)
+        and isinstance(coordinates.get("latitude"), (int, float))
+        and not isinstance(coordinates.get("latitude"), bool)
+        and isinstance(coordinates.get("longitude"), (int, float))
+        and not isinstance(coordinates.get("longitude"), bool)
+    )
+    has_address = isinstance(place.get("address"), str) and bool(place["address"])
+    return int(not has_coordinates), int(not has_address), _authority(candidate)
 
 
 def _freshness(candidate: Mapping[str, object]) -> int:

--- a/src/restaurant_intelligence.py
+++ b/src/restaurant_intelligence.py
@@ -106,7 +106,7 @@ def reconcile_restaurant_candidates(candidates: Iterable[Mapping[str, object]]) 
 
 def _reconcile_group(group: Sequence[Mapping[str, object]]) -> dict[str, object]:
     ranked = sorted(group, key=lambda item: (_authority(item), _freshness(item)))
-    result = _deep_copy_candidate(ranked[0])
+    result: dict[str, object] = {"provenance": _copy_value(_provenance(ranked[0]))}
     place_sources = [candidate for candidate in ranked if isinstance(candidate.get("place"), Mapping)]
     if place_sources:
         place_source = min(place_sources, key=_place_rank)
@@ -115,6 +115,14 @@ def _reconcile_group(group: Sequence[Mapping[str, object]]) -> dict[str, object]
     if source_provenance:
         result["source_provenance"] = source_provenance
     alternatives: list[dict[str, object]] = []
+    for candidate in ranked:
+        candidate_alternatives = candidate.get("alternatives")
+        if isinstance(candidate_alternatives, Sequence) and not isinstance(candidate_alternatives, (str, bytes)):
+            alternatives.extend(
+                dict(_copy_value(alternative))
+                for alternative in candidate_alternatives
+                if isinstance(alternative, Mapping)
+            )
     operational = (
         "opening_hours", "reservation_required", "reservation_url", "child_friendly",
         "smoking_policy", "parking_available", "business_status",
@@ -145,7 +153,7 @@ def _reconcile_group(group: Sequence[Mapping[str, object]]) -> dict[str, object]
         for source in sources[1:]:
             if _fact_value(source[field]) != _fact_value(result[field]):
                 alternatives.append({"field": field, "value": _copy_value(source[field]), "provenance": dict(_provenance(source))})
-    for candidate in ranked[1:]:
+    for candidate in ranked:
         for field in ("ratings", "meal_price_signals", "recommended_dishes"):
             if isinstance(candidate.get(field), list):
                 existing = result.setdefault(field, [])
@@ -153,9 +161,19 @@ def _reconcile_group(group: Sequence[Mapping[str, object]]) -> dict[str, object]
                     for value in candidate[field]:
                         if _stable_value(value) not in {_stable_value(item) for item in existing}:
                             existing.append(_copy_value(value))
-        for field in ("rating", "rating_source", "review_count", "cuisine", "price_range", "wait_risk"):
-            if field not in result and field in candidate:
-                result[field] = _copy_value(candidate[field])
+    quality = ("rating", "rating_source", "review_count", "cuisine", "price_range", "wait_risk")
+    for field in quality:
+        sources = sorted((candidate for candidate in ranked if field in candidate), key=lambda item: _quality_rank(item, field))
+        if not sources:
+            continue
+        result[field] = _copy_value(sources[0][field])
+        for source in sources[1:]:
+            if _fact_value(source[field]) != _fact_value(result[field]):
+                alternatives.append({
+                    "field": field,
+                    "value": _copy_value(source[field]),
+                    "provenance": dict(_provenance(source)),
+                })
     attributions: list[str] = []
     for candidate in ranked:
         values = candidate.get("attributions")
@@ -190,6 +208,15 @@ def _place_rank(candidate: Mapping[str, object]) -> tuple[int, int, int]:
     )
     has_address = isinstance(place.get("address"), str) and bool(place["address"])
     return int(not has_coordinates), int(not has_address), _authority(candidate)
+
+
+def _quality_rank(candidate: Mapping[str, object], field: str) -> tuple[int, int]:
+    """Prefer discovery evidence for quality fields; official priority is operational."""
+
+    source_type = str(_provenance(candidate).get("source_type"))
+    authority = {"provider": 0, "community": 1, "official": 2, "derived": 3, "user_input": 4}.get(source_type, 99)
+    unknown = field == "wait_risk" and candidate.get(field) == "unknown"
+    return int(unknown), authority
 
 
 def _freshness(candidate: Mapping[str, object]) -> int:

--- a/src/restaurant_intelligence.py
+++ b/src/restaurant_intelligence.py
@@ -161,7 +161,33 @@ def _reconcile_group(group: Sequence[Mapping[str, object]]) -> dict[str, object]
                     for value in candidate[field]:
                         if _stable_value(value) not in {_stable_value(item) for item in existing}:
                             existing.append(_copy_value(value))
-    quality = ("rating", "rating_source", "review_count", "cuisine", "price_range", "wait_risk")
+    rating_bundle = ("rating", "rating_source", "review_count")
+    rating_sources = sorted((candidate for candidate in ranked if "rating" in candidate), key=lambda item: _quality_rank(item, "rating"))
+    if rating_sources:
+        selected_rating = rating_sources[0]
+        for field in rating_bundle:
+            if field in selected_rating:
+                result[field] = _copy_value(selected_rating[field])
+        for source in rating_sources[1:]:
+            for field in rating_bundle:
+                if field in source and (field not in result or _fact_value(source[field]) != _fact_value(result[field])):
+                    alternatives.append({
+                        "field": field,
+                        "value": _copy_value(source[field]),
+                        "provenance": dict(_provenance(source)),
+                    })
+    else:
+        count_sources = sorted((candidate for candidate in ranked if "review_count" in candidate), key=lambda item: _quality_rank(item, "review_count"))
+        if count_sources:
+            result["review_count"] = _copy_value(count_sources[0]["review_count"])
+            for source in count_sources[1:]:
+                if _fact_value(source["review_count"]) != _fact_value(result["review_count"]):
+                    alternatives.append({
+                        "field": "review_count",
+                        "value": _copy_value(source["review_count"]),
+                        "provenance": dict(_provenance(source)),
+                    })
+    quality = ("cuisine", "price_range", "wait_risk")
     for field in quality:
         sources = sorted((candidate for candidate in ranked if field in candidate), key=lambda item: _quality_rank(item, field))
         if not sources:
@@ -182,7 +208,7 @@ def _reconcile_group(group: Sequence[Mapping[str, object]]) -> dict[str, object]
     if attributions:
         result["attributions"] = list(dict.fromkeys(attributions))
     if alternatives:
-        result["alternatives"] = alternatives
+        result["alternatives"] = _unique_alternatives(alternatives)
     return result
 
 
@@ -257,11 +283,36 @@ def _unique_provenance(candidates: Sequence[Mapping[str, object]]) -> list[dict[
     values: list[dict[str, object]] = []
     seen: set[str] = set()
     for candidate in candidates:
-        provenance = _provenance(candidate)
-        key = _stable_value(provenance)
-        if provenance and key not in seen:
+        provenance_values: list[Mapping[str, object]] = []
+        direct = _provenance(candidate)
+        if direct:
+            provenance_values.append(direct)
+        place = candidate.get("place")
+        if isinstance(place, Mapping) and isinstance(place.get("provenance"), Mapping):
+            provenance_values.append(place["provenance"])
+        nested = candidate.get("source_provenance")
+        if isinstance(nested, Sequence) and not isinstance(nested, (str, bytes)):
+            provenance_values.extend(value for value in nested if isinstance(value, Mapping))
+        for provenance in provenance_values:
+            key = _stable_value(provenance)
+            if key not in seen:
+                seen.add(key)
+                values.append(dict(provenance))
+    return values
+
+
+def _unique_alternatives(alternatives: Sequence[Mapping[str, object]]) -> list[dict[str, object]]:
+    values: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for alternative in alternatives:
+        key = _stable_value({
+            "field": alternative.get("field"),
+            "value": alternative.get("value"),
+            "provenance": alternative.get("provenance"),
+        })
+        if key not in seen:
             seen.add(key)
-            values.append(dict(provenance))
+            values.append(dict(alternative))
     return values
 
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -29,5 +29,13 @@ def test_renderer_displays_required_restaurant_attribution():
         "Powered by ホットペッパーグルメ Webサービス",
     ]
     html = build_site(trip)
-    assert "Powered by ホットペッパーグルメ Webサービス" in html
-    assert html.count("Powered by ホットペッパーグルメ Webサービス") == 1
+    assert 'Powered by <a href="http://webservice.recruit.co.jp/">ホットペッパーグルメ Webサービス</a>' in html
+    assert html.count("ホットペッパーグルメ Webサービス") == 1
+
+
+def test_renderer_escapes_unrecognized_restaurant_attribution():
+    trip = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    trip["candidate_sets"]["restaurants"][0]["attributions"] = ["<script>alert(1)</script>"]
+    html = build_site(trip)
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html

--- a/tests/test_restaurant_intelligence.py
+++ b/tests/test_restaurant_intelligence.py
@@ -146,8 +146,10 @@ def test_official_override_and_same_authority_conflict_are_auditable():
     provider["place"]["address"] = "福岡市中央区"
     provider["place"]["coordinates"] = {"latitude": 33.59, "longitude": 130.40}
     provider["attributions"] = ["Provider credit"]
+    provider.update({"rating": 4.7, "rating_source": "Google Places", "review_count": 120, "cuisine": "ramen"})
     official_source = {**PROVENANCE, "source_type": "official", "provider": "Restaurant official site"}
     official = candidate(provenance=official_source, intervals=[{"weekday": 2, "opens_at": "17:00", "closes_at": "20:00"}])
+    official.update({"rating": 1.0, "rating_source": "self_claimed", "review_count": 1, "cuisine": "official category"})
     reconciled = reconcile_restaurant_candidates([provider, official])[0]
     assert reconciled["opening_hours"]["intervals"][0]["opens_at"] == "17:00"
     assert len(reconciled["source_provenance"]) == 2
@@ -156,6 +158,11 @@ def test_official_override_and_same_authority_conflict_are_auditable():
     assert reconciled["place"]["coordinates"] == {"latitude": 33.59, "longitude": 130.40}
     assert reconciled["place"]["provenance"]["provider"] == "recorded"
     assert reconciled["attributions"] == ["Provider credit"]
+    assert (reconciled["rating"], reconciled["rating_source"], reconciled["review_count"], reconciled["cuisine"]) == (
+        4.7, "Google Places", 120, "ramen",
+    )
+    alternative_fields = {alternative["field"] for alternative in reconciled["alternatives"]}
+    assert {"rating", "rating_source", "review_count", "cuisine"} <= alternative_fields
 
     other_official = candidate(provenance={**official_source, "provider": "Official notice"})
     conflict = reconcile_restaurant_candidates([official, other_official])[0]

--- a/tests/test_restaurant_intelligence.py
+++ b/tests/test_restaurant_intelligence.py
@@ -172,6 +172,35 @@ def test_official_override_and_same_authority_conflict_are_auditable():
     assert len(reconcile_restaurant_candidates([candidate("one"), candidate("two")])) == 2
 
 
+def test_rating_bundle_and_reconciliation_audit_are_source_coherent_and_idempotent():
+    provider_a = candidate()
+    provider_a.update({"rating": 4.7, "rating_source": "Provider A"})
+    provider_b = candidate(provenance={**PROVENANCE, "provider": "Provider B"})
+    provider_b.update({"rating": 3.1, "rating_source": "Provider B", "review_count": 900})
+
+    bundled = reconcile_restaurant_candidates([provider_a, provider_b])[0]
+    assert (bundled["rating"], bundled["rating_source"]) == (4.7, "Provider A")
+    assert "review_count" not in bundled
+    provider_b_alternatives = {
+        item["field"]: item
+        for item in bundled["alternatives"]
+        if item["provenance"]["provider"] == "Provider B"
+    }
+    assert provider_b_alternatives["review_count"]["value"] == 900
+
+    official_source = {**PROVENANCE, "source_type": "official", "provider": "Restaurant official site"}
+    official = candidate(provenance=official_source, intervals=[{"weekday": 2, "opens_at": "17:00", "closes_at": "20:00"}])
+    official.update({"rating": 1.0, "rating_source": "self_claimed", "review_count": 1, "cuisine": "official category"})
+    provider_a.update({"review_count": 120, "cuisine": "ramen"})
+    first = reconcile_restaurant_candidates([provider_a, official])[0]
+    second = reconcile_restaurant_candidates([first, official])[0]
+    third = reconcile_restaurant_candidates([first])[0]
+    assert second["alternatives"] == first["alternatives"]
+    assert second["source_provenance"] == first["source_provenance"]
+    assert third["alternatives"] == first["alternatives"]
+    assert third["source_provenance"] == first["source_provenance"]
+
+
 def test_validator_uses_candidate_snapshot_as_direct_closed_fallback():
     trip = json.loads(FIXTURE.read_text(encoding="utf-8"))
     restaurant = candidate("ramen-shop", intervals=[])

--- a/tests/test_restaurant_intelligence.py
+++ b/tests/test_restaurant_intelligence.py
@@ -154,6 +154,7 @@ def test_official_override_and_same_authority_conflict_are_auditable():
     assert reconciled["alternatives"][0]["field"] == "opening_hours"
     assert reconciled["place"]["address"] == "福岡市中央区"
     assert reconciled["place"]["coordinates"] == {"latitude": 33.59, "longitude": 130.40}
+    assert reconciled["place"]["provenance"]["provider"] == "recorded"
     assert reconciled["attributions"] == ["Provider credit"]
 
     other_official = candidate(provenance={**official_source, "provider": "Official notice"})


### PR DESCRIPTION
Follow-up to #25 after PR #40 was merged while final independent review fixes were still in progress.

Closes #25

Exact head: `3dbe092161d2f69728a5a8339658431c8c9c641e`
Base: latest `main` integrated at PR creation.

This follow-up contains the final independent-review fixes:

- render the required Hot Pepper text credit with the provider-mandated Web Service link;
- keep the selected location-rich place record and its provenance together;
- limit official-source priority to operational facts; provider/community quality facts win, with conflicts retained as alternatives;
- select legacy rating/rating_source/review_count as one source bundle, leaving a missing count absent;
- preserve audit idempotence by expanding existing source provenance and stable-key deduplicating alternatives;
- add regressions for linking, escaping, location provenance, authority separation, partial multi-provider ratings, and repeated reconciliation.

Local verification:

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q` → 99 passed
- `PYTHONDONTWRITEBYTECODE=1 python3.13 -m unittest discover -s tests -q` → 67 tests, OK
- collaboration framework validation → PASS
- Draft 2020-12 schema and fixtures → PASS
- `git diff --check` → PASS

Regular non-Draft PR. No auto-merge.