### PR TITLE
[Web/P1] Issue 73 deterministic design gallery and review contract

### DIFF
--- a/docs/design-review/README.md
+++ b/docs/design-review/README.md
@@ -1,0 +1,20 @@
+# Design gallery workflow
+
+此目錄是 Issue 73 的 design governance contract。Gallery 是 public-safe、deterministic 的獨立 preview；production 元件由 web app 的既有 design system 提供，待各頁面 owner 增加對應 story/scenario 時，使用同一份 fixture 與 baseline manifest。
+
+## 本地驗證
+
+```sh
+node web/design-preview/build-gallery.mjs
+python3 -m json.tool web/visual-fixtures/gallery-scenarios.json >/dev/null
+python3 -m json.tool web/visual-baselines/manifest.json >/dev/null
+```
+
+開啟 `web/design-preview/design-gallery-dist/index.html`，依 baseline manifest 檢視 390×844、430×932、768×1024、1440×900；切換三種 theme 並檢查 state matrix。截圖產生器由 Issue 62 的 release tooling 呼叫，不能用此 gallery build 取代 screenshot artifact 或人工 review。
+
+## Baseline 更新規則
+
+1. fixture 固定 clock、random seed、API mode；不要使用 live API、private data、隨機內容或未固定時間。
+2. 只在 intentional design change 時更新 golden manifest 或 screenshot；PR 必須說明 visual diff、affected viewport/theme/state。
+3. unexplained large diff 必須停在 review，並由 reviewer 記錄 finding、fix commit 或 accepted limitation。
+4. review record 必須綁 exact SHA，material fix 後重新由獨立 reviewer 檢視。

--- a/docs/design-review/review-rubric.md
+++ b/docs/design-review/review-rubric.md
@@ -1,0 +1,35 @@
+# Design review rubric
+
+此 rubric 用於 Awaji release candidate 的獨立人工 review。Gallery build、visual diff、accessibility automation 與本文件是互補 gate；任何一項不能單獨宣告 design complete。
+
+## 評分方式
+
+每項記錄 pass、finding 或 accepted limitation。Finding 必須綁定 issue 或 fix commit；accepted limitation 必須寫出影響範圍與 owner。以下任一 blocker 未處理，不得宣告通過：誤導性的成功狀態、核心操作在 390px 不可用、狀態只靠顏色、長文字被截斷、offline/error 破壞主要 layout。
+
+## 視覺與資訊階層
+
+1. 5 秒內可辨識 trip、日期、目前狀態與主要行動。
+2. primary、secondary、tertiary 資訊有清楚層級，不以大量小灰字堆疊。
+3. 頁面有 hero、timeline、tabs、drawer 或其他節奏差異，不是所有 section 都是同一種 card wall。
+4. 重要資訊不需展開多層；source、freshness、細節採漸進揭露。
+
+## 目的地感與信任
+
+1. Setouchi/Awaji、generic Japan、fallback 三種 theme 可辨識且不改變 status 語意。
+2. 圖片或 motif 支援目的地理解，不壓過行程與操作；無圖片時仍完整。
+3. confirmed、estimated、unverified、stale、conflict、unresolved、invalid/error 有文字語意。
+4. source 與 last checked 可找到；preview、invalid、不完整資料不使用誤導成功文案。
+
+## 現場使用與長輩可讀性
+
+1. 390px 單手可找到今日行程、下一站、Maps、住宿、預約與緊急資訊。
+2. 互動目標至少約 44px；sticky UI 不遮內容，safe area 正確。
+3. 200% zoom、keyboard focus、forced colors（若平台支援）仍能辨識與操作。
+4. 主字級與 line-height 適合長輩；狀態不只靠顏色；長日文、地址、電話與 URL 不截斷。
+
+## Failure、motion 與品質證據
+
+1. loading、empty、offline cached、offline unavailable、broken image、bundle error 都有保留 layout 的狀態。
+2. reduced-motion 移除非必要動畫；print summary 隱藏導覽並保留核心內容。
+3. 390、430、768、1440 四種 viewport 與三種 theme 使用 deterministic fixture review。
+4. 每個 unexplained visual diff 都有 finding；每次 review 記錄 exact SHA、artifact、範圍、結果、修正與 accepted limitations。

--- a/docs/design-review/reviews/2026-08-21-awaji-rc.md
+++ b/docs/design-review/reviews/2026-08-21-awaji-rc.md
@@ -1,0 +1,34 @@
+# Awaji release candidate design review
+
+status: pending independent review
+issue: 73
+reviewed_sha: TODO-after-push
+artifact: local `web/design-preview/design-gallery-dist/index.html`
+reviewer: independent design reviewer (required)
+review_date: 2026-08-21
+
+## Scope
+
+Gallery scenarios：primitives、trip hero、itinerary timeline、operational hubs、handbook/local tools、failure/print。
+
+Viewports：390×844、430×932、768×1024、1440×900。
+
+Themes：setouchi-awaji、generic-japan、fallback-japan。
+
+States：confirmed、official、estimated、unverified、stale、conflict、unresolved、invalid/error、loading、empty、offline cached、offline unavailable、long Japanese、long Traditional Chinese、long address/URL、missing media、broken image、reduced motion、keyboard focus、print。
+
+## Review record
+
+| Area | Result | Finding / evidence |
+| --- | --- | --- |
+| Visual hierarchy | pending | reviewer fills after exact SHA review |
+| Destination identity | pending | reviewer fills after theme comparison |
+| Mobile field use | pending | reviewer fills at 390px and 430px |
+| Elder readability | pending | reviewer fills at 200% zoom / keyboard focus |
+| Trust and status semantics | pending | reviewer fills across status matrix |
+| Failure and offline states | pending | reviewer fills across failure scenarios |
+| Task-based usability | pending | use `usability-checks.md` |
+
+## Required closeout
+
+Replace every pending result with pass, finding, or accepted limitation. Attach screenshot artifact/run URL, list fix commits, and record the independent reviewer identity. This record must be updated after any material visual fix.

--- a/docs/design-review/usability-checks.md
+++ b/docs/design-review/usability-checks.md
@@ -1,0 +1,20 @@
+# Task-based usability checks
+
+每次 release candidate 由非實作者執行。使用 `web/visual-fixtures/gallery-scenarios.json` 的 recorded fixture，記錄 exact SHA、viewport、theme、執行者、日期與瀏覽器。成功不是只看畫面能載入，而是完成任務並能說明狀態。
+
+| 任務 | 通過條件 | 結果欄位 |
+| --- | --- | --- |
+| 5 秒內找到今天第一個主要行程 | 首屏指出日期、第一站與下一個主要 action | pass/fail、步驟、混淆 |
+| 找到下一站 Google Maps | 兩次互動內開啟正確 destination link | pass/fail、步驟、混淆 |
+| 找到今晚住宿地址與停車 | 不需搜尋 source detail 即讀到地址與停車資訊 | pass/fail、步驟、混淆 |
+| 找到固定預約與時間 | 可辨識 confirmed 預約、時間與地點 | pass/fail、步驟、混淆 |
+| 找到雨天 Plan B 與放棄條件 | 可找到 Plan B、觸發條件與 abandon rule | pass/fail、步驟、混淆 |
+| 找到七人座位日文並播放／複製 | phrase、播放與複製 action 均可操作 | pass/fail、步驟、混淆 |
+| 找到 119 與緊急日文 | 不依賴顏色即可找到電話與 phrase | pass/fail、步驟、混淆 |
+| 離線後找到核心資訊 | cached 行程、住宿、聯絡方式仍可讀；不可用來源有明示 | pass/fail、步驟、混淆 |
+
+## 結果判定
+
+1. 每項 pass：記錄步驟數與完成時間。
+2. 每項 fail：建立 finding，記錄觸發畫面、使用者預期、實際結果與修正或接受理由。
+3. 沒有執行的任務不可標記 pass；不可用「gallery build passed」代替 task review。

--- a/web/design-preview/build-gallery.mjs
+++ b/web/design-preview/build-gallery.mjs
@@ -1,0 +1,22 @@
+import { mkdir, readFile, cp } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const fixturePath = resolve(root, "visual-fixtures/gallery-scenarios.json");
+const baselinePath = resolve(root, "visual-baselines/manifest.json");
+const output = resolve(root, "design-gallery-dist");
+
+const fixture = JSON.parse(await readFile(fixturePath, "utf8"));
+const baseline = JSON.parse(await readFile(baselinePath, "utf8"));
+if (fixture.viewports.length !== 4 || fixture.themes.length < 3 || fixture.scenarios.length < 6) {
+  throw new Error("gallery fixture matrix is incomplete");
+}
+if (baseline.policy.reviewRequiredForUnexplainedDiff !== true) {
+  throw new Error("baseline policy must require review for unexplained diffs");
+}
+await mkdir(output, { recursive: true });
+await cp(resolve(dirname(fileURLToPath(import.meta.url)), "index.html"), resolve(output, "index.html"));
+await cp(fixturePath, resolve(output, "gallery-scenarios.json"));
+await cp(baselinePath, resolve(output, "baseline-manifest.json"));
+console.log(`gallery build passed: ${fixture.scenarios.length} scenarios, ${fixture.viewports.length} viewports, ${fixture.themes.length} themes`);

--- a/web/design-preview/index.html
+++ b/web/design-preview/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Trip design gallery</title>
+  <style>
+    :root { color-scheme: light; font: 16px/1.55 system-ui, sans-serif; --ink:#17324d; --muted:#52677a; --paper:#fffdf8; --wash:#eef6f5; --accent:#087f8c; --line:#c8d8d8; }
+    * { box-sizing:border-box } body { margin:0; color:var(--ink); background:var(--wash) }
+    header { padding:32px max(20px,calc((100% - 1180px)/2)); background:linear-gradient(120deg,#0b6670,#d2a85b); color:white }
+    main { max-width:1180px; margin:0 auto; padding:24px 20px 56px } h1,h2,h3 { line-height:1.2 } h1 { margin:0 0 8px; font-size:clamp(1.8rem,4vw,3rem) } h2 { margin-top:34px }
+    .toolbar { display:flex; flex-wrap:wrap; gap:8px; margin:20px 0 } button,.tab { min-height:44px; border:1px solid var(--line); border-radius:999px; padding:9px 16px; background:var(--paper); color:var(--ink); cursor:pointer } button:focus-visible,.tab:focus-visible { outline:3px solid #f5c542; outline-offset:2px }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:16px } .panel { background:var(--paper); border:1px solid var(--line); border-radius:18px; padding:18px; box-shadow:0 5px 18px #17324d12 } .hero { grid-column:1/-1; min-height:170px; background:linear-gradient(135deg,#fffdf8,#dceeed); display:flex; flex-direction:column; justify-content:end }
+    .eyebrow,.badge { font-size:.78rem; letter-spacing:.06em; text-transform:uppercase; font-weight:700 } .badge { display:inline-block; border-radius:8px; padding:4px 8px; background:#d9f1e5; color:#17603b } .badge.warn { background:#fff0c2;color:#755400 } .badge.alert { background:#ffe0df;color:#8b2621 }
+    .muted { color:var(--muted) } .row { display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap } .timeline { border-left:3px solid var(--accent); padding-left:16px } .timeline + .timeline { margin-top:14px } .sr { position:absolute; width:1px; height:1px; overflow:hidden; clip:rect(0,0,0,0) }
+    @media (prefers-reduced-motion:reduce) { *,*::before,*::after { scroll-behavior:auto!important; transition:none!important; animation:none!important } } @media print { header,.toolbar { display:none } body { background:white } .panel { break-inside:avoid; box-shadow:none } }
+  </style>
+</head>
+<body>
+  <header><div class="eyebrow">Component gallery · deterministic fixture</div><h1>淡路島家庭旅行</h1><div>2026/04/12（日） · 今日的行程與現場狀態</div></header>
+  <main>
+    <div class="toolbar" aria-label="Gallery controls"><button>Setouchi / Awaji</button><button>Generic Japan</button><button>Fallback theme</button><button>390 × 844</button><button aria-pressed="true">Reduced motion</button></div>
+    <section class="grid" aria-labelledby="patterns"><h2 id="patterns" class="sr">Product patterns</h2>
+      <article class="panel hero"><span class="eyebrow">Trip hero · user-confirmed</span><h2>鳴門漩渦與淡路島海岸線</h2><div class="row"><span class="muted">Day 2 · 5 個主要停留點</span><span class="badge">confirmed</span></div></article>
+      <article class="panel"><div class="row"><h3>狀態 vocabulary</h3><span class="badge">official</span></div><p><span class="badge">confirmed</span> <span class="badge warn">estimated</span> <span class="badge alert">stale</span></p><p class="muted">狀態同時以文字、色彩和位置表達。</p></article>
+      <article class="panel"><h3>下一站</h3><div class="timeline"><strong>大鳴門橋</strong><br><span class="muted">09:40–11:10 · 18 分鐘車程</span><br><button>開啟 Google Maps</button></div></article>
+      <article class="panel"><h3>住宿</h3><p>淡路島洲本溫泉旅館</p><p class="muted">兵庫縣洲本市……（長地址不截斷）</p><span class="badge warn">last checked 2h ago</span></article>
+      <article class="panel"><h3>離線狀態</h3><p><span class="badge">offline cached</span></p><p class="muted">核心行程可用；餐廳即時庫存暫不可用。</p><button>重新檢查</button></article>
+      <article class="panel"><h3>空狀態 / error</h3><p class="muted">還沒有加入雨天 Plan B。</p><button>新增備案</button> <button>顯示錯誤詳情</button></article>
+      <article class="panel"><h3>日本語 phrase</h3><p lang="ja">七人で座れる席はありますか？</p><div class="row"><button>播放</button><button>複製</button><span class="badge">long text</span></div></article>
+      <article class="panel"><h3>操作 checklist</h3><label><input type="checkbox" checked> 預約確認</label><br><label><input type="checkbox"> 紙本備份</label><br><label><input type="checkbox"> 119 緊急資訊</label></article>
+    </section>
+    <h2>Review notes</h2><p class="muted">此 gallery 使用 recorded public-safe fixture；時間、random seed、theme、viewport 與 failure states 均固定。請搭配 design-review 文件與 baseline manifest 審查，不以 gallery build 取代人工視覺、可及性與任務檢查。</p>
+  </main>
+</body>
+</html>

--- a/web/visual-baselines/manifest.json
+++ b/web/visual-baselines/manifest.json
@@ -1,0 +1,19 @@
+{
+  "schema": "design-gallery-baseline/v1",
+  "policy": {
+    "pixelTolerance": 0.1,
+    "animation": "disabled",
+    "fontLoading": "wait-for-document-fonts",
+    "clock": "2026-04-12T09:00:00+09:00",
+    "randomSeed": 73,
+    "reviewRequiredForUnexplainedDiff": true
+  },
+  "goldens": [
+    { "scenario": "primitives", "theme": "setouchi-awaji", "viewport": "mobile" },
+    { "scenario": "trip-hero", "theme": "setouchi-awaji", "viewport": "mobile-wide" },
+    { "scenario": "itinerary-timeline", "theme": "generic-japan", "viewport": "tablet" },
+    { "scenario": "operational-hubs", "theme": "setouchi-awaji", "viewport": "desktop" },
+    { "scenario": "handbook-local-tools", "theme": "fallback-japan", "viewport": "mobile" },
+    { "scenario": "failure-and-print", "theme": "setouchi-awaji", "viewport": "desktop" }
+  ]
+}

--- a/web/visual-fixtures/gallery-scenarios.json
+++ b/web/visual-fixtures/gallery-scenarios.json
@@ -1,0 +1,21 @@
+{
+  "schema": "design-gallery-scenario/v1",
+  "clock": "2026-04-12T09:00:00+09:00",
+  "randomSeed": 73,
+  "apiMode": "recorded-fixture",
+  "viewports": [
+    { "name": "mobile", "width": 390, "height": 844 },
+    { "name": "mobile-wide", "width": 430, "height": 932 },
+    { "name": "tablet", "width": 768, "height": 1024 },
+    { "name": "desktop", "width": 1440, "height": 900 }
+  ],
+  "themes": ["setouchi-awaji", "generic-japan", "fallback-japan"],
+  "scenarios": [
+    { "id": "primitives", "title": "Primitives and status vocabulary", "states": ["confirmed", "estimated", "stale", "conflict", "error", "focus"] },
+    { "id": "trip-hero", "title": "Trip hero and day tabs", "states": ["confirmed", "long-text", "missing-media"] },
+    { "id": "itinerary-timeline", "title": "Timeline, travel leg and route stop", "states": ["confirmed", "unresolved", "offline-cached", "long-address"] },
+    { "id": "operational-hubs", "title": "Reservation, lodging, meal and tide patterns", "states": ["confirmed", "empty", "stale", "offline-unavailable"] },
+    { "id": "handbook-local-tools", "title": "Handbook, Japanese phrase and checklist", "states": ["confirmed", "long-japanese", "loading", "broken-image"] },
+    { "id": "failure-and-print", "title": "Failure, offline update and print summary", "states": ["error", "offline-cached", "reduced-motion", "print"] }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #73

- add public-safe deterministic design gallery preview covering primitives, trip hero, timeline, operational hubs, handbook/local tools, failure/offline/print states
- add fixture matrix for 4 viewports and 3 themes with fixed clock and random seed
- add baseline manifest requiring review for unexplained visual diffs
- add design rubric, task-based usability checklist, workflow documentation, and Awaji RC review record

## Validation

- `node web/design-preview/build-gallery.mjs`
- `python3 -m unittest discover -s tests -v` (164 passed)
- `npm --prefix web run typecheck`
- `npm --prefix web run build`
- `python3 -m scripts.agent.collaboration check 73`

## Scope note

Issue 69 currently owns `web/src/**` and `docs/design/**`; this PR deliberately uses non-overlapping gallery and `docs/design-review/**` paths. Production component stories can be added by the relevant page owners using this contract.