### PR TITLE
[issue63] feat(pwa): enable vite manifest output for awaji cache bootstrap

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,4 +6,7 @@ const BASE_PATH = process.env.VITE_BASE_PATH || './'
 export default defineConfig({
   plugins: [react()],
   base: BASE_PATH,
+  build: {
+    manifest: true,
+  },
 })


### PR DESCRIPTION
## Summary
- Scope: issue63, implemented only the cache bootstrap prerequisite due exclusive path ownership constraints.
- Changed file: web/vite.config.ts
  - added `build: { manifest: true }` to enable stable manifest output for downstream cache/runtime work.
- Commit: 83be152da7c160a0f6a61e950b64484f716e6db0

## Ownership constraints
- issue61 owns:
  - scripts/build_awaji_public_bundle.py
  - web/public/**
  - web/src/App.tsx
  - web/src/styles.css
  - ... and related trip content assets.
- issue62 owns:
  - .github/workflows/ci.yml
- These paths are required by issue63 AC and currently block full implementation in this issue63 worktree.

## Validation evidence for this branch
- python3 -m scripts.agent.collaboration check 63
- python3 -m scripts.agent.collaboration handoff 63 --test-evidence "python3 -m scripts.agent.collaboration check 63 ; npm --prefix web run build"
- PR checks passed in 84 (framework, pytest, python, website) on Actions run 31962648121

## Notes
- Acceptance criteria are only partially covered by this PR. Full offline/cache behavior (SW, manifest metadata, update semantics, offline states, duplicate bundle canonicalization, E2E evidence) remains to be implemented in follow-up work after ownership handoff/alignment.
