### PR TITLE
fix(web): load Awaji prototype bundle from public root

### DIFF
--- a/docs/awaji-day-prototype.md
+++ b/docs/awaji-day-prototype.md
@@ -2,7 +2,7 @@
 
 預覽入口：`/awaji-day-prototype/`（由 Vite dev server 提供；目前是 isolated preview route，不修改 production composition root）。
 
-本 prototype 只載入既有 `web/public/trips/awaji-2026/public-bundle.json` 的 2026-08-28 day data。畫面保留 `しあわせのパンケーキ` 的已確認名稱，但將地點與 duration 明確標示為待補；沒有新增地址、停車或 reservation fact。若 bundle 無法載入，畫面會使用同一日的最小 fallback，並顯示 fallback data status。
+本 prototype 只載入既有 `web/public/trips/awaji-2026/public-bundle.json`（runtime URL：`/trips/awaji-2026/public-bundle.json`）的 2026-08-28 day data。畫面保留 `しあわせのパンケーキ` 的已確認名稱，但將地點與 duration 明確標示為待補；沒有新增地址、停車或 reservation fact。若 bundle 無法載入，畫面會使用同一日的最小 fallback，並顯示 fallback data status。
 
 設計取 `ai_kyushu` 的 desktop sidebar、top bar、day selector、timeline 與現場 quick actions；刻意改用既有 `setouchi-awaji` 的海藍、青綠、留白與波浪 motif，避免複製熊本內容或做成照片／card wall。Hero、時間軸和 amber unresolved reservation 形成主要資訊層級，mobile 以 390px 為優先並保留 44px action hit area。
 

--- a/web/awaji-day-prototype/main.tsx
+++ b/web/awaji-day-prototype/main.tsx
@@ -7,7 +7,7 @@ type BundlePlace = { id: string; name: string; address?: string; maps_query?: st
 type BundleDay = { date: string; summary: string; items: BundleItem[] }
 type PublicBundle = { days: BundleDay[]; places: BundlePlace[]; reservations?: Array<{ id: string; name: string; unresolved?: boolean }> }
 
-const BUNDLE_URL = '../public/trips/awaji-2026/public-bundle.json'
+const BUNDLE_URL = '/trips/awaji-2026/public-bundle.json'
 const DAY_DATE = '2026-08-28'
 
 const fallbackDay: BundleDay = {


### PR DESCRIPTION
## Follow-up fix for #89

修正 prototype runtime bundle URL。Vite 的 `public/` 內容以 site root 提供，應使用 `/trips/awaji-2026/public-bundle.json`；原路徑會錯誤地請求 `/public/trips/...` 並觸發 fallback，無法真正讀取 recorded data。

## Validation

- `npx tsc -p awaji-day-prototype/tsconfig.json --noEmit` PASS
- `npm run typecheck` PASS
- `npm run build` PASS
- HTTP smoke check：prototype route PASS；public bundle 回傳 2026-08-28、4 items、正確 summary PASS
- `python3 -m scripts.agent.collaboration check 89` PASS
