### PR TITLE
fix: enforce dynamic conditions in scheduler

### DIFF
--- a/src/planner/scheduler.py
+++ b/src/planner/scheduler.py
@@ -42,10 +42,10 @@ def schedule(request: SchedulingInput) -> SchedulingOutput:
         days.append({"date": current.isoformat(), "summary": "", "items": planned})
     for activity_id in unscheduled:
         violations.append(_failure("schedule.no_feasible_day", f"required activity {activity_id} has no feasible day", "/candidate_sets"))
-    if violations:
+    if _has_errors(violations):
         return SchedulingOutput((ScheduledTrip(trip, ScheduleState.FAILED, tuple(violations)),))
     trip["days"] = days
-    return SchedulingOutput((ScheduledTrip(trip, ScheduleState.READY, (),),))
+    return SchedulingOutput((ScheduledTrip(trip, ScheduleState.READY, tuple(violations)),))
 
 
 def _date_range(trip: dict, violations: list[Violation]) -> tuple[date | None, date | None]:
@@ -144,6 +144,7 @@ def _schedule_day(current: date, day_number: int, hotel_id: str, activities: Ite
         previous = anchor_items[-1]["place_id"]
         cursor = datetime.fromisoformat(anchor_items[-1]["end_at"])
     placed: set[str] = set()
+    placed_activity = False
     low_fatigue = any(preference.get("kind") in {"low_fatigue", "pace"} and preference.get("value") in {True, "low"}
                       for preference in request.trip.get("preferences", {}).get("soft_preferences", []))
     for activity in sorted(selected, key=lambda value: (
@@ -189,15 +190,16 @@ def _schedule_day(current: date, day_number: int, hotel_id: str, activities: Ite
         if end_at > closes or not _is_open(activity["id"], cursor, end_at, request):
             violations.append(_failure("schedule.closed_or_unverified", "activity lacks a verified open interval for its scheduled time", activity["path"]))
             continue
-        condition_errors = _condition_errors(activity["id"], cursor, end_at, request, activity["path"])
-        if condition_errors:
-            violations.extend(condition_errors)
+        condition_findings = _condition_findings(activity["id"], cursor, end_at, request, activity["path"])
+        violations.extend(condition_findings)
+        if _has_errors(condition_findings):
             continue
         items.append({"id": f"day{day_number}-{activity['id']}", "kind": activity["kind"], "place_id": activity["id"], "start_at": cursor.isoformat(), "end_at": end_at.isoformat(), "selection_status": "selected"})
+        placed_activity = True
         previous, cursor = activity["id"], end_at
         if activity["schedule"].get("day") is None:
             placed.add(activity["id"])
-    if placed or any(activity["schedule"].get("day") == day_number for activity in selected):
+    if placed_activity:
         back = request.validation_context.travel_minutes.get((previous, hotel_id))
         if back is None:
             violations.append(_failure("schedule.route_unknown", f"route from {previous} to {hotel_id} is required for daily hotel consistency", "/days"))
@@ -213,17 +215,21 @@ def _is_open(place_id: str, start: datetime, end: datetime, request: SchedulingI
     return any(interval.weekday == start.weekday() and interval.opens_at <= start.time() and end.time() <= interval.closes_at for interval in intervals)
 
 
-def _condition_errors(place_id: str, start: datetime, end: datetime, request: SchedulingInput, path: str) -> list[Violation]:
+def _condition_findings(place_id: str, start: datetime, end: datetime, request: SchedulingInput, path: str) -> list[Violation]:
     context = request.validation_context
-    if context.condition_snapshot is None or context.condition_evaluated_at is None:
+    if context.condition_snapshot is None:
         return []
+    if context.condition_evaluated_at is None:
+        return [Violation("condition.unverified", "warning", "condition evaluated_at is required", path)]
     decision = evaluate_conditions(
         context.condition_snapshot, place_id, start, end,
         context.condition_evaluated_at, context.condition_policy,
     )
-    # Scheduler feasibility is binary: only evaluator errors reject a
-    # placement. Warnings and their soft penalties remain schedulable signals.
-    return [Violation(item.code, item.severity, item.message, path) for item in decision.findings if item.severity == "error"]
+    return [Violation(item.code, item.severity, item.message, path) for item in decision.findings]
+
+
+def _has_errors(violations: Iterable[Violation]) -> bool:
+    return any(item.severity == "error" for item in violations)
 
 
 def _failure(code: str, message: str, path: str) -> Violation:

--- a/src/planner/scheduler.py
+++ b/src/planner/scheduler.py
@@ -7,6 +7,7 @@ from datetime import date, datetime, time, timedelta
 from typing import Iterable
 from zoneinfo import ZoneInfo
 
+from src.conditions import evaluate_conditions
 from src.validator import OpeningInterval, Violation
 
 from .contracts import ScheduledTrip, ScheduleState, SchedulingInput, SchedulingOutput
@@ -188,6 +189,10 @@ def _schedule_day(current: date, day_number: int, hotel_id: str, activities: Ite
         if end_at > closes or not _is_open(activity["id"], cursor, end_at, request):
             violations.append(_failure("schedule.closed_or_unverified", "activity lacks a verified open interval for its scheduled time", activity["path"]))
             continue
+        condition_errors = _condition_errors(activity["id"], cursor, end_at, request, activity["path"])
+        if condition_errors:
+            violations.extend(condition_errors)
+            continue
         items.append({"id": f"day{day_number}-{activity['id']}", "kind": activity["kind"], "place_id": activity["id"], "start_at": cursor.isoformat(), "end_at": end_at.isoformat(), "selection_status": "selected"})
         previous, cursor = activity["id"], end_at
         if activity["schedule"].get("day") is None:
@@ -206,6 +211,19 @@ def _is_open(place_id: str, start: datetime, end: datetime, request: SchedulingI
     if not intervals:
         return False
     return any(interval.weekday == start.weekday() and interval.opens_at <= start.time() and end.time() <= interval.closes_at for interval in intervals)
+
+
+def _condition_errors(place_id: str, start: datetime, end: datetime, request: SchedulingInput, path: str) -> list[Violation]:
+    context = request.validation_context
+    if context.condition_snapshot is None or context.condition_evaluated_at is None:
+        return []
+    decision = evaluate_conditions(
+        context.condition_snapshot, place_id, start, end,
+        context.condition_evaluated_at, context.condition_policy,
+    )
+    # Scheduler feasibility is binary: only evaluator errors reject a
+    # placement. Warnings and their soft penalties remain schedulable signals.
+    return [Violation(item.code, item.severity, item.message, path) for item in decision.findings if item.severity == "error"]
 
 
 def _failure(code: str, message: str, path: str) -> Violation:

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,5 +1,6 @@
 import copy
 import json
+from dataclasses import replace
 from datetime import datetime, time, timedelta
 from pathlib import Path
 import unittest
@@ -16,7 +17,7 @@ from src.planner import (
     schedule,
 )
 from src.validator import BudgetLimit, OpeningInterval, ValidationContext
-from src.conditions import ConditionPolicy, load_condition_snapshot
+from src.conditions import ConditionPolicy, ConditionSnapshot, ConditionStatus, load_condition_snapshot
 
 
 ROOT = Path(__file__).parents[1]
@@ -260,7 +261,7 @@ class PlannerTests(unittest.TestCase):
         self.assertIsNone(result.best_plan)
         self.assertIn("condition.closure.closed", {item.code for item in result.plans[0].violations})
 
-    def _scheduler_condition_case(self, fixture, daily_start="09:00"):
+    def _scheduler_condition_case(self, fixture_or_snapshot, daily_start="09:00", evaluated_at="2026-04-10T09:00:00+09:00"):
         trip = copy.deepcopy(self.trip)
         trip["days"] = []
         ohori = next(place for place in trip["candidate_sets"]["places"] if place["id"] == "ohori-park")
@@ -271,8 +272,11 @@ class PlannerTests(unittest.TestCase):
                 ("ohori-park", "hakata-hotel"): 20,
             },
             opening_hours={"ohori-park": [OpeningInterval(weekday, time(8), time(22)) for weekday in range(7)]},
-            condition_snapshot=load_condition_snapshot(ROOT / f"fixtures/conditions/{fixture}.json"),
-            condition_evaluated_at=datetime.fromisoformat("2026-04-10T09:00:00+09:00"),
+            condition_snapshot=(
+                load_condition_snapshot(ROOT / f"fixtures/conditions/{fixture_or_snapshot}.json")
+                if isinstance(fixture_or_snapshot, str) else fixture_or_snapshot
+            ),
+            condition_evaluated_at=datetime.fromisoformat(evaluated_at) if evaluated_at else None,
             condition_policy=ConditionPolicy(max_age=timedelta(days=1)),
         )
         return schedule(SchedulingInput(trip, context, daily_start=daily_start))
@@ -281,6 +285,7 @@ class PlannerTests(unittest.TestCase):
         result = self._scheduler_condition_case("tide")
         self.assertIsNone(result.best_trip)
         self.assertIn("condition.tide.outside_window", {item.code for item in result.candidates[0].violations})
+        self.assertNotIn("schedule.route_unknown", {item.code for item in result.candidates[0].violations})
 
     def test_scheduler_accepts_tide_placement_inside_authoritative_window(self):
         result = self._scheduler_condition_case("tide", daily_start="09:10")
@@ -298,6 +303,26 @@ class PlannerTests(unittest.TestCase):
         assert candidate is not None
         self.assertEqual(candidate.state, ScheduleState.READY)
         self.assertEqual(candidate.trip["days"][1]["items"][0]["start_at"], "2026-04-11T09:20:00+09:00")
+        self.assertIn("condition.weather.risk", {item.code for item in candidate.violations})
+
+    def test_scheduler_keeps_stale_and_unknown_condition_warnings_visible(self):
+        stale = self._scheduler_condition_case("weather", evaluated_at="2026-04-11T09:00:01+09:00").best_trip
+        self.assertIsNotNone(stale)
+        assert stale is not None
+        self.assertIn("condition.stale", {item.code for item in stale.violations})
+
+        weather = load_condition_snapshot(ROOT / "fixtures/conditions/weather.json")
+        unknown = replace(weather.records[0], status=ConditionStatus.UNKNOWN)
+        unknown_candidate = self._scheduler_condition_case(ConditionSnapshot((unknown,))).best_trip
+        self.assertIsNotNone(unknown_candidate)
+        assert unknown_candidate is not None
+        self.assertIn("condition.unverified", {item.code for item in unknown_candidate.violations})
+
+    def test_scheduler_snapshot_without_evaluated_at_is_ready_but_unverified(self):
+        candidate = self._scheduler_condition_case("weather", evaluated_at=None).best_trip
+        self.assertIsNotNone(candidate)
+        assert candidate is not None
+        self.assertIn("condition.unverified", {item.code for item in candidate.violations})
 
 
 if __name__ == "__main__":

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -260,6 +260,45 @@ class PlannerTests(unittest.TestCase):
         self.assertIsNone(result.best_plan)
         self.assertIn("condition.closure.closed", {item.code for item in result.plans[0].violations})
 
+    def _scheduler_condition_case(self, fixture, daily_start="09:00"):
+        trip = copy.deepcopy(self.trip)
+        trip["days"] = []
+        ohori = next(place for place in trip["candidate_sets"]["places"] if place["id"] == "ohori-park")
+        ohori["schedule"] = {"duration_minutes": 60, "day": 2, "required": True}
+        context = ValidationContext(
+            travel_minutes={
+                ("hakata-hotel", "ohori-park"): 20,
+                ("ohori-park", "hakata-hotel"): 20,
+            },
+            opening_hours={"ohori-park": [OpeningInterval(weekday, time(8), time(22)) for weekday in range(7)]},
+            condition_snapshot=load_condition_snapshot(ROOT / f"fixtures/conditions/{fixture}.json"),
+            condition_evaluated_at=datetime.fromisoformat("2026-04-10T09:00:00+09:00"),
+            condition_policy=ConditionPolicy(max_age=timedelta(days=1)),
+        )
+        return schedule(SchedulingInput(trip, context, daily_start=daily_start))
+
+    def test_scheduler_rejects_tide_placement_outside_authoritative_window(self):
+        result = self._scheduler_condition_case("tide")
+        self.assertIsNone(result.best_trip)
+        self.assertIn("condition.tide.outside_window", {item.code for item in result.candidates[0].violations})
+
+    def test_scheduler_accepts_tide_placement_inside_authoritative_window(self):
+        result = self._scheduler_condition_case("tide", daily_start="09:10")
+        candidate = result.best_trip
+        self.assertIsNotNone(candidate)
+        assert candidate is not None
+        item = candidate.trip["days"][1]["items"][0]
+        self.assertEqual(item["start_at"], "2026-04-11T09:30:00+09:00")
+        self.assertEqual(candidate.state, ScheduleState.READY)
+
+    def test_scheduler_keeps_weather_soft_risk_schedulable(self):
+        result = self._scheduler_condition_case("weather")
+        candidate = result.best_trip
+        self.assertIsNotNone(candidate)
+        assert candidate is not None
+        self.assertEqual(candidate.state, ScheduleState.READY)
+        self.assertEqual(candidate.trip["days"][1]["items"][0]["start_at"], "2026-04-11T09:20:00+09:00")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 變更摘要

### 一句話摘要

補齊 PR #45 合併後，Issue #33 scheduler 對 dynamic conditions 的 deterministic 整合。

### Issue 與 acceptance criteria

- Follow-up to #31 and merged PR #45
- [x] Scheduler 不會將低潮限定景點排在 authoritative eligibility window 外
- [x] Severe closure condition error 阻止 READY placement
- [x] stale、unknown、缺 evaluated_at 均保留 unverified warning
- [x] Weather soft risk 保持可排程，不升級為 hard closure

### Agent workspace

- Branch：`agent/issue-31-dynamic-conditions`
- Worktree：`../.worktrees/ai-travel-planner/issue-31-dynamic-conditions`
- Declared write ownership：`src/planner/**`、`tests/test_planner.py`（包含於 Issue #31 ownership）
- [x] `python3 -m scripts.agent.collaboration check 31` 通過
- [x] Actual changed files 全部位於 declared write ownership

### 風險與角色

- Risk：`high`
- Independent review roles：core.spec-reviewer、core.code-reviewer、core.verifier
- Domain reviewers：domain.itinerary-invariant-reviewer

### Exact evidence

- Base SHA：`ecbd4c43eeb5cdd27e10fe9e1b753ea02740a026`
- Exact head SHA：`cbfd288b28f6d8cbfcbc6387ab9902b8d28fe379`
- `python3 -m unittest discover -s tests`：150 tests PASS
- `python3 -m pytest -q`：182 tests PASS
- `python3 scripts/validate_agent_collaboration.py`：PASS
- `git diff --check origin/main...HEAD`：PASS
- [ ] Handoff evidence 綁定目前 pushed exact head SHA
- [x] PR 是 regular non-Draft 狀態
- [ ] 沒有未解決的 blocking finding

### Project correctness gates

- [x] Deterministic validator/evaluator 仍是 final correctness gate
- [x] Unknown condition 未視為 safe
- [x] Weather soft risk 未轉為 hard closure
- [x] Provider raw payload 未進入 planner

### CI

- [ ] `framework`
- [ ] `python`
- [ ] `pytest`
- [ ] `website`

### Merge boundary

- [x] 本 PR 不使用自動 merge；由使用者或已授權流程決定合併
