### PR TITLE
fix(issue-52): fix Awaji trip path assets on GitHub Pages

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build --base /trips/awaji-2026/",
+    "build": "tsc && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "echo \"lint: skipped\"",

--- a/web/public/404.html
+++ b/web/public/404.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="refresh" content="0;url=/trips/awaji-2026/" />
+    <meta http-equiv="refresh" content="0;url=./" />
     <title>重導向中</title>
   </head>
   <body>
     <p>頁面不存在，正在導向 2026 淡路島・鳴門家庭旅行頁面…</p>
-    <a href="/trips/awaji-2026/">如果沒有自動跳轉，請點此前往。</a>
+    <a href="./">如果沒有自動跳轉，請點此前往。</a>
     <script>
-      window.location.replace('/trips/awaji-2026/');
+      window.location.replace('./');
     </script>
   </body>
 </html>

--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Awaji 2026 Golden Trip",
   "short_name": "Awaji2026",
-  "start_url": "/trips/awaji-2026/",
+  "start_url": "./",
   "display": "standalone",
   "background_color": "#071026",
   "theme_color": "#0f6a69",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -184,10 +184,10 @@ function App() {
 
       try {
         const urls = [
-          `${baseUrl}trips/awaji-2026/public-bundle.json`,
           `${baseUrl}public-bundle.json`,
-          '/trips/awaji-2026/public-bundle.json',
-          '/public-bundle.json',
+          `${baseUrl}trips/awaji-2026/public-bundle.json`,
+          './public-bundle.json',
+          './trips/awaji-2026/public-bundle.json',
         ]
         const attemptLogs: string[] = []
         let response: Response | null = null

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-const BASE_PATH = process.env.VITE_BASE_PATH || '/'
+const BASE_PATH = process.env.VITE_BASE_PATH || './'
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## 變更摘要
- 將 Vite 打包 base 預設改為相對路徑 `./`，避免 GitHub Pages 專案頁路徑下仍產生 `/trips/...` 資產路徑。
- 將 `web` 的 `build` 腳本改回 `tsc && vite build`，不再在腳本中硬編碼 `--base /trips/awaji-2026/`。
- 將入口頁面 fallback 與 manifest 改為相對路徑。
- 將 `public-bundle.json` 載入順序改為以 `import.meta.env.BASE_URL` 為主，移除固定 `/trips/...` 絕對 URL。

## 驗證
- 本機 build 檔顯示輸出 `index.html` 內資產使用 `./assets/...`。
- 該分支已 rebase 至最新 `origin/main`。
