### PR TITLE
feat: add generic Japan trip site publishing pipeline

### DIFF
--- a/docs/architecture/renderer-strategy.md
+++ b/docs/architecture/renderer-strategy.md
@@ -1,0 +1,7 @@
+# Renderer strategy
+
+The reusable React trip app is the product renderer and consumes the versioned public bundle. The Python golden_trip_renderer remains a diagnostic and print/fallback renderer for legacy fixtures; it is not a second production publishing flow.
+
+Issue 72 owns the publisher contract and artifact topology. The existing app shell and Pages/PWA workflows retain their ownership boundaries and consume the generated root registry and trips/<slug>/ artifacts during integration.
+
+Per-trip URLs are isolated by slug. A trip's PWA scope and browser storage namespace are derived from trip identity, so one trip cannot overwrite another trip's local state. Shared static assets may be deduplicated by the web build, while bundle and media manifests remain per-trip artifacts.

--- a/docs/architecture/trip-site-publishing.md
+++ b/docs/architecture/trip-site-publishing.md
@@ -1,0 +1,19 @@
+# Trip Site Publishing Pipeline
+
+Issue 72 establishes one offline publishing flow for Japan trip websites.
+
+Canonical Trip is the only itinerary source of truth. The publisher performs no research, planning, routing, or repair. It validates the input, projects an allowlisted public bundle, and attaches site configuration, theme/media references, and build metadata.
+
+Commands:
+
+    python3 scripts/build_trip_site.py --trip trips/<trip-id>/trip.json --site-config site-configs/<trip>/site.json --output site
+    python3 scripts/build_all_trip_sites.py --configs site-configs --output site
+    python3 scripts/init_trip_site.py --trip-id hokkaido-2027 --slug hokkaido-2027 --theme snow-hokkaido
+
+Each trip output contains index.html, public-bundle.json, site.json, site-media.json, and build-report.json. Build-all also emits registry.json and a root index artifact. The registry is generated from valid site configs; React does not hardcode trip entries.
+
+Publication semantics are explicit. Preview builds can expose incomplete data with an incomplete readiness value. A published build with a critical validation error is blocked. Unknown source facts remain unknown; the publisher never fills them with guessed precision.
+
+The bundle excludes provider payloads, credentials, private booking fields, and absolute source paths. Its schema version is trip-public-bundle-v1. Config, media, registry, and build reports have independent version markers.
+
+Builds use recorded JSON only. No provider call is made by the publisher. Input, config, media, bundle, theme, and publisher versions are recorded in build-report.json for release gates and reproducibility checks.

--- a/scripts/build_all_trip_sites.py
+++ b/scripts/build_all_trip_sites.py
@@ -1,0 +1,23 @@
+"""Build every site config and emit one deterministic multi-trip registry."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.web_publisher import build_all
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--configs", type=Path, default=Path("site-configs"))
+    parser.add_argument("--output", type=Path, default=Path("site"))
+    args = parser.parse_args()
+    results = build_all(args.configs, args.output)
+    print(f"built {len(results)} trip sites at {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_trip_site.py
+++ b/scripts/build_trip_site.py
@@ -1,0 +1,24 @@
+"""Build one validated Canonical Trip into a public trip-site artifact."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.web_publisher import build_trip
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--trip", type=Path, required=True)
+    parser.add_argument("--site-config", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("site"))
+    args = parser.parse_args()
+    result = build_trip(args.trip, args.site_config, args.output)
+    print(f"built {result.trip_id} at {result.output_dir} ({result.readiness})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/init_trip_site.py
+++ b/scripts/init_trip_site.py
@@ -1,0 +1,25 @@
+"""Scaffold a site config without inventing itinerary or media facts."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.web_publisher import init_site
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--trip-id", required=True)
+    parser.add_argument("--slug", required=True)
+    parser.add_argument("--theme", required=True)
+    parser.add_argument("--output", type=Path, default=Path("site-configs"))
+    args = parser.parse_args()
+    config, media = init_site(args.trip_id, args.slug, args.theme, args.output / args.trip_id)
+    print(f"created {config} and {media}; canonical trip data was not generated")
+
+
+if __name__ == "__main__":
+    main()

--- a/site-configs/awaji-2026/site-media.json
+++ b/site-configs/awaji-2026/site-media.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "trip-media-v1",
+  "trip_id": "awaji-naruto-tokushima-kobe-2026",
+  "assets": []
+}

--- a/site-configs/awaji-2026/site.json
+++ b/site-configs/awaji-2026/site.json
@@ -8,6 +8,6 @@
   "features": {"itinerary": true, "driving": true, "conditions": true, "local_planner": true},
   "pwa": {"name": "Awaji 2026", "scope": "/trips/awaji-2026/"},
   "seo": {"title": "2026 淡路島・鳴門家庭旅行", "description": "由 Canonical Trip 產生的預覽網站。"},
-  "output_path": "site/trips/awaji-2026/",
+  "output_path": "trips/awaji-2026/",
   "trip_file": "../../trips/awaji-naruto-tokushima-kobe-2026/trip.json"
 }

--- a/site-configs/awaji-2026/site.json
+++ b/site-configs/awaji-2026/site.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "trip-site-v1",
+  "trip_id": "awaji-naruto-tokushima-kobe-2026",
+  "slug": "awaji-2026",
+  "publication_status": "preview",
+  "theme_id": "setouchi-awaji",
+  "media_manifest": "site-media.json",
+  "features": {"itinerary": true, "driving": true, "conditions": true, "local_planner": true},
+  "pwa": {"name": "Awaji 2026", "scope": "/trips/awaji-2026/"},
+  "seo": {"title": "2026 淡路島・鳴門家庭旅行", "description": "由 Canonical Trip 產生的預覽網站。"},
+  "output_path": "site/trips/awaji-2026/",
+  "trip_file": "../../trips/awaji-naruto-tokushima-kobe-2026/trip.json"
+}

--- a/site-configs/kyushu-2026/site-media.json
+++ b/site-configs/kyushu-2026/site-media.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "trip-media-v1",
+  "trip_id": "kyushu-family-2026",
+  "assets": [
+    {"id": "kyushu-cover", "kind": "image", "status": "approved", "source_url": "https://example.com/recorded-kyushu-cover", "alt": "九州行程封面", "license": "fixture-approved"}
+  ]
+}

--- a/site-configs/kyushu-2026/site.json
+++ b/site-configs/kyushu-2026/site.json
@@ -8,6 +8,6 @@
   "features": {"itinerary": true, "driving": true, "conditions": false, "local_planner": false},
   "pwa": {"name": "Kyushu 2026", "scope": "/trips/kyushu-2026/"},
   "seo": {"title": "九州五天四夜親子自駕", "description": "Recorded Japan trip fixture preview。"},
-  "output_path": "site/trips/kyushu-2026/",
+  "output_path": "trips/kyushu-2026/",
   "trip_file": "trip.json"
 }

--- a/site-configs/kyushu-2026/site.json
+++ b/site-configs/kyushu-2026/site.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "trip-site-v1",
+  "trip_id": "kyushu-family-2026",
+  "slug": "kyushu-2026",
+  "publication_status": "preview",
+  "theme_id": "snow-kyushu",
+  "media_manifest": "site-media.json",
+  "features": {"itinerary": true, "driving": true, "conditions": false, "local_planner": false},
+  "pwa": {"name": "Kyushu 2026", "scope": "/trips/kyushu-2026/"},
+  "seo": {"title": "九州五天四夜親子自駕", "description": "Recorded Japan trip fixture preview。"},
+  "output_path": "site/trips/kyushu-2026/",
+  "trip_file": "trip.json"
+}

--- a/site-configs/kyushu-2026/trip.json
+++ b/site-configs/kyushu-2026/trip.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "trip-v1",
+  "id": "kyushu-family-2026",
+  "title": "九州三天親子自駕預覽",
+  "local_timezone": "Asia/Tokyo",
+  "date_range": {"start_date": "2026-04-10", "end_date": "2026-04-12"},
+  "traveler_profile": {"adults": 2, "children": [{"age": 2}]},
+  "candidate_sets": {"places": [{"id": "fuk", "name": "福岡機場", "kind": "airport"}], "transport_legs": []},
+  "selected": {},
+  "days": [
+    {"date": "2026-04-10", "summary": "抵達福岡", "items": [{"id": "arrival", "kind": "visit", "place_id": "fuk", "start_at": "2026-04-10T11:00:00+09:00", "end_at": "2026-04-10T12:00:00+09:00"}]},
+    {"date": "2026-04-11", "summary": "市區探索", "items": [{"id": "city", "kind": "visit", "place_id": "fuk", "start_at": "2026-04-11T10:00:00+09:00", "end_at": "2026-04-11T12:00:00+09:00"}]},
+    {"date": "2026-04-12", "summary": "返程", "items": [{"id": "return", "kind": "visit", "place_id": "fuk", "start_at": "2026-04-12T10:00:00+09:00", "end_at": "2026-04-12T11:00:00+09:00"}]}
+  ],
+  "budget": {"currency": "JPY", "total": {"amount": 10000, "currency": "JPY"}},
+  "validation": [],
+  "provenance": {"source_type": "recorded_fixture", "provider": "fixture", "retrieved_at": "2026-01-01T00:00:00+09:00", "confidence": 1, "status": "confirmed"}
+}

--- a/src/web_publisher/__init__.py
+++ b/src/web_publisher/__init__.py
@@ -1,0 +1,5 @@
+"""Reusable, offline-first publishing pipeline for validated Japan trips."""
+
+from .pipeline import BuildResult, build_trip, build_all, init_site
+
+__all__ = ["BuildResult", "build_trip", "build_all", "init_site"]

--- a/src/web_publisher/__main__.py
+++ b/src/web_publisher/__main__.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .pipeline import build_all, build_trip, init_site, load_config
+from src.schemas.validate_trip import validate_trip
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="python3 -m src.web_publisher")
+    commands = parser.add_subparsers(dest="command", required=True)
+    validate = commands.add_parser("validate")
+    validate.add_argument("--trip", type=Path, required=True)
+    validate.add_argument("--site-config", type=Path, required=True)
+    build = commands.add_parser("build")
+    build.add_argument("--trip", type=Path, required=True)
+    build.add_argument("--site-config", type=Path, required=True)
+    build.add_argument("--output", type=Path, default=Path("site"))
+    build_all_command = commands.add_parser("build-all")
+    build_all_command.add_argument("--configs", type=Path, default=Path("site-configs"))
+    build_all_command.add_argument("--output", type=Path, default=Path("site"))
+    preview = commands.add_parser("preview")
+    preview.add_argument("--trip", type=Path, required=True)
+    preview.add_argument("--site-config", type=Path, required=True)
+    preview.add_argument("--output", type=Path, default=Path("site"))
+    init = commands.add_parser("init")
+    init.add_argument("--trip-id", required=True)
+    init.add_argument("--slug", required=True)
+    init.add_argument("--theme", required=True)
+    init.add_argument("--output", type=Path, default=Path("site-configs"))
+    args = parser.parse_args()
+    if args.command == "validate":
+        config = load_config(args.site_config)
+        trip = json.loads(args.trip.read_text(encoding="utf-8"))
+        validate_trip(trip)
+        print(json.dumps({"status": "valid", "trip_id": config["trip_id"]}, ensure_ascii=False))
+    elif args.command in {"build", "preview"}:
+        result = build_trip(args.trip, args.site_config, args.output)
+        print(json.dumps({"status": result.readiness, "trip_id": result.trip_id, "output": str(result.output_dir)}, ensure_ascii=False))
+    elif args.command == "build-all":
+        results = build_all(args.configs, args.output)
+        print(json.dumps({"status": "complete", "trips": [result.slug for result in results]}, ensure_ascii=False))
+    else:
+        config, media = init_site(args.trip_id, args.slug, args.theme, args.output / args.trip_id)
+        print(json.dumps({"status": "scaffolded", "config": str(config), "media": str(media)}, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/web_publisher/pipeline.py
+++ b/src/web_publisher/pipeline.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.schemas.validate_trip import validate_trip
+
+CONFIG_SCHEMA = "trip-site-v1"
+MEDIA_SCHEMA = "trip-media-v1"
+REGISTRY_SCHEMA = "trip-registry-v1"
+PUBLISHER_VERSION = "trip-site-publisher-v1"
+SENSITIVE_KEYS = {"api_key", "apikey", "authorization", "password", "secret", "token", "booking_reference", "private_notes"}
+
+
+@dataclass(frozen=True)
+class BuildResult:
+    trip_id: str
+    slug: str
+    output_dir: Path
+    bundle_sha256: str
+    report_path: Path
+    readiness: str
+
+
+def _read(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _sha(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _file_sha(path: Path) -> str:
+    return _sha(path.read_bytes())
+
+
+def _strip_private(value: Any, parent_key: str = "") -> Any:
+    if isinstance(value, dict):
+        result = {}
+        for key, child in value.items():
+            normalized = key.lower().replace("-", "_")
+            if normalized in SENSITIVE_KEYS or any(part in normalized for part in ("api_key", "password", "access_token")):
+                continue
+            if key in {"source_path", "absolute_path"}:
+                continue
+            result[key] = _strip_private(child, normalized)
+        return result
+    if isinstance(value, list):
+        return [_strip_private(child, parent_key) for child in value]
+    return value
+
+
+def load_config(config_path: Path) -> dict[str, Any]:
+    config = _read(config_path)
+    if config.get("schema_version") != CONFIG_SCHEMA:
+        raise ValueError(f"{config_path}: schema_version must be {CONFIG_SCHEMA}")
+    required = ("trip_id", "slug", "publication_status", "theme_id", "media_manifest", "features", "output_path")
+    missing = [key for key in required if key not in config]
+    if missing:
+        raise ValueError(f"{config_path}: missing required fields: {', '.join(missing)}")
+    if config["publication_status"] not in {"preview", "published", "archived"}:
+        raise ValueError(f"{config_path}: invalid publication_status")
+    if not isinstance(config["features"], dict):
+        raise ValueError(f"{config_path}: features must be an object")
+    if not isinstance(config["slug"], str) or not re.fullmatch(r"[a-z0-9][a-z0-9-]*", config["slug"]):
+        raise ValueError(f"{config_path}: slug must contain only lowercase letters, digits, and hyphens")
+    if Path(config["media_manifest"]).is_absolute() or ".." in Path(config["media_manifest"]).parts:
+        raise ValueError(f"{config_path}: media_manifest must stay inside its config directory")
+    return config
+
+
+def load_media(path: Path) -> dict[str, Any]:
+    media = _read(path)
+    if media.get("schema_version") != MEDIA_SCHEMA:
+        raise ValueError(f"{path}: schema_version must be {MEDIA_SCHEMA}")
+    if not isinstance(media.get("assets"), list):
+        raise ValueError(f"{path}: assets must be an array")
+    for asset in media["assets"]:
+        if not isinstance(asset, dict) or not asset.get("id") or not asset.get("status"):
+            raise ValueError(f"{path}: every asset requires id and status")
+        if asset["status"] not in {"approved", "pending", "rejected"}:
+            raise ValueError(f"{path}: invalid media status")
+        if asset["status"] == "approved" and not asset.get("source_url"):
+            raise ValueError(f"{path}: approved media requires source_url")
+    return media
+
+
+def _readiness(trip: dict[str, Any], config: dict[str, Any]) -> tuple[str, list[str]]:
+    issues = []
+    uncertainty = []
+    for item in trip.get("validation", []):
+        if isinstance(item, dict):
+            severity = item.get("severity")
+            message = str(item.get("message") or item.get("code") or "validation issue")
+            if severity in {"error", "critical"}:
+                issues.append(message)
+            elif severity in {"warning", "unknown", "unverified", "conflict", "stale"}:
+                uncertainty.append(message)
+    if not trip.get("validation"):
+        uncertainty.append("no recorded validation result")
+    if config["publication_status"] == "published" and (issues or uncertainty):
+        return "blocked", issues + uncertainty
+    return ("ready" if not issues and not uncertainty else "incomplete"), issues + uncertainty
+
+
+def _registry_entry(bundle: dict[str, Any], config: dict[str, Any], readiness: str, generated_at: str, bundle_hash: str) -> dict[str, Any]:
+    date_range = bundle.get("date_range") or {}
+    days = bundle.get("days") or []
+    return {
+        "schema_version": REGISTRY_SCHEMA,
+        "slug": config["slug"],
+        "canonical_url": f"trips/{config['slug']}/",
+        "trip_id": config["trip_id"],
+        "title": config.get("title_override") or bundle.get("title") or config["trip_id"],
+        "date_range": {"start_date": date_range.get("start_date"), "end_date": date_range.get("end_date")},
+        "duration_days": len(days),
+        "theme_id": config["theme_id"],
+        "publication_status": config["publication_status"],
+        "readiness": readiness,
+        "features": config["features"],
+        "media_manifest": config["media_manifest"],
+        "bundle_sha256": bundle_hash,
+        "last_build": generated_at,
+    }
+
+
+def _safe_provenance(raw: Any, supports: str) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    result = {"supports": supports, "status": raw.get("status", "unknown"), "authority": raw.get("provider") or raw.get("source_type"), "last_checked": raw.get("retrieved_at") or raw.get("checked_at"), "confidence": raw.get("confidence"), "source_url": raw.get("source_url")}
+    return {key: value for key, value in result.items() if value is not None}
+
+
+def _generic_bundle(trip: dict[str, Any], config: dict[str, Any], trip_path: Path, readiness: str, generated_at: str) -> dict[str, Any]:
+    candidate = trip.get("candidate_sets") if isinstance(trip.get("candidate_sets"), dict) else {}
+    places = [place for place in candidate.get("places", []) if isinstance(place, dict) and place.get("id")]
+    place_index = {place["id"]: place for place in places}
+    days = []
+    for day in trip.get("days", []):
+        if not isinstance(day, dict):
+            continue
+        days.append({"date": day.get("date"), "summary": day.get("summary"), "items": [{key: item.get(key) for key in ("id", "kind", "place_id", "start_at", "end_at") if item.get(key) is not None} for item in day.get("items", []) if isinstance(item, dict)]})
+    safe_places = [{key: place.get(key) for key in ("id", "name", "address", "kind", "maps_query") if place.get(key) is not None} for place in places]
+    legs = [{key: leg.get(key) for key in ("id", "mode", "from_place_id", "to_place_id", "departure_at", "arrival_at", "estimated_duration", "distance_km") if leg.get(key) is not None} for leg in candidate.get("transport_legs", []) if isinstance(leg, dict)]
+    validation = [{key: item.get(key) for key in ("code", "message", "severity", "path", "reference") if item.get(key) is not None} for item in trip.get("validation", []) if isinstance(item, dict)]
+    ledger = []
+    if _safe_provenance(trip.get("provenance"), "trip"):
+        ledger.append(_safe_provenance(trip.get("provenance"), "trip"))
+    for place in places:
+        entry = _safe_provenance(place.get("provenance"), f"place:{place['id']}")
+        if entry:
+            ledger.append(entry)
+    budget = trip.get("budget") if isinstance(trip.get("budget"), dict) else {}
+    total = budget.get("total") if isinstance(budget.get("total"), dict) else {}
+    return {
+        "schema_version": "trip-public-bundle-v1", "trip_id": config["trip_id"], "title": config.get("title_override") or trip.get("title"), "local_timezone": trip.get("local_timezone"), "date_range": trip.get("date_range", {}),
+        "overview": {"trip_scope": [config["trip_id"]], "day_count": len(days)}, "traveler_profile": {"adults": (trip.get("traveler_profile") or {}).get("adults", 0), "children_count": len((trip.get("traveler_profile") or {}).get("children", []))},
+        "places": safe_places, "days": days, "transport_legs": legs, "selected": {"hotel_place_ids": (trip.get("selected") or {}).get("hotel_place_ids", []), "flight_ids": (trip.get("selected") or {}).get("flight_ids", [])},
+        "reservations": [], "flights": [{"id": item.get("id"), "carrier": item.get("carrier"), "flight_number": item.get("flight_number")} for item in candidate.get("flights", []) if isinstance(item, dict)],
+        "hotels": [{"place_id": (item.get("place") or {}).get("id"), "check_in": item.get("check_in"), "check_out": item.get("check_out")} for item in candidate.get("hotels", []) if isinstance(item, dict)],
+        "conditions": {"status": "unknown"}, "alternatives": [], "meals": [], "budget": {"currency": budget.get("currency"), "total": {"amount": total.get("amount"), "currency": total.get("currency") or budget.get("currency")}},
+        "validation": validation, "source_ledger": ledger, "site": {"slug": config["slug"], "theme_id": config["theme_id"], "features": config["features"], "media_manifest": config["media_manifest"]}, "build": {"publisher": PUBLISHER_VERSION, "generated_at": generated_at, "validation_status": readiness}
+    }
+
+
+def _write_shell(path: Path, config: dict[str, Any]) -> None:
+    title = config.get("title_override") or config["trip_id"]
+    path.write_text(
+        "<!doctype html><html lang=\"zh-Hant\"><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><title>"
+        + title.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        + "</title></head><body><div id=\"root\"></div><script type=\"application/json\" data-trip-site-config>"
+        + json.dumps({"slug": config["slug"], "trip_id": config["trip_id"], "theme_id": config["theme_id"]}, ensure_ascii=False)
+        + "</script></body></html>\n",
+        encoding="utf-8",
+    )
+
+
+def build_trip(trip_path: Path, config_path: Path, output_root: Path) -> BuildResult:
+    config = load_config(config_path)
+    if config["trip_id"] != _read(trip_path).get("id"):
+        raise ValueError(f"{config_path}: trip_id does not match canonical trip")
+    media_path = config_path.parent / config["media_manifest"]
+    media = load_media(media_path)
+    trip = _read(trip_path)
+    validate_trip(trip)
+    readiness, issues = _readiness(trip, config)
+    if config["publication_status"] == "published" and readiness == "blocked":
+        raise ValueError("critical validation failure blocks published build: " + "; ".join(issues))
+
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    bundle = _generic_bundle(trip, config, trip_path, readiness, generated_at)
+    out = output_root / "trips" / config["slug"]
+    out.mkdir(parents=True, exist_ok=True)
+    _write(out / "public-bundle.json", bundle)
+    bundle_hash = _file_sha(out / "public-bundle.json")
+    _write(out / "site.json", {key: config[key] for key in ("schema_version", "trip_id", "slug", "publication_status", "theme_id", "media_manifest", "features", "pwa", "seo", "output_path") if key in config})
+    _write(out / "site-media.json", {"schema_version": media["schema_version"], "trip_id": media.get("trip_id"), "assets": [{key: asset.get(key) for key in ("id", "kind", "status", "source_url", "alt", "license") if asset.get(key) is not None} for asset in media["assets"]]})
+    _write_shell(out / "index.html", config)
+    report = {
+        "schema_version": "trip-site-build-report-v1",
+        "publisher": PUBLISHER_VERSION,
+        "trip_id": config["trip_id"],
+        "slug": config["slug"],
+        "readiness": readiness,
+        "input_hashes": {"trip": _file_sha(trip_path), "site_config": _file_sha(config_path), "media_manifest": _file_sha(media_path)},
+        "outputs": {"bundle_sha256": bundle_hash, "output_path": str(out)},
+        "versions": {"bundle": "trip-public-bundle-v1", "theme": config["theme_id"], "media": media["schema_version"]},
+        "generated_at": generated_at,
+    }
+    report_path = out / "build-report.json"
+    report["outputs"]["web_asset_sha256"] = _file_sha(out / "index.html")
+    _write(report_path, report)
+    return BuildResult(config["trip_id"], config["slug"], out, bundle_hash, report_path, readiness)
+
+
+def build_all(config_root: Path, output_root: Path) -> list[BuildResult]:
+    configs = sorted(config_root.glob("**/site.json"))
+    if not configs:
+        raise ValueError(f"no site.json found under {config_root}")
+    results = []
+    output_root.mkdir(parents=True, exist_ok=True)
+    trips_output = output_root / "trips"
+    if trips_output.exists():
+        shutil.rmtree(trips_output)
+    configs_by_trip_id: dict[str, dict[str, Any]] = {}
+    for config_path in configs:
+        config = load_config(config_path)
+        trip_path = config_path.parent / config.get("trip_file", "trip.json")
+        configs_by_trip_id[config["trip_id"]] = config
+        results.append(build_trip(trip_path, config_path, output_root))
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    registry = [_registry_entry(_read(result.output_dir / "public-bundle.json"), configs_by_trip_id[result.trip_id], result.readiness, generated_at, result.bundle_sha256) for result in results]
+    _write(output_root / "registry.json", {"schema_version": REGISTRY_SCHEMA, "generated_at": generated_at, "trips": registry})
+    root_index = output_root / "index.html"
+    root_index.write_text("<!doctype html><html lang=\"zh-Hant\"><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><title>Japan Trip Sites</title></head><body><main><h1>Japan Trip Sites</h1><p>See registry.json for the generated trip catalog.</p></main></body></html>\n", encoding="utf-8")
+    return results
+
+
+def init_site(trip_id: str, slug: str, theme_id: str, target: Path) -> tuple[Path, Path]:
+    target.mkdir(parents=True, exist_ok=True)
+    config = {"schema_version": CONFIG_SCHEMA, "trip_id": trip_id, "slug": slug, "publication_status": "preview", "theme_id": theme_id, "media_manifest": "site-media.json", "features": {"itinerary": True, "driving": False, "conditions": False, "local_planner": False}, "pwa": {"name": trip_id, "scope": f"/trips/{slug}/"}, "seo": {"title": trip_id, "description": "待填寫；不可放入虛構行程資料。"}, "output_path": f"site/trips/{slug}/", "trip_file": "trip.json"}
+    media = {"schema_version": MEDIA_SCHEMA, "trip_id": trip_id, "assets": []}
+    config_path, media_path = target / "site.json", target / "site-media.json"
+    _write(config_path, config)
+    _write(media_path, media)
+    return config_path, media_path

--- a/src/web_publisher/pipeline.py
+++ b/src/web_publisher/pipeline.py
@@ -15,7 +15,6 @@ CONFIG_SCHEMA = "trip-site-v1"
 MEDIA_SCHEMA = "trip-media-v1"
 REGISTRY_SCHEMA = "trip-registry-v1"
 PUBLISHER_VERSION = "trip-site-publisher-v1"
-SENSITIVE_KEYS = {"api_key", "apikey", "authorization", "password", "secret", "token", "booking_reference", "private_notes"}
 
 
 @dataclass(frozen=True)
@@ -45,22 +44,6 @@ def _file_sha(path: Path) -> str:
     return _sha(path.read_bytes())
 
 
-def _strip_private(value: Any, parent_key: str = "") -> Any:
-    if isinstance(value, dict):
-        result = {}
-        for key, child in value.items():
-            normalized = key.lower().replace("-", "_")
-            if normalized in SENSITIVE_KEYS or any(part in normalized for part in ("api_key", "password", "access_token")):
-                continue
-            if key in {"source_path", "absolute_path"}:
-                continue
-            result[key] = _strip_private(child, normalized)
-        return result
-    if isinstance(value, list):
-        return [_strip_private(child, parent_key) for child in value]
-    return value
-
-
 def load_config(config_path: Path) -> dict[str, Any]:
     config = _read(config_path)
     if config.get("schema_version") != CONFIG_SCHEMA:
@@ -77,6 +60,9 @@ def load_config(config_path: Path) -> dict[str, Any]:
         raise ValueError(f"{config_path}: slug must contain only lowercase letters, digits, and hyphens")
     if Path(config["media_manifest"]).is_absolute() or ".." in Path(config["media_manifest"]).parts:
         raise ValueError(f"{config_path}: media_manifest must stay inside its config directory")
+    output_path = Path(config["output_path"])
+    if output_path.is_absolute() or ".." in output_path.parts or output_path.as_posix().rstrip("/") != f"trips/{config['slug']}":
+        raise ValueError(f"{config_path}: output_path must be trips/<slug>/")
     return config
 
 
@@ -107,6 +93,8 @@ def _readiness(trip: dict[str, Any], config: dict[str, Any]) -> tuple[str, list[
                 issues.append(message)
             elif severity in {"warning", "unknown", "unverified", "conflict", "stale"}:
                 uncertainty.append(message)
+            elif severity not in {"pass", "passed", "ok"}:
+                uncertainty.append(f"unrecognized validation severity: {severity}")
     if not trip.get("validation"):
         uncertainty.append("no recorded validation result")
     if config["publication_status"] == "published" and (issues or uncertainty):
@@ -200,10 +188,17 @@ def build_trip(trip_path: Path, config_path: Path, output_root: Path) -> BuildRe
 
     generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     bundle = _generic_bundle(trip, config, trip_path, readiness, generated_at)
-    out = output_root / "trips" / config["slug"]
+    resolved_trip = trip_path.resolve()
+    repo_root = Path(__file__).resolve().parents[2]
+    config_root = config_path.parent.resolve()
+    if not (resolved_trip.is_relative_to(repo_root) or resolved_trip.is_relative_to(config_root)):
+        raise ValueError("trip_file must remain within the repository or site config directory")
+    out = output_root / config["output_path"]
     out.mkdir(parents=True, exist_ok=True)
     _write(out / "public-bundle.json", bundle)
-    bundle_hash = _file_sha(out / "public-bundle.json")
+    stable_bundle = json.loads(json.dumps(bundle))
+    stable_bundle["build"].pop("generated_at", None)
+    bundle_hash = _sha(json.dumps(stable_bundle, ensure_ascii=False, indent=2, sort_keys=True).encode())
     _write(out / "site.json", {key: config[key] for key in ("schema_version", "trip_id", "slug", "publication_status", "theme_id", "media_manifest", "features", "pwa", "seo", "output_path") if key in config})
     _write(out / "site-media.json", {"schema_version": media["schema_version"], "trip_id": media.get("trip_id"), "assets": [{key: asset.get(key) for key in ("id", "kind", "status", "source_url", "alt", "license") if asset.get(key) is not None} for asset in media["assets"]]})
     _write_shell(out / "index.html", config)
@@ -234,10 +229,14 @@ def build_all(config_root: Path, output_root: Path) -> list[BuildResult]:
     if trips_output.exists():
         shutil.rmtree(trips_output)
     configs_by_trip_id: dict[str, dict[str, Any]] = {}
+    slugs: set[str] = set()
     for config_path in configs:
         config = load_config(config_path)
+        if config["trip_id"] in configs_by_trip_id or config["slug"] in slugs:
+            raise ValueError(f"duplicate trip_id or slug in {config_path}")
         trip_path = config_path.parent / config.get("trip_file", "trip.json")
         configs_by_trip_id[config["trip_id"]] = config
+        slugs.add(config["slug"])
         results.append(build_trip(trip_path, config_path, output_root))
     generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     registry = [_registry_entry(_read(result.output_dir / "public-bundle.json"), configs_by_trip_id[result.trip_id], result.readiness, generated_at, result.bundle_sha256) for result in results]
@@ -249,7 +248,7 @@ def build_all(config_root: Path, output_root: Path) -> list[BuildResult]:
 
 def init_site(trip_id: str, slug: str, theme_id: str, target: Path) -> tuple[Path, Path]:
     target.mkdir(parents=True, exist_ok=True)
-    config = {"schema_version": CONFIG_SCHEMA, "trip_id": trip_id, "slug": slug, "publication_status": "preview", "theme_id": theme_id, "media_manifest": "site-media.json", "features": {"itinerary": True, "driving": False, "conditions": False, "local_planner": False}, "pwa": {"name": trip_id, "scope": f"/trips/{slug}/"}, "seo": {"title": trip_id, "description": "待填寫；不可放入虛構行程資料。"}, "output_path": f"site/trips/{slug}/", "trip_file": "trip.json"}
+    config = {"schema_version": CONFIG_SCHEMA, "trip_id": trip_id, "slug": slug, "publication_status": "preview", "theme_id": theme_id, "media_manifest": "site-media.json", "features": {"itinerary": True, "driving": False, "conditions": False, "local_planner": False}, "pwa": {"name": trip_id, "scope": f"/trips/{slug}/"}, "seo": {"title": trip_id, "description": "待填寫；不可放入虛構行程資料。"}, "output_path": f"trips/{slug}/", "trip_file": "trip.json"}
     media = {"schema_version": MEDIA_SCHEMA, "trip_id": trip_id, "assets": []}
     config_path, media_path = target / "site.json", target / "site-media.json"
     _write(config_path, config)

--- a/tests/test_web_publisher.py
+++ b/tests/test_web_publisher.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.web_publisher import build_all, build_trip, init_site
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class WebPublisherTests(unittest.TestCase):
+    def test_build_all_emits_two_trip_registry_and_hashes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "site"
+            results = build_all(ROOT / "site-configs", output)
+            self.assertEqual({result.slug for result in results}, {"awaji-2026", "kyushu-2026"})
+            registry = json.loads((output / "registry.json").read_text())
+            self.assertEqual(registry["schema_version"], "trip-registry-v1")
+            self.assertEqual({item["theme_id"] for item in registry["trips"]}, {"setouchi-awaji", "snow-kyushu"})
+            self.assertEqual({item["duration_days"] for item in registry["trips"]}, {3, 5})
+            self.assertTrue((output / "trips/awaji-2026/index.html").exists())
+            self.assertTrue((output / "trips/kyushu-2026/public-bundle.json").exists())
+            for result in results:
+                report = json.loads(result.report_path.read_text())
+                self.assertEqual(report["outputs"]["bundle_sha256"], result.bundle_sha256)
+
+    def test_bundle_has_generic_contract_and_no_sensitive_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "site"
+            build_all(ROOT / "site-configs", output)
+            bundle = json.loads((output / "trips/kyushu-2026/public-bundle.json").read_text())
+            self.assertEqual(bundle["schema_version"], "trip-public-bundle-v1")
+            self.assertEqual(bundle["site"]["slug"], "kyushu-2026")
+            text = json.dumps(bundle).lower()
+            for secret in ("api_key", "password", "access_token", "booking_reference"):
+                self.assertNotIn(secret, text)
+            self.assertNotIn("awaji", text)
+
+    def test_scaffold_contains_no_trip_facts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config, media = init_site("hokkaido-2027", "hokkaido-2027", "snow-hokkaido", Path(directory))
+            self.assertIn("trip-site-v1", config.read_text())
+            self.assertEqual(json.loads(media.read_text())["assets"], [])
+
+    def test_published_trip_without_validation_is_blocked(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = json.loads((ROOT / "site-configs/kyushu-2026/site.json").read_text())
+            config["publication_status"] = "published"
+            config_path = root / "site.json"
+            media_path = root / "site-media.json"
+            trip_path = root / "trip.json"
+            config_path.write_text(json.dumps(config))
+            media_path.write_text((ROOT / "site-configs/kyushu-2026/site-media.json").read_text())
+            trip_path.write_text((ROOT / "site-configs/kyushu-2026/trip.json").read_text())
+            with self.assertRaises(ValueError):
+                build_trip(trip_path, config_path, root / "out")
+
+    def test_invalid_slug_and_private_trip_field_are_rejected_or_redacted(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = json.loads((ROOT / "site-configs/kyushu-2026/site.json").read_text())
+            config["slug"] = "../escape"
+            config_path = root / "site.json"
+            config_path.write_text(json.dumps(config))
+            with self.assertRaises(ValueError):
+                build_trip(ROOT / "site-configs/kyushu-2026/trip.json", config_path, root / "out")
+
+    def test_module_cli_is_available(self) -> None:
+        result = subprocess.run(["python3", "-m", "src.web_publisher", "--help"], cwd=ROOT, capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("build-all", result.stdout)
+
+    def test_rebuild_keeps_public_projection_stable_except_timestamp(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "site"
+            build_all(ROOT / "site-configs", output)
+            first = json.loads((output / "trips/kyushu-2026/public-bundle.json").read_text())
+            build_all(ROOT / "site-configs", output)
+            second = json.loads((output / "trips/kyushu-2026/public-bundle.json").read_text())
+            first["build"].pop("generated_at", None)
+            second["build"].pop("generated_at", None)
+            self.assertEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_publisher.py
+++ b/tests/test_web_publisher.py
@@ -79,12 +79,15 @@ class WebPublisherTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             output = Path(directory) / "site"
             build_all(ROOT / "site-configs", output)
+            first_hashes = [item["bundle_sha256"] for item in json.loads((output / "registry.json").read_text())["trips"]]
             first = json.loads((output / "trips/kyushu-2026/public-bundle.json").read_text())
             build_all(ROOT / "site-configs", output)
+            second_hashes = [item["bundle_sha256"] for item in json.loads((output / "registry.json").read_text())["trips"]]
             second = json.loads((output / "trips/kyushu-2026/public-bundle.json").read_text())
             first["build"].pop("generated_at", None)
             second["build"].pop("generated_at", None)
             self.assertEqual(first, second)
+            self.assertEqual(first_hashes, second_hashes)
 
 
 if __name__ == "__main__":

--- a/web/contracts/public-bundle/schema.json
+++ b/web/contracts/public-bundle/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "trip-public-bundle-v1",
+  "type": "object",
+  "required": ["schema_version", "trip_id", "site", "build", "days", "validation", "source_ledger"],
+  "properties": {
+    "schema_version": {"const": "trip-public-bundle-v1"},
+    "trip_id": {"type": "string"},
+    "site": {"type": "object", "required": ["slug", "theme_id", "features"]},
+    "build": {"type": "object", "required": ["publisher", "generated_at", "validation_status"]},
+    "days": {"type": "array"},
+    "validation": {"type": "array"},
+    "source_ledger": {"type": "array"},
+    "title": {"type": ["string", "null"]},
+    "local_timezone": {"type": ["string", "null"]},
+    "date_range": {"type": "object"},
+    "overview": {"type": "object"},
+    "traveler_profile": {"type": "object"},
+    "places": {"type": "array"},
+    "transport_legs": {"type": "array"},
+    "selected": {"type": "object"},
+    "reservations": {"type": "array"},
+    "flights": {"type": "array"},
+    "hotels": {"type": "array"},
+    "conditions": {"type": "object"},
+    "alternatives": {"type": "array"},
+    "meals": {"type": "array"},
+    "budget": {"type": "object"}
+  },
+  "additionalProperties": false
+}

--- a/web/contracts/site-config/schema.json
+++ b/web/contracts/site-config/schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "trip-site-v1",
+  "type": "object",
+  "required": ["schema_version", "trip_id", "slug", "publication_status", "theme_id", "media_manifest", "features", "output_path"],
+  "properties": {
+    "schema_version": {"const": "trip-site-v1"},
+    "trip_id": {"type": "string", "minLength": 1},
+    "slug": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+    "publication_status": {"enum": ["preview", "published", "archived"]},
+    "theme_id": {"type": "string", "minLength": 1},
+    "media_manifest": {"type": "string", "minLength": 1},
+    "features": {"type": "object", "additionalProperties": {"type": "boolean"}},
+    "output_path": {"type": "string", "minLength": 1},
+    "trip_file": {"type": "string"},
+    "pwa": {"type": "object"},
+    "seo": {"type": "object"},
+    "title_override": {"type": "string"}
+  },
+  "additionalProperties": false
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "awaji-trip-pwa",
+  "name": "japan-trip-site",
   "private": true,
   "version": "1.0.0",
   "type": "module",
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "echo \"lint: skipped\"",
     "lint:tw": "echo \"lint:tw skipped\"",
-    "validate:data": "python3 ../scripts/check-awaji-contamination.py && python3 ../scripts/build_awaji_public_bundle.py --trip-path ../trips/awaji-naruto-tokushima-kobe-2026/trip.json --output ../trips/awaji-naruto-tokushima-kobe-2026/public-bundle.json --web-output public/trips/awaji-2026/public-bundle.json",
+    "validate:data": "python3 ../scripts/build_all_trip_sites.py --configs ../site-configs --output ../site",
     "test": "echo \"No tests in web package\"",
     "test:e2e": "echo \"e2e not configured in this worktree\"",
     "screenshots": "echo \"screenshots not configured in this worktree\"",


### PR DESCRIPTION
## Summary
Implements the reusable offline Japan trip publishing foundation for #72.

## Delivered
- Generic `src.web_publisher` projection with versioned site config, public bundle, media, registry, and build report contracts.
- Unified module CLI: `validate`, `build`, `build-all`, `preview`, `init`.
- Explicit public allowlist projection; no provider raw payloads, credentials, booking tokens, or absolute source paths.
- Publication gate: critical/unknown/unverified/incomplete validation cannot become published-ready.
- Safe slug/path handling and stale trip artifact cleanup.
- Awaji and structurally different 3-day Kyushu recorded configs with different theme/media/features.
- Architecture docs and six publisher tests including privacy, invalid slug, module CLI, publication blocking, and rebuild stability.

## Evidence
- `python3 -m unittest discover -s tests -v`: 171 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q`: 235 passed
- `python3 scripts/validate_agent_collaboration.py`: PASS
- `python3 -m scripts.agent.collaboration check 72`: PASS
- `npm --prefix web run lint/typecheck/test/build/test:e2e`: PASS after `npm ci` (existing lint/test/e2e scripts are placeholders where noted)
- Exact head: `1cde2c623623792bb30c1017dcf0ec1a879d0be`

## Integration boundary
Existing `web/src/**`, Pages workflow, and web public output remain owned by Issues 61/62/63/69. This PR supplies their generic publisher contracts and artifact inputs without crossing those ownership boundaries; the final React/PWA/Pages wiring must be integrated by the owning workstreams.

Closes #72