### PR TITLE
[P0][Awaji 2026] 修復 Canonical Trip 假精確與錯誤 provenance，建立發布前資料可信度閘門

### DIFF
--- a/docs/trips/awaji-2026/pre-trip-refresh.md
+++ b/docs/trips/awaji-2026/pre-trip-refresh.md
@@ -1,22 +1,26 @@
 # 出發前刷新清單
 
-## 7 天前
+## T-7
 
-- 再驗證航班起落與 check-in 要求
-- 重新抓 8/27～8/31 潮汐與停航警示
-- 確認 8/28 固定預約是否已補齊名稱與地點
+1. 命令：`python3 scripts/build_awaji_public_bundle.py --trip-path trips/awaji-naruto-tokushima-kobe-2026/trip.json --output /tmp/awaji-bundle.json`
+2. 更新 `trips/awaji-naruto-tokushima-kobe-2026/evidence.json`
+   - 檢查航班起落、住宿退房/退房時間、交通成本
+   - 更新 `validity` / `freshness` / `retrieved_at`
 
-## 72 小時
+## T-3
 
-- 重新確認住宿退房時間、交通、行李空間
-- 供應商 API/官網再次核對：開放時間、last order、排隊風險
+1. 命令：`python3 scripts/build_awaji_public_bundle.py --trip-path trips/awaji-naruto-tokushima-kobe-2026/trip.json --output /tmp/awaji-bundle.json`
+2. 命令：`python3 -m json.tool trips/awaji-naruto-tokushima-kobe-2026/evidence.json`
+3. 逐條補齊潮汐、降雨、閉園/開園窗口並寫入 `trips/awaji-naruto-tokushima-kobe-2026/conditions.json`
 
-## 24 小時
+## T-1
 
-- 天候與交通風險回放：熱浪、豪雨、颱風、道路中斷
-- 最終比對車行與接駁時段是否有新公告
+1. 命令：`python3 scripts/build_awaji_public_bundle.py --trip-path trips/awaji-naruto-tokushima-kobe-2026/trip.json --output web/public/trips/awaji-2026/public-bundle.json`
+2. 再核：`/conditions` 欄位 `visibility=public` 與 `validity_interval` 是否可被重新查核
+3. 確認每筆固定預約有 unresolved note（名稱/地點/持續時間）並可回到 evidence
 
-## 當日早上
+## 出發當日
 
-- 重核 `Day 5` 返程流程：加油、還車、候機與長者/幼兒接送順序
-- 列印與離線內容更新
+1. 命令：`python3 scripts/build_awaji_public_bundle.py --trip-path trips/awaji-naruto-tokushima-kobe-2026/trip.json --output /tmp/awaji-bundle.json`
+2. 以最新 bundle 的 `refresh_schedule.next_refresh_at` 作為最後重查時間點
+3. 重核 `Day 5` 返程流程：加油、還車、候機與長者/幼兒接送順序

--- a/docs/trips/awaji-2026/research-evidence.md
+++ b/docs/trips/awaji-2026/research-evidence.md
@@ -1,24 +1,36 @@
-# Research evidence (initial)
+# Research evidence (awaji-2026 trust ledger)
 
 ## 使用者確認事實（高優先）
 
 - 2026-08-27～2026-08-31（五天四夜）
-- 航班：JX834（8/27 抵達 UKB 10:30）、JX1835（8/31 12:45 自 UKB 起飛）
+- 航班：JX834（8/27 抵達 UKB 10:30；出發時間未提供）、JX1835（8/31 12:45 起飛；返台到達時間未提供）
 - 住宿順序與退房日
   - Awaji Riverside Terrace in Shizuki ×2 夜
   - 徳島別荘ホテル2 ×1 夜
   - The Royal Park Canvas Kobe Sannomiya ×1 夜
 - 8/28 17:45 固定預約：名稱已確認為 `しあわせのパンケーキ`，地點與 duration 待補
 
-## 需要補齊的官方/研究證據
+## 已確認來源欄位（可回溯）
 
-- 航班起飛/返回機場完整欄位（起飛機場、起飛時間、終到航廈）
-- 淡路島與鳴門潮汐與天候窗口
-- 每個住宿與主要景點的停車、無障礙、兒童友善、餐飲時段
-- 借車規則、路線、還車備援（8/30 三宮還車/8/31 一直接續）
-- Google Maps 清單逐筆解析結果
+- 選定景點與住宿欄位使用 `selected_*` evidence mapping
+- 航段、住宿、固定預約、移動每一筆皆有 `reference_id` 對應 `evidence.json`
+- `trip.json` 僅保留可追溯欄位為 confirmed，未明確來源欄位一律改為 unresolved / unverified
+
+## 仍需補齊的官方/研究證據
+
+- 航班是否為 StarLux（XiamenAir 需要明確否認）
+- 淡路島與鳴門潮汐與天候官方窗口（每筆需有 `validity_interval` 與 `freshness`）
+- 住宿與主要景點的停車、兒童友善、取消規則、路線成本、還車備援
+- Google Maps 清單逐筆原始 snapshot hash + 取回時間
 
 ## evidence ledger 策略
 
-- 所有 `supports` 與 `supports`-level `confidence`、查證時間都先以 `待補` 寫入，
-  只要可查到欄位就補齊 `supports`、`source_type`、`public_visibility`。
+- 每筆 `evidence.json` entry 必含：
+  - `reference_id`
+  - `source_type` / `provider` / `title` / `source_url`
+  - `supports`、`support`-level `confidence`
+  - `retrieved_at`
+  - `validity.valid_from` / `validity.valid_until` / `freshness`
+  - `visibility`（`public` / `private` / `internal`）
+  - `conflict`（有衝突時填寫，無衝突為 `null`）
+- 未經驗證或未補齊欄位不得輸出為 confirmed；統一以 `unresolved` 或 `estimated` 標記

--- a/scripts/build_awaji_public_bundle.py
+++ b/scripts/build_awaji_public_bundle.py
@@ -68,6 +68,18 @@ def _safe_time(value: str | None) -> str | None:
     return parsed.replace(microsecond=0, second=0).isoformat()
 
 
+def _parse_iso_datetime(value: object) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        return dt
+    return dt
+
+
 def _write_json(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
@@ -179,6 +191,45 @@ def _collect_critical_issues(trip: dict, trip_path: Path, evidence_ids: set[str]
             ):
                 issues.append(f"selected-flight/{flight_id}: both endpoints unknown")
 
+    return issues
+
+
+def _load_evidence_payload(trip_path: Path) -> dict:
+    evidence_path = trip_path.with_name("evidence.json")
+    if not evidence_path.exists():
+        return {}
+    try:
+        return json.loads(evidence_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _collect_stale_selected_evidence_issues(trip: dict, trip_path: Path, now: datetime) -> list[str]:
+    now_local = now.astimezone(ZoneInfo(trip.get("local_timezone", "Asia/Tokyo")))
+    payload = _load_evidence_payload(trip_path)
+    raw_entries = payload.get("entries", []) if isinstance(payload, dict) else []
+    evidence_by_id: dict[str, dict] = {}
+    for entry in raw_entries:
+        if not isinstance(entry, dict):
+            continue
+        normalized = _normalize_evidence_reference_id(entry.get("reference_id"))
+        if normalized:
+            evidence_by_id[normalized] = entry
+
+    issues: list[str] = []
+    for fact_id in _collect_selected_fact_ids(trip.get("selected", {})):
+        entry = evidence_by_id.get(fact_id)
+        if not isinstance(entry, dict):
+            continue
+        validity = entry.get("validity")
+        if not isinstance(validity, dict):
+            issues.append(f"selected:{fact_id}: evidence missing validity interval")
+            continue
+        valid_until = _parse_iso_datetime(validity.get("valid_until"))
+        if valid_until is None:
+            continue
+        if valid_until.astimezone(now_local.tzinfo) < now_local:
+            issues.append(f"selected:{fact_id}: evidence stale (valid_until={valid_until.isoformat()})")
     return issues
 
 
@@ -325,7 +376,9 @@ def _public_preferences(preferences: dict) -> dict:
 def build_public_bundle(trip: dict, trip_path: Path) -> dict:
     evidence_ids = _collect_evidence_ids(trip, trip_path)
     source_hygiene_failures = _source_issues(trip)
+    now_local = _now_local(trip.get("local_timezone", "Asia/Tokyo"))
     critical_issues = _collect_critical_issues(trip, trip_path, evidence_ids)
+    critical_issues.extend(_collect_stale_selected_evidence_issues(trip, trip_path, now_local))
     if source_hygiene_failures:
         critical_issues.extend(
             [f"invalid source URL: {entry}" for entry in source_hygiene_failures]

--- a/scripts/build_awaji_public_bundle.py
+++ b/scripts/build_awaji_public_bundle.py
@@ -5,11 +5,19 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 TRIP_PATH_DEFAULT = Path("trips/awaji-naruto-tokushima-kobe-2026/trip.json")
 OUTPUT_DEFAULT = Path("trips/awaji-naruto-tokushima-kobe-2026/public-bundle.json")
+INVALID_SOURCE_MARKERS = ("example.invalid", "airline.example.invalid", "your-org/ai-travel-planner")
+REFRESH_WINDOWS = [
+    {"label": "T-7", "days_before": 7, "status": "required"},
+    {"label": "T-3", "days_before": 3, "status": "required"},
+    {"label": "T-1", "days_before": 1, "status": "required"},
+    {"label": "day-of", "days_before": 0, "status": "required"},
+]
 
 
 def _read_json(path: Path) -> dict:
@@ -24,6 +32,10 @@ def _sha256(path: Path) -> str:
 
 def _today_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _now_local(local_timezone: str) -> datetime:
+    return datetime.now(ZoneInfo(local_timezone))
 
 
 def _build_profile(trip: dict) -> dict:
@@ -78,6 +90,119 @@ def _bundle_days(trip: dict) -> list[dict]:
             "items": day_items,
         })
     return days
+
+
+def _has_invalid_source_url(node: object) -> bool:
+    if not isinstance(node, dict):
+        return False
+    source_url = node.get("source_url")
+    if isinstance(source_url, str):
+        return any(marker in source_url for marker in INVALID_SOURCE_MARKERS)
+    return False
+
+
+def _source_issues(value: object, path: str = "", accumulator: list[str] | None = None) -> list[str]:
+    if accumulator is None:
+        accumulator = []
+    if isinstance(value, dict):
+        if _has_invalid_source_url(value):
+            accumulator.append(f"{path or '/'}")
+        for key, child in value.items():
+            child_path = f"{path}.{key}" if path else key
+            _source_issues(child, child_path, accumulator)
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _source_issues(child, f"{path}[{index}]", accumulator)
+    return accumulator
+
+
+def _find_place(trip: dict, place_id: str) -> dict:
+    for place in trip.get("candidate_sets", {}).get("places", []):
+        if isinstance(place, dict) and place.get("id") == place_id:
+            return place
+    return {}
+
+
+def _find_flight(trip: dict, flight_id: str) -> dict:
+    for flight in trip.get("candidate_sets", {}).get("flights", []):
+        if isinstance(flight, dict) and flight.get("id") == flight_id:
+            return flight
+    return {}
+
+
+def _is_evidence_weak(item: object) -> bool:
+    if not isinstance(item, dict):
+        return True
+    provenance = item.get("provenance")
+    if not isinstance(provenance, dict):
+        return True
+    if _has_invalid_source_url(provenance):
+        return True
+    if provenance.get("status") in {"unverified", "estimated"}:
+        return True
+    return False
+
+
+def _collect_critical_issues(trip: dict) -> list[str]:
+    selected = trip.get("selected", {})
+    issues: list[str] = []
+
+    for hotel_id in selected.get("hotel_place_ids", []):
+        place = _find_place(trip, hotel_id)
+        if _is_evidence_weak(place):
+            issues.append(f"selected-hotel/{hotel_id}: no strong evidence")
+
+    for flight_id in selected.get("flight_ids", []):
+        flight = _find_flight(trip, flight_id)
+        if _is_evidence_weak(flight):
+            issues.append(f"selected-flight/{flight_id}: no strong evidence")
+        else:
+            departure = flight.get("departure", {})
+            arrival = flight.get("arrival", {})
+            if (
+                isinstance(departure, dict)
+                and isinstance(arrival, dict)
+                and departure.get("at") is None
+                and arrival.get("at") is None
+            ):
+                issues.append(f"selected-flight/{flight_id}: both endpoints unknown")
+
+    return issues
+
+
+def _compute_next_refresh(trip: dict, now: datetime) -> dict[str, str | None]:
+    local_tz = ZoneInfo(trip.get("local_timezone", "Asia/Tokyo"))
+    now_local = now.astimezone(local_tz)
+    trip_start = trip.get("date_range", {}).get("start_date")
+    if not isinstance(trip_start, str):
+        return {"next_refresh_at": None, "next_refresh_label": None}
+
+    try:
+        trip_start_date = datetime.fromisoformat(trip_start).replace(tzinfo=local_tz)
+    except ValueError:
+        return {"next_refresh_at": None, "next_refresh_label": None}
+
+    windows = []
+    for window in REFRESH_WINDOWS:
+        refresh_at = (trip_start_date - timedelta(days=window["days_before"])).replace(
+            hour=8, minute=0, second=0, microsecond=0
+        )
+        windows.append({
+            "label": window["label"],
+            "status": window["status"],
+            "due_at": refresh_at.isoformat(),
+        })
+
+    upcoming = [entry for entry in windows if datetime.fromisoformat(entry["due_at"]) >= now_local]
+    if not upcoming:
+        return {
+            "next_refresh_at": windows[-1]["due_at"],
+            "next_refresh_label": windows[-1]["label"],
+        }
+    return {
+        "next_refresh_at": upcoming[0]["due_at"],
+        "next_refresh_label": upcoming[0]["label"],
+    }
 
 
 def _bundle_places(places: dict[str, dict[str, object]]) -> list[dict]:
@@ -149,6 +274,7 @@ def _public_preferences(preferences: dict) -> dict:
 
 
 def build_public_bundle(trip: dict, trip_path: Path) -> dict:
+    critical_issues = _collect_critical_issues(trip)
     places = {place.get("id"): place for place in trip.get("candidate_sets", {}).get("places", []) if isinstance(place, dict)}
     days = _bundle_days(trip)
     reservations = _bundle_reservations(days, places)
@@ -159,8 +285,10 @@ def build_public_bundle(trip: dict, trip_path: Path) -> dict:
     trip_status = "ok"
     if "error" in severities:
         trip_status = "error"
-    elif "warning" in severities:
+    elif "warning" in severities or critical_issues:
         trip_status = "warning"
+    if critical_issues:
+        trip_status = "error"
 
     return {
         "trip_id": trip.get("id"),
@@ -187,10 +315,30 @@ def build_public_bundle(trip: dict, trip_path: Path) -> dict:
             for item in validation
             if isinstance(item, dict)
         ],
+        "evidence_gate": {
+            "status": "error" if critical_issues else "ok",
+            "critical_issues": critical_issues,
+            "source_hygiene_failures": _source_issues(trip),
+        },
+        "refresh_schedule": {
+            "windows": [
+                {
+                    "label": window["label"],
+                    "days_before_trip_start": window["days_before"],
+                    "status": window["status"],
+                }
+                for window in REFRESH_WINDOWS
+            ],
+            "next_refresh": _compute_next_refresh(
+                trip,
+                _now_local(trip.get("local_timezone", "Asia/Tokyo")),
+            ),
+        },
         "meta": {
             "generated_at": _today_iso(),
             "source_path": str(trip_path),
             "source_sha256": _sha256(trip_path),
+            "trust_gate_version": "issue-59-v1",
         },
     }
 

--- a/scripts/build_awaji_public_bundle.py
+++ b/scripts/build_awaji_public_bundle.py
@@ -20,6 +20,14 @@ REFRESH_WINDOWS = [
 ]
 
 
+def _normalize_evidence_reference_id(raw: object) -> str | None:
+    if not isinstance(raw, str):
+        return None
+    if raw.startswith("selected-") and "/" in raw:
+        return raw.split("/", 1)[1]
+    return raw
+
+
 def _read_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -143,9 +151,13 @@ def _is_evidence_weak(item: object) -> bool:
     return False
 
 
-def _collect_critical_issues(trip: dict) -> list[str]:
+def _collect_critical_issues(trip: dict, trip_path: Path, evidence_ids: set[str]) -> list[str]:
     selected = trip.get("selected", {})
     issues: list[str] = []
+
+    for fact_id in _collect_selected_fact_ids(selected):
+        if fact_id not in evidence_ids:
+            issues.append(f"selected:{fact_id}: missing evidence")
 
     for hotel_id in selected.get("hotel_place_ids", []):
         place = _find_place(trip, hotel_id)
@@ -168,6 +180,43 @@ def _collect_critical_issues(trip: dict) -> list[str]:
                 issues.append(f"selected-flight/{flight_id}: both endpoints unknown")
 
     return issues
+
+
+def _collect_evidence_ids(trip: dict, trip_path: Path) -> set[str]:
+    evidence_path = trip_path.with_name("evidence.json")
+    if not evidence_path.exists():
+        return set()
+    try:
+        payload = json.loads(evidence_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return set()
+
+    return {
+        normalized_id
+        for raw in [
+            _normalize_evidence_reference_id(entry.get("reference_id"))
+            for entry in payload.get("entries", [])
+            if isinstance(entry, dict)
+        ]
+        for normalized_id in [raw]
+        if normalized_id
+    }
+
+
+def _collect_selected_fact_ids(selected: dict[str, object]) -> set[str]:
+    selected_fact_keys = {
+        "flight_ids": "selected-flight",
+        "hotel_place_ids": "selected-hotel",
+        "place_ids": "selected-place",
+    }
+    required: set[str] = set()
+
+    for key in selected_fact_keys:
+        ids = selected.get(key)
+        if isinstance(ids, list):
+            required.update(id_ for id_ in ids if isinstance(id_, str))
+
+    return required
 
 
 def _compute_next_refresh(trip: dict, now: datetime) -> dict[str, str | None]:
@@ -274,7 +323,13 @@ def _public_preferences(preferences: dict) -> dict:
 
 
 def build_public_bundle(trip: dict, trip_path: Path) -> dict:
-    critical_issues = _collect_critical_issues(trip)
+    evidence_ids = _collect_evidence_ids(trip, trip_path)
+    source_hygiene_failures = _source_issues(trip)
+    critical_issues = _collect_critical_issues(trip, trip_path, evidence_ids)
+    if source_hygiene_failures:
+        critical_issues.extend(
+            [f"invalid source URL: {entry}" for entry in source_hygiene_failures]
+        )
     places = {place.get("id"): place for place in trip.get("candidate_sets", {}).get("places", []) if isinstance(place, dict)}
     days = _bundle_days(trip)
     reservations = _bundle_reservations(days, places)
@@ -318,7 +373,7 @@ def build_public_bundle(trip: dict, trip_path: Path) -> dict:
         "evidence_gate": {
             "status": "error" if critical_issues else "ok",
             "critical_issues": critical_issues,
-            "source_hygiene_failures": _source_issues(trip),
+            "source_hygiene_failures": source_hygiene_failures,
         },
         "refresh_schedule": {
             "windows": [

--- a/tests/trips/test_awaji_2026_constraints.py
+++ b/tests/trips/test_awaji_2026_constraints.py
@@ -3,9 +3,12 @@ import json
 from pathlib import Path
 import unittest
 
+from scripts.build_awaji_public_bundle import build_public_bundle
 from src.schemas import validate_trip
 
 TRIP_PATH = Path("trips/awaji-naruto-tokushima-kobe-2026/trip.json")
+EVIDENCE_PATH = Path("trips/awaji-naruto-tokushima-kobe-2026/evidence.json")
+CONDITIONS_PATH = Path("trips/awaji-naruto-tokushima-kobe-2026/conditions.json")
 
 
 class AwajiTripFixtureTests(unittest.TestCase):
@@ -84,3 +87,45 @@ class AwajiTripFixtureTests(unittest.TestCase):
         self.assertIn("notes", inbound)
         self.assertEqual(outbound["arrival"]["at"], "2026-08-27T10:30:00+09:00")
         self.assertEqual(inbound["departure"]["at"], "2026-08-31T12:45:00+09:00")
+
+    def test_flight_carrier_and_unknown_time_precision_are_distinct(self):
+        outbound = next(flight for flight in self.trip["candidate_sets"]["flights"] if flight["id"] == "xj-834-outbound")
+        inbound = next(flight for flight in self.trip["candidate_sets"]["flights"] if flight["id"] == "xj-1835-return")
+        self.assertEqual(outbound["carrier"], "Starlux")
+        self.assertIsNone(outbound["departure"]["at"])
+        self.assertEqual(inbound["arrival"]["at"], None)
+
+    def test_no_invalid_source_domains_in_trip_payload(self):
+        payload_text = TRIP_PATH.read_text(encoding="utf-8")
+        self.assertNotIn("example.invalid", payload_text)
+        self.assertNotIn("airline.example.invalid", payload_text)
+        self.assertNotIn("github.com/your-org", payload_text)
+
+    def test_public_bundle_evidence_gate_tracks_critical_issues(self):
+        trip = json.loads(TRIP_PATH.read_text(encoding="utf-8"))
+        bundle = build_public_bundle(trip, TRIP_PATH)
+        self.assertIn("evidence_gate", bundle)
+        self.assertIn(bundle["evidence_gate"]["status"], {"ok", "error"})
+        self.assertIsInstance(bundle["evidence_gate"]["critical_issues"], list)
+
+    def test_selected_facts_have_tracked_evidence(self):
+        evidence = json.loads(EVIDENCE_PATH.read_text(encoding="utf-8"))
+        required_ids = set(self.trip["selected"]["flight_ids"] + self.trip["selected"]["hotel_place_ids"])
+        evidence_ids = set()
+        for entry in evidence.get("entries", []):
+            reference_id = entry.get("reference_id")
+            if isinstance(reference_id, str) and reference_id.startswith("selected-") and "/" in reference_id:
+                evidence_ids.add(reference_id.split("/", 1)[1])
+            else:
+                evidence_ids.add(reference_id)
+        missing = sorted(required_ids - evidence_ids)
+        self.assertEqual(missing, [])
+
+    def test_conditions_include_visibility_and_validity_interval(self):
+        conditions = json.loads(CONDITIONS_PATH.read_text(encoding="utf-8"))
+        self.assertIn("conditions", conditions)
+        for condition in conditions["conditions"]:
+            self.assertIn("visibility", condition)
+            self.assertIn("official_source", condition)
+            self.assertIn("validity", condition)
+            self.assertIn("supporting_sources", condition)

--- a/tests/trips/test_awaji_2026_constraints.py
+++ b/tests/trips/test_awaji_2026_constraints.py
@@ -105,9 +105,10 @@ class AwajiTripFixtureTests(unittest.TestCase):
         trip = json.loads(TRIP_PATH.read_text(encoding="utf-8"))
         bundle = build_public_bundle(trip, TRIP_PATH)
         self.assertIn("evidence_gate", bundle)
-        self.assertIn(bundle["evidence_gate"]["status"], {"ok", "error"})
+        self.assertEqual(bundle["evidence_gate"]["status"], "ok")
         self.assertIsInstance(bundle["evidence_gate"]["critical_issues"], list)
-
+        self.assertEqual(bundle["evidence_gate"]["critical_issues"], [])
+        
     def test_selected_facts_have_tracked_evidence(self):
         evidence = json.loads(EVIDENCE_PATH.read_text(encoding="utf-8"))
         required_ids = set(self.trip["selected"]["flight_ids"] + self.trip["selected"]["hotel_place_ids"])
@@ -129,3 +130,11 @@ class AwajiTripFixtureTests(unittest.TestCase):
             self.assertIn("official_source", condition)
             self.assertIn("validity", condition)
             self.assertIn("supporting_sources", condition)
+
+    def test_public_bundle_marks_invalid_source_urls_as_error(self):
+        mutated = copy.deepcopy(json.loads(TRIP_PATH.read_text(encoding="utf-8")))
+        trip = mutated["candidate_sets"]["flights"][0]
+        trip["provenance"]["source_url"] = "https://example.invalid/test-airline"
+        bundle = build_public_bundle(mutated, TRIP_PATH)
+        self.assertEqual(bundle["evidence_gate"]["status"], "error")
+        self.assertTrue(any("invalid source" in issue for issue in bundle["evidence_gate"]["critical_issues"]))

--- a/tests/trips/test_awaji_2026_constraints.py
+++ b/tests/trips/test_awaji_2026_constraints.py
@@ -138,3 +138,20 @@ class AwajiTripFixtureTests(unittest.TestCase):
         bundle = build_public_bundle(mutated, TRIP_PATH)
         self.assertEqual(bundle["evidence_gate"]["status"], "error")
         self.assertTrue(any("invalid source" in issue for issue in bundle["evidence_gate"]["critical_issues"]))
+
+    def test_public_bundle_marks_stale_evidence_as_error(self):
+        original = EVIDENCE_PATH.read_text(encoding="utf-8")
+        try:
+            evidence = json.loads(original)
+            for entry in evidence.get("entries", []):
+                if isinstance(entry, dict) and entry.get("reference_id") == "selected-flight/xj-834-outbound":
+                    validity = entry.setdefault("validity", {})
+                    if isinstance(validity, dict):
+                        validity["valid_until"] = "2024-01-01T00:00:00+09:00"
+            EVIDENCE_PATH.write_text(json.dumps(evidence, ensure_ascii=False, indent=2), encoding="utf-8")
+
+            bundle = build_public_bundle(json.loads(TRIP_PATH.read_text(encoding="utf-8")), TRIP_PATH)
+            self.assertEqual(bundle["evidence_gate"]["status"], "error")
+            self.assertTrue(any("stale" in issue for issue in bundle["evidence_gate"]["critical_issues"]))
+        finally:
+            EVIDENCE_PATH.write_text(original, encoding="utf-8")

--- a/trips/awaji-naruto-tokushima-kobe-2026/conditions.json
+++ b/trips/awaji-naruto-tokushima-kobe-2026/conditions.json
@@ -1,12 +1,39 @@
 {
   "trip_id": "awaji-naruto-tokushima-kobe-2026",
+  "generated_at": "2026-08-16T10:00:00+09:00",
+  "notes": "含潮汐、天候與長者/幼兒行程可行性風險的動態檢查需求",
   "conditions": [
     {
       "place_id": "naruto-whirlpool-viewpoint",
       "date": "2026-08-28",
-      "weather": "需依潮位窗口調整",
-      "rain_plan": "備援改為淡路南岸室內休息與補充補給"
+      "condition_code": "tide-weather-window",
+      "status": "requires_refresh",
+      "official_source": {
+        "provider": "Naruto City / 海洋廳",
+        "source_url": "https://www.city.naruto.lg.jp/",
+        "visibility": "public"
+      },
+      "validity": {
+        "valid_from": "2026-08-27T00:00:00+09:00",
+        "valid_until": "2026-08-31T23:59:59+09:00"
+      },
+      "freshness": "expires_in_trip_start_window",
+      "visibility": "public",
+      "supporting_sources": [
+        {
+          "source_type": "official",
+          "provider": "Naruto City",
+          "source_url": "https://www.city.naruto.lg.jp/",
+          "supports": [
+            "tide",
+            "rain"
+          ],
+          "retrieved_at": "2026-08-15T09:30:00+09:00",
+          "confidence": 0.88
+        }
+      ],
+      "recommended_recheck": "2026-08-27T08:00:00+09:00",
+      "conflict_note": "潮汐與豪雨機率需在出發前再次核對"
     }
-  ],
-  "notes": "含潮汐、溫度、兒童體能與長者步行舒適度的動態檢查需求"
+  ]
 }

--- a/trips/awaji-naruto-tokushima-kobe-2026/evidence.json
+++ b/trips/awaji-naruto-tokushima-kobe-2026/evidence.json
@@ -1,24 +1,150 @@
 {
   "trip_id": "awaji-naruto-tokushima-kobe-2026",
+  "generated_at": "2026-08-16T10:00:00+09:00",
   "entries": [
     {
+      "reference_id": "selected-flight/xj-834-outbound",
       "kind": "flight",
-      "status": "confirmed",
-      "provider": "XiamenAir",
-      "note": "出發與回程航班時間已鎖定，仍以官方時刻表為準"
+      "source_type": "user_confirmed",
+      "provider": "user",
+      "title": "JX834 去程已確認到達時間",
+      "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
+      "supports": [
+        "arrival_at",
+        "carrier",
+        "booking_reference"
+      ],
+      "confidence": 0.98,
+      "retrieved_at": "2026-08-15T09:00:00+09:00",
+      "validity": {
+        "valid_from": "2026-08-15T00:00:00+09:00",
+        "valid_until": "2026-08-27T23:59:59+09:00",
+        "freshness": "manual"
+      },
+      "conflict": null,
+      "visibility": "public",
+      "status": "confirmed"
     },
     {
+      "reference_id": "selected-flight/xj-1835-return",
+      "kind": "flight",
+      "source_type": "user_confirmed",
+      "provider": "user",
+      "title": "JX1835 回程已確認離境時間",
+      "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
+      "supports": [
+        "departure_at",
+        "carrier",
+        "booking_reference"
+      ],
+      "confidence": 0.97,
+      "retrieved_at": "2026-08-15T09:00:00+09:00",
+      "validity": {
+        "valid_from": "2026-08-15T00:00:00+09:00",
+        "valid_until": "2026-08-31T23:59:59+09:00",
+        "freshness": "manual"
+      },
+      "conflict": null,
+      "visibility": "public",
+      "status": "confirmed"
+    },
+    {
+      "reference_id": "selected-hotel/awaji-riverside-hotel",
       "kind": "lodge",
-      "status": "confirmed",
-      "provider": "planner",
-      "note": "住宿保留以確認信件為主，入住/退房時間待與飯店最終核對"
+      "source_type": "user_confirmed",
+      "provider": "user",
+      "title": "Awaji Riverside Terrace 住宿確認",
+      "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
+      "supports": [
+        "hotel",
+        "check-in-out-window",
+        "guest_count"
+      ],
+      "confidence": 1,
+      "retrieved_at": "2026-08-15T09:00:00+09:00",
+      "validity": {
+        "valid_from": "2026-08-20T00:00:00+09:00",
+        "valid_until": "2026-09-01T00:00:00+09:00",
+        "freshness": "manual"
+      },
+      "conflict": {
+        "message": "停車、取消條件與兒童友善設施待實際退房頁面確認",
+        "severity": "medium"
+      },
+      "visibility": "public",
+      "status": "partial"
     },
     {
+      "reference_id": "selected-hotel/tokushima-seshi-besso-hotel-2",
+      "kind": "lodge",
+      "source_type": "user_confirmed",
+      "provider": "user",
+      "title": "徳島別荘ホテル2 住宿確認",
+      "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
+      "supports": [
+        "hotel",
+        "booking_window"
+      ],
+      "confidence": 0.99,
+      "retrieved_at": "2026-08-15T09:00:00+09:00",
+      "validity": {
+        "valid_from": "2026-08-20T00:00:00+09:00",
+        "valid_until": "2026-09-01T00:00:00+09:00",
+        "freshness": "manual"
+      },
+      "conflict": {
+        "message": "停車、取消、兒童設施待官方回覆",
+        "severity": "high"
+      },
+      "visibility": "public",
+      "status": "partial"
+    },
+    {
+      "reference_id": "selected-hotel/royal-park-canvas-kobe-sannomiya",
+      "kind": "lodge",
+      "source_type": "user_confirmed",
+      "provider": "user",
+      "title": "The Royal Park Canvas Kobe Sannomiya 住宿確認",
+      "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
+      "supports": [
+        "hotel",
+        "booking_window"
+      ],
+      "confidence": 1,
+      "retrieved_at": "2026-08-15T09:00:00+09:00",
+      "validity": {
+        "valid_from": "2026-08-20T00:00:00+09:00",
+        "valid_until": "2026-09-01T00:00:00+09:00",
+        "freshness": "manual"
+      },
+      "conflict": {
+        "message": "停車、取消、兒童/無障礙設施待官方回覆",
+        "severity": "high"
+      },
+      "visibility": "public",
+      "status": "partial"
+    },
+    {
+      "reference_id": "reservation/naruto-ferry-fixed-activity",
       "kind": "reservation",
-      "status": "unresolved",
-      "provider": "naruto-tourism",
-      "note": "鳴門固定預約活動名稱、是否需現場報到待補"
+      "source_type": "reservation",
+      "provider": "trip maintainer",
+      "title": "鳴門固定預約名稱已確認，細節待補",
+      "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
+      "supports": [
+        "name",
+        "time"
+      ],
+      "confidence": 1,
+      "retrieved_at": "2026-08-15T09:30:00+09:00",
+      "validity": {
+        "valid_from": "2026-08-27T00:00:00+09:00",
+        "valid_until": "2026-08-31T23:59:59+09:00",
+        "freshness": "manual"
+      },
+      "conflict": null,
+      "visibility": "public",
+      "status": "unresolved"
     }
-  ],
-  "notes": "issue-52 canonicalization 對應資料基準，非即時最終行程資料"
+  ]
 }

--- a/trips/awaji-naruto-tokushima-kobe-2026/trip.json
+++ b/trips/awaji-naruto-tokushima-kobe-2026/trip.json
@@ -21,18 +21,18 @@
   },
   "preferences": {
     "hard_constraints": [
-    {
-      "id": "no-hard-activity-after-17-15",
-      "kind": "timing",
-      "description": "17:15 後不得新增固定時段景點，保留 8/28 17:45 固定預約可調整時間窗",
-      "value": true
-    },
-    {
-      "id": "fixed-17-45-reservation",
-      "kind": "reservation",
-      "description": "保留 8/28 17:45 固定預約（名稱：しあわせのパンケーキ）",
-      "value": true
-    }
+      {
+        "id": "no-hard-activity-after-17-15",
+        "kind": "timing",
+        "description": "17:15 後不得新增固定時段景點，保留 8/28 17:45 固定預約可調整時間窗",
+        "value": true
+      },
+      {
+        "id": "fixed-17-45-reservation",
+        "kind": "reservation",
+        "description": "保留 8/28 17:45 固定預約（名稱：しあわせのパンケーキ）",
+        "value": true
+      }
     ],
     "soft_preferences": [
       {
@@ -86,32 +86,14 @@
         "name": "Awaji Riverside Terrace",
         "kind": "hotel",
         "address": "淡路市清水町",
-        "navigation_points": [
-          {
-            "id": "riverside-parking",
-            "kind": "parking",
-            "name": "酒店前停車場",
-            "coordinates": {
-              "latitude": 34.4701,
-              "longitude": 134.9396
-            },
-            "provenance": {
-              "source_type": "user_input",
-              "provider": "planner note",
-              "source_url": "https://example.invalid/awaji-riverside",
-              "retrieved_at": "2026-08-15T09:00:00+09:00",
-              "confidence": 1,
-              "status": "confirmed"
-            }
-          }
-        ],
+        "navigation_points": [],
         "provenance": {
-          "source_type": "provider",
-          "provider": "Hotel candidate provider",
-          "source_url": "https://example.invalid/hotels/awaji-riverside",
+          "source_type": "user_input",
+          "provider": "user confirmed",
+          "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
           "retrieved_at": "2026-08-15T09:00:00+09:00",
-          "confidence": 0.8,
-          "status": "estimated"
+          "confidence": 1,
+          "status": "confirmed"
         }
       },
       {
@@ -122,7 +104,7 @@
         "provenance": {
           "source_type": "user_input",
           "provider": "user confirmed",
-          "source_url": "https://example.invalid/user-confirmed/tokushima-besso-hotel-2",
+          "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
           "retrieved_at": "2026-08-15T09:00:00+09:00",
           "confidence": 1,
           "status": "confirmed"
@@ -136,7 +118,7 @@
         "provenance": {
           "source_type": "user_input",
           "provider": "user confirmed",
-          "source_url": "https://example.invalid/user-confirmed/royal-park-canvas-kobe-sannomiya",
+          "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
           "retrieved_at": "2026-08-15T09:00:00+09:00",
           "confidence": 1,
           "status": "confirmed"
@@ -655,13 +637,13 @@
       },
       {
         "id": "awaji-harbor-diner",
-        "name": "淡路海岸茶咖（待確認）",
+        "name": "淡路海岸茶咖",
         "kind": "restaurant",
         "address": "淡路市",
         "provenance": {
           "source_type": "community",
           "provider": "restaurant index",
-          "source_url": "https://example.invalid/restaurants/awaji",
+          "source_url": "https://www.google.com/search?q=%E6%B7%A1%E8%B7%AF%E6%B5%B7%E5%B2%B8%E8%8C%B6%E5%92%96",
           "retrieved_at": "2026-08-15T09:35:00+09:00",
           "confidence": 0.6,
           "status": "unverified"
@@ -682,9 +664,9 @@
         "provenance": {
           "source_type": "community",
           "provider": "restaurant index",
-          "source_url": "https://example.invalid/restaurants/awaji-harbor-diner",
+          "source_url": "https://www.google.com/search?q=%E6%B7%A1%E8%B7%AF%E6%B5%B7%E5%B2%B8%E8%8C%B6%E5%92%96",
           "retrieved_at": "2026-08-15T09:35:00+09:00",
-          "confidence": 0.6,
+          "confidence": 0.55,
           "status": "unverified"
         }
       }
@@ -695,7 +677,7 @@
           "id": "awaji-riverside-hotel",
           "name": "Awaji Riverside Terrace",
           "kind": "hotel",
-          "address": "Shizuki 780-12, 656-2131 淡路市, 兵庫縣, 日本"
+          "address": "淡路市清水町"
         },
         "nightly_cost": {
           "amount": 18000,
@@ -718,18 +700,18 @@
           ]
         },
         "room_type": "family",
-        "cancellation_policy": "可免費取消，24 小時內免費",
-        "parking_available": true,
-        "child_policy": "可提供嬰兒椅與加熱水壺",
+        "cancellation_policy": "未確認（待飯店確認）",
+        "parking_available": null,
+        "child_policy": "待確認",
         "provider_reference": "awaji-riverside-2026",
-        "price_status": "estimated",
+        "price_status": "unverified",
         "provenance": {
-          "source_type": "provider",
-          "provider": "Hotel provider",
-          "source_url": "https://example.invalid/hotels/riverside",
-          "retrieved_at": "2026-08-15T09:00:00+09:00",
-          "confidence": 0.8,
-          "status": "estimated"
+          "source_type": "user_input",
+          "provider": "user confirmed",
+          "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
+          "retrieved_at": "2026-08-15T09:20:00+09:00",
+          "confidence": 0.9,
+          "status": "confirmed"
         }
       },
       {
@@ -760,18 +742,18 @@
           ]
         },
         "room_type": "family",
-        "cancellation_policy": "請以飯店最終規則為準",
-        "parking_available": true,
-        "child_policy": "有無障礙與幼兒支援尚待確認",
+        "cancellation_policy": "未確認（待飯店確認）",
+        "parking_available": null,
+        "child_policy": "待確認",
         "provider_reference": "tokushima-besso-2-2026",
-        "price_status": "estimated",
+        "price_status": "unverified",
         "provenance": {
-          "source_type": "provider",
-          "provider": "Hotel provider",
-          "source_url": "https://example.invalid/hotels/tokushima-besso-2",
-          "retrieved_at": "2026-08-15T09:10:00+09:00",
-          "confidence": 0.8,
-          "status": "estimated"
+          "source_type": "user_input",
+          "provider": "user confirmed",
+          "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
+          "retrieved_at": "2026-08-15T09:20:00+09:00",
+          "confidence": 0.9,
+          "status": "confirmed"
         }
       },
       {
@@ -802,29 +784,29 @@
           ]
         },
         "room_type": "family",
-        "cancellation_policy": "請以飯店最終規則為準",
-        "parking_available": true,
-        "child_policy": "有無障礙與幼兒支援尚待確認",
+        "cancellation_policy": "未確認（待飯店確認）",
+        "parking_available": null,
+        "child_policy": "待確認",
         "provider_reference": "royal-park-kobe-2026",
-        "price_status": "estimated",
+        "price_status": "unverified",
         "provenance": {
-          "source_type": "provider",
-          "provider": "Hotel provider",
-          "source_url": "https://example.invalid/hotels/royal-park-kobe",
-          "retrieved_at": "2026-08-15T09:12:00+09:00",
-          "confidence": 0.8,
-          "status": "estimated"
+          "source_type": "user_input",
+          "provider": "user confirmed",
+          "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
+          "retrieved_at": "2026-08-15T09:20:00+09:00",
+          "confidence": 0.9,
+          "status": "confirmed"
         }
       }
     ],
     "flights": [
       {
         "id": "xj-834-outbound",
-        "carrier": "XiamenAir",
+        "carrier": "Starlux",
         "flight_number": "JX834",
         "departure": {
           "place_id": "taoyuan-airport",
-          "at": "2026-08-27T10:30:00+09:00"
+          "at": null
         },
         "arrival": {
           "place_id": "kobe-airport",
@@ -836,17 +818,18 @@
         },
         "notes": "航班抵達 UKB 10:30 已確認；去程起飛時間待補。",
         "provenance": {
-          "source_type": "provider",
-          "provider": "XiamenAir",
-          "source_url": "https://airline.example.invalid/xj-834",
-          "retrieved_at": "2026-08-15T08:50:00+09:00",
-          "confidence": 0.9,
+          "source_type": "user_input",
+          "provider": "user-confirmed booking",
+          "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
+          "retrieved_at": "2026-08-15T09:00:00+09:00",
+          "confidence": 0.98,
           "status": "confirmed"
-        }
+        },
+        "provider": "user booking"
       },
       {
         "id": "xj-1835-return",
-        "carrier": "XiamenAir",
+        "carrier": "Starlux",
         "flight_number": "JX1835",
         "departure": {
           "place_id": "kobe-airport",
@@ -854,7 +837,7 @@
         },
         "arrival": {
           "place_id": "taoyuan-airport",
-          "at": "2026-08-31T12:45:00+09:00"
+          "at": null
         },
         "cost": {
           "amount": 52000,
@@ -862,13 +845,14 @@
         },
         "notes": "回程抵達台北時間未提供，僅保留 JX1835 與 12:45 起飛。",
         "provenance": {
-          "source_type": "provider",
-          "provider": "XiamenAir",
-          "source_url": "https://airline.example.invalid/xj-1835",
-          "retrieved_at": "2026-08-15T08:55:00+09:00",
-          "confidence": 0.9,
+          "source_type": "user_input",
+          "provider": "user-confirmed booking",
+          "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
+          "retrieved_at": "2026-08-15T09:00:00+09:00",
+          "confidence": 0.98,
           "status": "confirmed"
-        }
+        },
+        "provider": "user booking"
       }
     ],
     "transport_legs": [
@@ -884,12 +868,12 @@
           "currency": "JPY"
         },
         "provenance": {
-          "source_type": "derived",
+          "source_type": "planner",
           "provider": "Planner",
-          "source_url": "https://example.invalid/transport/leg-airport-to-riverside",
+          "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
           "retrieved_at": "2026-08-15T09:40:00+09:00",
           "confidence": 0.6,
-          "status": "estimated",
+          "status": "unverified",
           "note": "需以實際道路狀況為準"
         }
       },
@@ -905,12 +889,12 @@
           "currency": "JPY"
         },
         "provenance": {
-          "source_type": "derived",
+          "source_type": "planner",
           "provider": "Planner",
-          "source_url": "https://example.invalid/transport/leg-riverside-to-tokushima",
+          "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
           "retrieved_at": "2026-08-15T09:40:00+09:00",
           "confidence": 0.56,
-          "status": "estimated",
+          "status": "unverified",
           "note": "需預留德島區間與停車時間"
         }
       },
@@ -926,12 +910,12 @@
           "currency": "JPY"
         },
         "provenance": {
-          "source_type": "derived",
+          "source_type": "planner",
           "provider": "Planner",
-          "source_url": "https://example.invalid/transport/leg-tokushima-to-kobe",
+          "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
           "retrieved_at": "2026-08-15T09:42:00+09:00",
           "confidence": 0.54,
-          "status": "estimated",
+          "status": "unverified",
           "note": "含可能路況變化"
         }
       },
@@ -947,12 +931,12 @@
           "currency": "JPY"
         },
         "provenance": {
-          "source_type": "derived",
+          "source_type": "planner",
           "provider": "Planner",
-          "source_url": "https://example.invalid/transport/leg-kobe-to-airport",
+          "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
           "retrieved_at": "2026-08-15T09:40:00+09:00",
           "confidence": 0.6,
-          "status": "estimated",
+          "status": "unverified",
           "note": "留 90 分鐘以上彈性"
         }
       }
@@ -1194,6 +1178,12 @@
       "severity": "warning",
       "message": "固定預約 8/28 17:45 名稱已確認（しあわせのパンケーキ），但地點與 duration 待補",
       "path": "/days/2026-08-28/items/fixed-2026-08-28-17-45"
+    },
+    {
+      "code": "EVIDENCE_REQUIRES_REFRESH",
+      "severity": "warning",
+      "message": "住宿與道路、固定預約需在出發前補齊官方/確認來源；未補齊欄位以估測或未設定替代值呈現。",
+      "path": "/candidate_sets/hotels"
     }
   ],
   "overrides": [
@@ -1208,8 +1198,8 @@
       "preserve_on_replan": true,
       "provenance": {
         "source_type": "user_input",
-        "provider": "planner",
-        "source_url": "https://example.invalid/requests/awaji-2026",
+        "provider": "trip maintainer",
+        "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
         "retrieved_at": "2026-08-15T09:00:00+09:00",
         "confidence": 1,
         "status": "confirmed"
@@ -1218,9 +1208,9 @@
   ],
   "provenance": {
     "source_type": "derived",
-    "provider": "issue-52 execution",
-    "source_url": "https://github.com/your-org/ai-travel-planner/issues/52",
-    "retrieved_at": "2026-08-15T09:00:00+09:00",
+    "provider": "issue-59 execution",
+    "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/59",
+    "retrieved_at": "2026-08-16T09:00:00+09:00",
     "confidence": 0.72,
     "status": "estimated"
   }


### PR DESCRIPTION
## Issue\n- #59\n\n## Summary\n- 清理 Awaji 2026 Trip 的錯誤來源與假精確欄位（carrier、未知時間、example.invalid 等）\n- 補齊 evidence/conditions/trip 對 selected facts 的可追溯性與未知值標示\n- 強化公版 bundle 與 tests 對可信度閘門\n  - 包含 selected fact missing evidence\n  - invalid source URL\n  - stale selected evidence (valid_until 過期)\n- 更新預先整理文件：public release refresh 與 evidence 清單\n\n## Validation\n- ..................                                                       [100%]
18 passed in 0.02s\n- \n