### PR TITLE
feat(web): refresh Awaji itinerary readability

### DIFF
--- a/docs/awaji-day-ui-refresh.md
+++ b/docs/awaji-day-ui-refresh.md
@@ -1,0 +1,7 @@
+# Awaji day UI refresh
+
+Issue #89 的正式頁面改採 ai_kyushu 的資訊階層：深色 desktop sidebar、白色 top bar、sticky day selector、單一日摘要 hero，以及可在現場掃讀的垂直 itinerary timeline。視覺保留淡路島的海藍與青綠，而不是複製九州內容或假造旅行資料。
+
+每一個停靠點都直接由 Canonical public bundle 的 date、place、notes、status 與 operational unknown 驅動。固定預約仍以 amber warning 顯示，未解析的地址、duration 與狀態不會被渲染成 confirmed。
+
+仍未實作：完整五日的 prototype-specific hero 文案、地圖 API、reservation write workflow，及外部 photo media。這次變更只改善正式 TripApp 的可讀性與資訊層級，不改動 Canonical Trip 或 production data source。

--- a/web/src/hooks/useBundleLoader.ts
+++ b/web/src/hooks/useBundleLoader.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Bundle, parseBundle } from '../contracts/trip'
 
 type LoadStatus = 'loading' | 'ready' | 'error' | 'offline-with-cache' | 'offline-without-cache'
@@ -21,6 +21,7 @@ export function resolveBundleUrl(baseUrl: string, canonicalUrl: string): string 
 
 export function useBundleLoader(): BundleLoaderState {
   const [bundle, setBundle] = useState<Bundle | null>(null)
+  const bundleRef = useRef<Bundle | null>(null)
   const [status, setStatus] = useState<LoadStatus>('loading')
   const [error, setError] = useState('')
   const [isOnline, setIsOnline] = useState(true)
@@ -52,7 +53,7 @@ export function useBundleLoader(): BundleLoaderState {
       response = await fetch(resolveBundleUrl(baseUrl, entry.canonical_url))
       if (!response.ok) throw new Error(`bundle HTTP ${response.status}`)
     } catch (error) {
-      const hasCache = !!bundle
+      const hasCache = !!bundleRef.current
       const message = `${hasCache ? '目前為離線快取資料' : '載入不到行程資料'}（${error instanceof Error ? error.message : 'network error'}）`
       setError(message)
       setStatus(hasCache ? 'offline-with-cache' : 'offline-without-cache')
@@ -63,6 +64,7 @@ export function useBundleLoader(): BundleLoaderState {
       const parsed = parseBundle(await response.json())
       if (!parsed.ok) throw new Error(parsed.error)
       const data = parsed.value
+      bundleRef.current = data
       setBundle(data)
       setIsUpdateAvailable(false)
       checkVersion(data)
@@ -71,7 +73,7 @@ export function useBundleLoader(): BundleLoaderState {
       setError(err instanceof Error ? err.message : '資料格式錯誤')
       setStatus('error')
     }
-  }, [baseUrl, bundle, checkVersion])
+  }, [baseUrl, checkVersion])
 
   useEffect(() => {
     setIsOnline(window.navigator.onLine)

--- a/web/src/layouts/DesktopSidebar.tsx
+++ b/web/src/layouts/DesktopSidebar.tsx
@@ -12,10 +12,12 @@ export function DesktopSidebar({ sections, activeSection, onNavigate, title, sub
   return (
     <aside className="trip-sidebar" aria-label="主要導覽">
       <div className="trip-brand">
-        <p className="trip-brand-title">Golden Trip</p>
-        <p className="trip-brand-subtitle">{title}</p>
+        <p className="trip-brand-kicker"><span>✦</span> Trip Planner · 2026</p>
+        <h1 className="trip-brand-title">{title}</h1>
         <p className="trip-brand-subtitle">{subtitle}</p>
       </div>
+      <div className="trip-sidebar-status"><span>●</span><div><strong>旅途中可用行程</strong><small>公開資料與待補狀態會明確標示</small></div></div>
+      <p className="trip-nav-label">主控選單</p>
       <nav className="trip-nav" aria-label="行程區段">
         {sections.map((section) => (
           <button

--- a/web/src/layouts/TripShell.tsx
+++ b/web/src/layouts/TripShell.tsx
@@ -53,7 +53,6 @@ export default function TripShell({
   setDrawerOpen,
   children,
 }: TripShellProps) {
-  const pageRef = useRef<HTMLDivElement>(null)
   const drawerRef = useRef<HTMLDivElement>(null)
   const [currentStatusText, setCurrentStatusText] = useState(statusText[shellStatus])
 
@@ -97,11 +96,11 @@ export default function TripShell({
     }
   }, [isDrawerOpen, setDrawerOpen])
 
-  useEffect(() => {
-    pageRef.current?.focus()
-  }, [children, activeSection])
-
   const visibleState = useMemo(() => shellStatus !== 'normal', [shellStatus])
+  const activeLabel = sections.find((section) => section.id === activeSection)?.label || '旅行總覽'
+  const travelerText = bundle
+    ? `${bundle.traveler_profile.adults} 大 ${bundle.traveler_profile.children_count} 小`
+    : '旅客資料載入中'
 
   return (
     <div className={`app-shell ${visibleState ? 'with-alert' : ''}`}>
@@ -123,8 +122,12 @@ export default function TripShell({
         />
 
         <main className="app-main" id="trip-main">
+          <header className="desktop-topbar">
+            <div><span className="desktop-topbar-section">{activeLabel}</span><span className="desktop-topbar-divider">/</span><span>{subtitle}</span></div>
+            <div><span className="desktop-status"><i />{currentStatusText}</span><span className="desktop-travelers">{travelerText}</span></div>
+          </header>
           <header className="trip-main-header">
-            <div className="main-title" id={pageTitleId} ref={pageRef} tabIndex={-1}>
+            <div className="main-title" id={pageTitleId}>
               {title}
             </div>
             <div className="shell-status-line">

--- a/web/src/pages/ItineraryPage.tsx
+++ b/web/src/pages/ItineraryPage.tsx
@@ -2,11 +2,14 @@ import { useEffect, useMemo, useState } from 'react'
 import { Bundle, BundleDayItem, buildMapsLink, findPlaceAddress, findPlaceLabel } from '../contracts/trip'
 import { buildRoutePath, TripRoute } from '../app/route-registry'
 
-interface ItineraryPageProps { bundle: Bundle; route: TripRoute; onNavigate: (next: Partial<TripRoute>) => void }
+interface ItineraryPageProps {
+  bundle: Bundle
+  route: TripRoute
+  onNavigate: (next: Partial<TripRoute>) => void
+}
 
 function parseMinutes(value: string | null): number | null {
-  if (!value) return null
-  const match = value.match(/(\d{1,2}):(\d{2})/)
+  const match = value?.match(/(\d{1,2}):(\d{2})/)
   return match ? Number(match[1]) * 60 + Number(match[2]) : null
 }
 
@@ -14,40 +17,35 @@ function currentMinutesInTripZone(timeZone: string, dayDate: string): number | n
   try {
     const parts = new Intl.DateTimeFormat('en-CA', {
       timeZone,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
+      year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: false,
     }).formatToParts(new Date())
     const values = Object.fromEntries(parts.filter((part) => part.type !== 'literal').map((part) => [part.type, part.value]))
     if (`${values.year}-${values.month}-${values.day}` !== dayDate) return null
-    const hour = Number(values.hour)
-    const minute = Number(values.minute)
-    return Number.isFinite(hour) && Number.isFinite(minute) ? hour * 60 + minute : null
+    return Number(values.hour) * 60 + Number(values.minute)
   } catch {
     return null
   }
 }
 
-function approvedAlternative(status: string | null | undefined): boolean {
-  return ['approved', 'ok', 'recommended', 'selected', 'validator-approved'].includes((status || '').toLowerCase())
+function timeLabel(value: string | null): string {
+  if (!value) return '待補'
+  return value.match(/T(\d{2}:\d{2})/)?.[1] || value
 }
 
-function itemState(item: BundleDayItem): string[] {
+function itemState(item: BundleDayItem, reservationUnresolved: boolean): string[] {
   const states: string[] = []
   if (item.fixed || item.kind === 'reservation' || item.kind === 'flight') states.push('固定')
   if (item.optional || item.kind === 'optional' || item.notes?.toLowerCase().includes('optional')) states.push('可選')
   if (item.cancelable || item.notes?.includes('可取消')) states.push('可取消')
-  if (item.unresolved || !item.start_at || !item.end_at) states.push('待補')
+  if (item.unresolved || reservationUnresolved || !item.start_at || !item.end_at) states.push('待補')
   return states.length ? states : ['已確認']
 }
 
-function highlight(value: string, query: string): JSX.Element {
-  if (!query) return <>{value}</>
-  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  return <>{value.split(new RegExp(`(${escaped})`, 'ig')).map((part, index) => part.toLowerCase() === query.toLowerCase() ? <mark key={index}>{part}</mark> : part)}</>
+function itemVisualKind(item: BundleDayItem, reservationLinked = false): 'reservation' | 'meal' | 'move' | 'place' {
+  if (reservationLinked || item.fixed || item.kind === 'reservation' || item.kind === 'flight') return 'reservation'
+  if (item.kind === 'meal' || item.kind === 'food') return 'meal'
+  if (item.kind === 'transport' || item.kind === 'car' || item.kind === 'move') return 'move'
+  return 'place'
 }
 
 export function ItineraryPage({ bundle, route, onNavigate }: ItineraryPageProps) {
@@ -57,51 +55,123 @@ export function ItineraryPage({ bundle, route, onNavigate }: ItineraryPageProps)
   const [quickMode, setQuickMode] = useState<'all' | 'now' | 'next'>('all')
   const [showPrintView, setShowPrintView] = useState(false)
   const selectedDay = bundle.days.find((day) => day.date === route.day) ?? (route.day && Number(route.day) > 0 ? bundle.days[Number(route.day) - 1] : undefined) ?? bundle.days[0]
-  const currentMinutes = useMemo(() => {
-    return selectedDay ? currentMinutesInTripZone(bundle.local_timezone, selectedDay.date) : null
-  }, [bundle.local_timezone, selectedDay])
-  const nowIndex = selectedDay?.items.findIndex((item) => { const start = parseMinutes(item.start_at); const end = parseMinutes(item.end_at); return currentMinutes != null && start != null && end != null && currentMinutes >= start && currentMinutes <= end }) ?? -1
-  const nextIndex = selectedDay?.items.findIndex((item) => { const start = parseMinutes(item.start_at); return currentMinutes != null && start != null && start >= currentMinutes }) ?? -1
+  const selectedDayIndex = bundle.days.findIndex((day) => day.date === selectedDay?.date)
+  const currentMinutes = useMemo(() => selectedDay ? currentMinutesInTripZone(bundle.local_timezone, selectedDay.date) : null, [bundle.local_timezone, selectedDay])
+  const nowIndex = selectedDay?.items.findIndex((item) => {
+    const start = parseMinutes(item.start_at)
+    const end = parseMinutes(item.end_at)
+    return currentMinutes != null && start != null && end != null && currentMinutes >= start && currentMinutes <= end
+  }) ?? -1
+  const nextIndex = selectedDay?.items.findIndex((item) => {
+    const start = parseMinutes(item.start_at)
+    return currentMinutes != null && start != null && start >= currentMinutes
+  }) ?? -1
   const visibleItems = selectedDay?.items.filter((_, index) => quickMode === 'now' ? index === nowIndex : quickMode === 'next' ? index === nextIndex : true) ?? []
+  const reservationFor = (item: BundleDayItem) => bundle.reservations.find((reservation) => reservation.id === item.id || reservation.itinerary_item_id === item.id)
   const normalizedQuery = query.trim().toLowerCase()
   const searchResults = useMemo(() => !normalizedQuery ? [] : bundle.days.flatMap((day, dayIndex) => day.items.flatMap((item) => {
     const place = bundle.places?.find((candidate) => candidate.id === item.place_id)
-    const text = [day.date, day.summary, item.id, item.kind, item.notes, place?.name, place?.name_ja, place?.address].filter(Boolean).join(' ').toLowerCase()
+    const text = [day.date, day.summary, item.notes, place?.name, place?.name_ja, place?.address].filter(Boolean).join(' ').toLowerCase()
     return text.includes(normalizedQuery) ? [{ day, dayIndex, item, label: place?.name || item.place_id }] : []
   })), [bundle.days, bundle.places, normalizedQuery])
-  const metrics = useMemo(() => ({
-    attractions: selectedDay?.items.filter((item) => ['attraction', 'sightseeing', 'poi'].includes(item.kind)).length ?? 0,
-    optional: selectedDay?.items.filter((item) => item.optional || item.kind === 'optional').length ?? 0,
-    unresolved: selectedDay?.items.filter((item) => item.unresolved || !item.start_at || !item.end_at).length ?? 0,
-  }), [selectedDay])
-  const alternatives = (bundle.alternatives || []).filter((alternative) => (alternative.plan || 'A') === plan && approvedAlternative(alternative.status))
+  const metrics = {
+    places: selectedDay?.items.filter((item) => itemVisualKind(item, !!reservationFor(item)) === 'place').length ?? 0,
+    fixed: selectedDay?.items.filter((item) => itemVisualKind(item, !!reservationFor(item)) === 'reservation').length ?? 0,
+    unresolved: selectedDay?.items.filter((item) => item.unresolved || reservationFor(item)?.unresolved || !item.start_at || !item.end_at).length ?? 0,
+  }
+  const alternatives = (bundle.alternatives || []).filter((alternative) => (alternative.plan || 'A') === plan && ['approved', 'ok', 'recommended', 'selected', 'validator-approved'].includes((alternative.status || '').toLowerCase()))
+
   useEffect(() => {
     if (!route.item) return
-    const timer = window.setTimeout(() => {
-      const target = document.getElementById(`item-${route.item}`)
-      target?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-      target?.focus()
-    }, 0)
+    const timer = window.setTimeout(() => document.getElementById(`item-${route.item}`)?.scrollIntoView({ behavior: 'smooth', block: 'center' }), 0)
     return () => window.clearTimeout(timer)
-  }, [route.item, selectedDay.date])
+  }, [route.item, selectedDay?.date])
+
   if (!selectedDay) return <section className="card">沒有可顯示的行程日。</section>
-  const copyText = async (label: string, text: string) => { try { await navigator.clipboard.writeText(text); setCopiedId(label); setTimeout(() => setCopiedId(''), 1200) } catch { setCopiedId('error') } }
-  const navigateTo = (day: string, item?: string) => {
-    onNavigate({ section: 'today', day, item })
-    if (item) window.setTimeout(() => {
-      const target = document.getElementById(`item-${item}`)
-      target?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-      target?.focus()
-    }, 0)
+
+  const copyText = async (label: string, text: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopiedId(label)
+      window.setTimeout(() => setCopiedId((current) => current === label ? '' : current), 1400)
+    } catch {
+      setCopiedId('error')
+    }
   }
-  return <section className={`card itinerary-workspace ${showPrintView ? 'print-itinerary' : ''}`} aria-label="每日行程工作區">
-    <div className="itinerary-toolbar"><div><h2>互動行程工作區</h2><p className="muted">{bundle.date_range.start_date} ~ {bundle.date_range.end_date} · 時區 {bundle.local_timezone || 'unknown'}</p></div><button type="button" onClick={() => setShowPrintView((value) => !value)}>{showPrintView ? '返回操作模式' : '列印完整行程'}</button></div>
-    <div className="day-tabs" role="tablist" aria-label="行程日程頁籤">{bundle.days.map((day, index) => <button key={day.date} className={`day-tab ${day.date === selectedDay.date ? 'active' : ''}`} role="tab" aria-selected={day.date === selectedDay.date} onClick={() => navigateTo(day.date)} type="button">Day {index + 1}<span>{day.date}</span></button>)}</div>
-    {!showPrintView && <div className="itinerary-search"><label htmlFor="itinerary-search">搜尋全行程</label><input id="itinerary-search" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="中文／日文／地址／備註／category" />{searchResults.length > 0 && <ul className="search-results">{searchResults.map(({ day, dayIndex, item, label }) => <li key={`${day.date}-${item.id}`}><button type="button" onClick={() => navigateTo(day.date, item.id)}>{highlight(`${day.date} · ${label} · ${item.kind}`, query)}</button><span>{dayIndex + 1} 日</span></li>)}</ul>}{normalizedQuery && !searchResults.length && <p className="muted">找不到符合的公開行程資料。</p>}</div>}
-    <div className="journey-meta itinerary-metrics" aria-label="每日指標"><span>景點 {metrics.attractions}</span><span>可選 {metrics.optional}</span><span>待補 {metrics.unresolved}</span><span>開車時間 unknown</span><span>步行 unknown</span></div>
-    {!showPrintView && <div className="journey-meta quick-mode" aria-label="現場快速模式"><span>現場模式：</span>{(['all', 'now', 'next'] as const).map((mode) => <button key={mode} type="button" className={quickMode === mode ? 'active-pill' : ''} aria-pressed={quickMode === mode} onClick={() => setQuickMode(mode)}>{mode === 'all' ? '全部' : mode}</button>)}<span className="muted">{currentMinutes == null ? '時間或時區不足，now/next 為 unknown' : '依可比較時間顯示'}</span></div>}
-    <div className="day"><h3>{selectedDay.date}</h3><p>{selectedDay.summary}</p><ul>{visibleItems.map((item) => { const place = bundle.places?.find((candidate) => candidate.id === item.place_id); const states = itemState(item); return <li tabIndex={-1} className={`journey-item ${item.id === route.item ? 'item-highlight' : ''}`} id={`item-${item.id}`} key={item.id}><div><strong>{item.kind}</strong><span> · {item.start_at || '待補'} ~ {item.end_at || '待補'}</span><div className="status-chips">{states.map((state) => <span key={state} className="status-chip">{state}</span>)}</div></div><div className="journey-meta"><span>地點：{findPlaceLabel(bundle.places, item.place_id)}{place?.name_ja ? ` · ${place.name_ja}` : ''}</span>{findPlaceAddress(bundle.places, item.place_id) && <span>地址：{findPlaceAddress(bundle.places, item.place_id)}</span>}<span>停留：{item.expected_stay_minutes == null ? 'unknown' : `${item.expected_stay_minutes} 分鐘`} · 轉移：{item.transfer_minutes == null ? 'unknown' : `${item.transfer_minutes} 分鐘`} · buffer：{item.buffer_minutes == null ? 'unknown' : `${item.buffer_minutes} 分鐘`}</span>{item.notes && <span>備註：{item.notes}</span>}<a href={buildMapsLink(place?.maps_query || place?.name || item.place_id)} target="_blank" rel="noreferrer">開啟 Google Maps</a>{place?.phone && <a href={`tel:${place.phone}`}>撥打電話</a>}{place?.official_url && <a href={place.official_url} target="_blank" rel="noreferrer">官方網站</a>}<a href={buildRoutePath({ section: 'today', day: selectedDay.date, item: item.id })}>複製路徑</a><button type="button" onClick={() => copyText(`${selectedDay.date}-${item.id}`, `${findPlaceLabel(bundle.places, item.place_id)} ${findPlaceAddress(bundle.places, item.place_id)}`)}>{copiedId === `${selectedDay.date}-${item.id}` ? '已複製' : '複製地址'}</button></div></li> })}</ul></div>
-    <section className="workspace-subsection"><h3>Plan A / B / C</h3><div className="journey-meta">{(['A', 'B', 'C'] as const).map((value) => <button key={value} type="button" className={plan === value ? 'active-pill' : ''} onClick={() => setPlan(value)} aria-pressed={plan === value}>Plan {value}</button>)}</div>{alternatives.length ? alternatives.map((alternative) => <article className="journey-item" key={alternative.id}><strong>{alternative.title}</strong><p>{alternative.trigger || '觸發條件待補'} · {alternative.tradeoff || '取捨待補'}</p><p>{alternative.summary || '方案內容待補'} · Decision Gate：{alternative.decision_gate || '待補'}</p></article>) : <p className="muted">Plan {plan} unavailable：目前 public bundle 沒有 validator-approved 備案。</p>}<p className="muted">固定 anchor：{selectedDay.items.filter((item) => item.fixed || item.kind === 'reservation' || item.kind === 'flight').map((item) => item.kind).join('、') || 'unknown'}（方案切換不會修改 Canonical Trip）</p></section>
-    {showPrintView && <section className="workspace-subsection print-only"><h3>列印摘要</h3><p>資料版本：{bundle.meta.generated_at} · Critical unknown：{bundle.overview?.critical_unknown_count == null ? 'unknown' : bundle.overview.critical_unknown_count}</p></section>}
-  </section>
+  const navigateTo = (day: string, item?: string) => onNavigate({ section: 'today', day, item })
+
+  return (
+    <section className={`itinerary-workspace ${showPrintView ? 'print-itinerary' : ''}`} aria-label="每日行程工作區">
+      <div className="itinerary-day-nav" role="tablist" aria-label="行程日程頁籤">
+        <div className="day-nav-label"><span /> 五日導覽</div>
+        <div className="day-tabs">
+          {bundle.days.map((day, index) => (
+            <button key={day.date} className={`day-tab ${day.date === selectedDay.date ? 'active' : ''}`} role="tab" aria-selected={day.date === selectedDay.date} onClick={() => navigateTo(day.date)} type="button">
+              <strong>D{index + 1}</strong><span>{day.date.slice(5)}</span>
+            </button>
+          ))}
+        </div>
+        <button type="button" className="print-button" onClick={() => setShowPrintView((value) => !value)}>{showPrintView ? '返回操作模式' : '列印'}</button>
+      </div>
+
+      <header className="day-hero">
+        <div className="day-hero-copy">
+          <div className="day-kicker"><span>DAY {selectedDayIndex + 1}</span><span>{selectedDay.date}</span></div>
+          <h2>{selectedDay.summary}</h2>
+          <p>依 public bundle 呈現今日順序；固定事項與待補資料會在時間軸中明確標示。</p>
+        </div>
+        <div className="day-stats" aria-label="今日摘要">
+          <span><strong>{selectedDay.items.length}</strong> 停靠</span>
+          <span><strong>{metrics.fixed}</strong> 固定</span>
+          <span className={metrics.unresolved ? 'has-warning' : ''}><strong>{metrics.unresolved}</strong> 待補</span>
+        </div>
+      </header>
+
+      {!showPrintView && <div className="itinerary-utility">
+        <label className="itinerary-search" htmlFor="itinerary-search">
+          <span>搜尋全行程</span>
+          <input id="itinerary-search" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="景點、日文名稱、地址或備註" />
+        </label>
+        <div className="quick-mode" aria-label="現場快速模式">
+          <span>顯示：</span>
+          {(['all', 'now', 'next'] as const).map((mode) => <button key={mode} type="button" className={quickMode === mode ? 'active-pill' : ''} aria-pressed={quickMode === mode} onClick={() => setQuickMode(mode)}>{mode === 'all' ? '全部' : mode === 'now' ? '現在' : '下一站'}</button>)}
+        </div>
+      </div>}
+
+      {normalizedQuery ? <section className="search-results" aria-live="polite">
+        <p>找到 {searchResults.length} 個相符行程</p>
+        {searchResults.map(({ day, dayIndex, item, label }) => <button key={`${day.date}-${item.id}`} type="button" onClick={() => navigateTo(day.date, item.id)}><strong>D{dayIndex + 1}</strong><span>{label}</span><small>{day.date}</small></button>)}
+      </section> : <div className="timeline" aria-label={`${selectedDay.date} 時間軸`}>
+        {visibleItems.map((item, index) => {
+          const place = bundle.places?.find((candidate) => candidate.id === item.place_id)
+          const reservation = reservationFor(item)
+          const states = itemState(item, reservation?.unresolved === true)
+          const visualKind = itemVisualKind(item, !!reservation)
+          const itemCopied = copiedId === `${selectedDay.date}-${item.id}`
+          return <article tabIndex={-1} className={`timeline-entry ${visualKind} ${item.id === route.item ? 'item-highlight' : ''}`} id={`item-${item.id}`} key={item.id}>
+            <div className="timeline-time"><strong>{timeLabel(item.start_at)}</strong><span>{item.end_at && item.end_at !== item.start_at ? timeLabel(item.end_at) : visualKind === 'reservation' ? '固定' : ''}</span></div>
+            <div className="timeline-track"><span>{visualKind === 'reservation' ? '◆' : visualKind === 'meal' ? '✦' : visualKind === 'move' ? '→' : '●'}</span>{index < visibleItems.length - 1 && <i />}</div>
+            <div className="timeline-card">
+              <div className="timeline-card-topline"><span className="timeline-category">{visualKind === 'reservation' ? '固定預約' : visualKind === 'meal' ? '餐飲安排' : visualKind === 'move' ? '移動 / 緩衝' : '行程停靠'}</span><div className="status-chips">{states.map((state) => <span key={state} className="status-chip">{state}</span>)}</div></div>
+              <h3>{findPlaceLabel(bundle.places, item.place_id)}{place?.name_ja ? <small>{place.name_ja}</small> : null}</h3>
+              <p className="timeline-detail">{item.notes || (visualKind === 'reservation' ? '此固定事項仍有待確認資訊。' : `停留 ${item.expected_stay_minutes == null ? 'unknown' : `${item.expected_stay_minutes} 分鐘`} · 移動 ${item.transfer_minutes == null ? 'unknown' : `${item.transfer_minutes} 分鐘`}`)}</p>
+              {findPlaceAddress(bundle.places, item.place_id) && <p className="timeline-address">{findPlaceAddress(bundle.places, item.place_id)}</p>}
+              <div className="timeline-actions">
+                <a href={buildMapsLink(place?.maps_query || place?.name || item.place_id)} target="_blank" rel="noreferrer">導航地圖</a>
+                <button type="button" onClick={() => copyText(`${selectedDay.date}-${item.id}`, `${findPlaceLabel(bundle.places, item.place_id)} ${findPlaceAddress(bundle.places, item.place_id)}`)}>{itemCopied ? '已複製' : '複製地點'}</button>
+                <a href={buildRoutePath({ section: 'today', day: selectedDay.date, item: item.id })}>連結</a>
+              </div>
+            </div>
+          </article>
+        })}
+        {quickMode !== 'all' && visibleItems.length === 0 && <p className="timeline-empty">目前無法依公開時間資料判斷「{quickMode === 'now' ? '現在' : '下一站'}」。</p>}
+      </div>}
+
+      <section className="itinerary-alternatives">
+        <div><p className="section-label">ALTERNATIVES</p><h3>Plan A / B / C</h3></div>
+        <div className="plan-tabs">{(['A', 'B', 'C'] as const).map((value) => <button key={value} type="button" className={plan === value ? 'active-pill' : ''} onClick={() => setPlan(value)} aria-pressed={plan === value}>Plan {value}</button>)}</div>
+        {alternatives.length ? alternatives.map((alternative) => <article key={alternative.id}><strong>{alternative.title}</strong><p>{alternative.summary || '方案內容待補'}</p></article>) : <p className="muted">Plan {plan} unavailable：目前 public bundle 沒有 validator-approved 備案。</p>}
+      </section>
+    </section>
+  )
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -748,3 +748,104 @@ textarea {
     break-inside: avoid;
   }
 }
+
+/* Awaji day workspace visual refresh. */
+:root {
+  --bg: #f8fafc;
+  --panel: #ffffff;
+  --panel-strong: #f1f8fb;
+  --text: #172b3a;
+  --text-sub: #5f7180;
+  --line: #e2e9ed;
+  --brand: #0b6da8;
+  --brand-soft: #147fb8;
+  --focus: #0b6da8;
+}
+
+body { background: var(--bg); font-family: Inter, "Noto Sans TC", "PingFang TC", sans-serif; }
+button { font-family: inherit; }
+.app-frame { min-height: 100dvh; }
+.trip-sidebar { width: 288px; padding: 28px 18px; background: #0f1e2e; border: 0; height: 100vh; }
+.trip-brand { margin-bottom: 22px; }
+.trip-brand-kicker { margin: 0 0 10px; color: #72cadd; font-size: .68rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.trip-brand-kicker span { font-size: 1rem; margin-right: 5px; }
+.trip-brand-title { color: #fff; font-size: 1.22rem; letter-spacing: -.02em; line-height: 1.38; }
+.trip-brand-subtitle { color: #8da5b7; font-size: .72rem; line-height: 1.5; }
+.trip-sidebar-status { display: flex; gap: 9px; align-items: flex-start; padding: 12px; margin: 0 2px 25px; border: 1px solid #233c50; border-radius: 12px; background: #0b1826; }
+.trip-sidebar-status > span { color: #37bca3; font-size: .75rem; padding-top: 2px; }
+.trip-sidebar-status strong { display: block; color: #d9e8ed; font-size: .72rem; }
+.trip-sidebar-status small { display: block; color: #7791a2; font-size: .65rem; line-height: 1.55; margin-top: 3px; }
+.trip-nav-label { color: #718696; font-size: .63rem; letter-spacing: .14em; text-transform: uppercase; font-weight: 800; margin: 0 0 8px 10px; }
+.trip-nav { margin-top: 0; gap: 4px; }
+.trip-nav-item { min-height: 52px; padding: 10px 12px; border: 0; border-radius: 10px; background: transparent; color: #a8bdca; }
+.trip-nav-item:hover { background: #182c3d; color: #fff; }
+.trip-nav-item small { color: #69808f; font-size: .64rem; }
+.trip-nav-item.is-active { background: #0b6da8; box-shadow: 0 9px 20px #00000024; }
+.trip-nav-item.is-active small { color: #c8edf1; }
+.app-main { padding: 0 28px 38px; background: #f8fafc; }
+.desktop-topbar { height: 68px; margin: 0 -28px 25px; padding: 0 28px; display: flex; align-items: center; justify-content: space-between; color: #7a8b97; font-size: .78rem; background: #fff; border-bottom: 1px solid #e7edf0; }
+.desktop-topbar > div { display: flex; align-items: center; gap: 12px; }
+.desktop-topbar-section { color: #1d3342; font-weight: 800; }
+.desktop-topbar-divider { color: #c5d0d6; }
+.desktop-status, .desktop-travelers { display: inline-flex; align-items: center; gap: 6px; padding: 7px 10px; border-radius: 9px; background: #f6f9fa; border: 1px solid #e4ebee; color: #526875; font-size: .7rem; }
+.desktop-status i { width: 7px; height: 7px; background: #2ba88f; border-radius: 50%; }
+.trip-main-header { margin: 0 0 12px; }
+.main-title { font-size: 1.36rem; font-weight: 800; letter-spacing: -.025em; }
+.shell-status-line { margin-top: 4px; font-size: .78rem; }
+.trip-version { font-size: .7rem; color: #7a8c97; margin-bottom: 16px; }
+.trip-main-header, .trip-version, .trip-content > .muted { display: none; }
+.trip-content { width: min(1120px, 100%); }
+.card, .card-shell { border: 1px solid #e5ecef; border-radius: 16px; padding: 20px; box-shadow: 0 4px 16px rgba(28, 50, 64, .04); }
+.mobile-topbar { background: #0f1e2e; border-bottom: 1px solid #20394d; }
+.mobile-bottom-nav { background: #0f1e2e; border-top: 1px solid #20394d; }
+.bottom-nav-item { background: #182c3d; }
+.bottom-nav-item.is-active { background: #0b6da8; }
+
+.itinerary-workspace { min-width: 0; }
+.itinerary-day-nav { position: sticky; top: 0; z-index: 10; display: flex; align-items: center; gap: 14px; padding: 12px 0; margin-bottom: 20px; background: color-mix(in srgb, #f8fafc 92%, transparent); backdrop-filter: blur(10px); border-bottom: 1px solid #e4ebee; }
+.day-nav-label { display: flex; align-items: center; gap: 7px; white-space: nowrap; color: #718391; font-size: .68rem; font-weight: 800; letter-spacing: .09em; }
+.day-nav-label span { width: 7px; height: 7px; border-radius: 50%; background: var(--brand); }
+.day-tabs { display: flex; grid-template-columns: none; gap: 7px; overflow-x: auto; padding: 0; }
+.day-tab { min-height: 0; min-width: 62px; padding: 7px 10px; border: 1px solid #e0e8eb; border-radius: 10px; color: #667b88; background: #fff; flex-direction: row; justify-content: center; align-items: baseline; gap: 5px; font-size: .72rem; }
+.day-tab strong { font-size: .7rem; }
+.day-tab span { font-size: .65rem; }
+.day-tab.active { background: #0b6da8; border-color: #0b6da8; box-shadow: 0 6px 14px #0b6da829; }
+.print-button { min-height: 34px; margin-left: auto; padding: 7px 11px; background: #fff; border: 1px solid #dbe5e9; color: #58707d; font-size: .72rem; white-space: nowrap; }
+.day-hero { position: relative; overflow: hidden; display: flex; justify-content: space-between; gap: 28px; padding: 29px 32px; margin-bottom: 18px; border: 1px solid #163b55; border-radius: 20px; color: #fff; background: linear-gradient(118deg, #102536 0%, #15516b 62%, #148da2 150%); box-shadow: 0 12px 28px #1025361a; }
+.day-hero::after { content: ""; position: absolute; right: -6%; bottom: -92%; width: 450px; aspect-ratio: 1; border: 1px solid #8ee5e055; border-radius: 50%; box-shadow: 0 0 0 32px #8ee5e015, 0 0 0 65px #8ee5e00b; }
+.day-hero-copy, .day-stats { position: relative; z-index: 1; }
+.day-kicker { display: flex; flex-wrap: wrap; gap: 8px; color: #b4e6e5; font-size: .68rem; font-weight: 800; letter-spacing: .11em; }
+.day-kicker span + span { color: #d2e4e7; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-weight: 500; }
+.day-hero h2 { max-width: 650px; margin: 11px 0 8px; color: #fff; font-size: clamp(1.35rem, 2.5vw, 2rem); line-height: 1.25; letter-spacing: -.035em; }
+.day-hero p { max-width: 630px; margin: 0; color: #c3d8df; font-size: .78rem; line-height: 1.7; }
+.day-stats { align-self: end; display: flex; gap: 9px; }
+.day-stats span { display: grid; gap: 2px; min-width: 55px; padding: 8px 10px; border: 1px solid #ffffff28; border-radius: 10px; background: #061b2b38; color: #b6d5db; font-size: .62rem; text-align: center; }
+.day-stats strong { color: #fff; font-size: 1rem; }
+.day-stats .has-warning strong { color: #ffe1a4; }
+.itinerary-utility { display: flex; justify-content: space-between; align-items: end; gap: 15px; padding: 13px 0; margin-bottom: 4px; }
+.itinerary-search { display: grid; gap: 5px; min-width: min(100%, 340px); color: #718391; font-size: .68rem; font-weight: 800; }
+.itinerary-search input { width: 100%; height: 38px; padding: 0 11px; border: 1px solid #dde7ea; border-radius: 9px; color: #334c5b; font: inherit; font-size: .78rem; outline: none; background: #fff; }
+.itinerary-search input:focus { border-color: #0b6da8; box-shadow: 0 0 0 3px #0b6da818; }
+.quick-mode, .plan-tabs { display: flex; align-items: center; gap: 5px; color: #718391; font-size: .7rem; }
+.quick-mode button, .plan-tabs button { min-height: 32px; padding: 6px 9px; border: 1px solid #dfe8eb; border-radius: 8px; background: #fff; color: #56707d; font-size: .7rem; }
+.quick-mode .active-pill, .plan-tabs .active-pill { background: #e5f4f6; border-color: #8bcbd0; color: #086f7a; }
+.search-results { display: grid; gap: 7px; padding: 16px; margin: 8px 0 18px; border: 1px solid #e1eaed; border-radius: 14px; background: #fff; }
+.search-results p { margin: 0 0 4px; color: #5d7380; font-size: .78rem; }
+.search-results button { display: grid; grid-template-columns: 42px 1fr auto; gap: 10px; min-height: 42px; padding: 9px 10px; color: #314958; text-align: left; background: #f8fafb; border: 1px solid #edf2f4; font-size: .78rem; }
+.search-results button strong { color: var(--brand); }.search-results button small { color: #82939c; }
+.timeline { position: relative; padding: 10px 0 0; }
+.timeline-entry { display: grid; grid-template-columns: 82px 34px minmax(0, 1fr); min-height: 148px; }
+.timeline-time { padding: 9px 14px 0 0; text-align: right; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.timeline-time strong { display: block; color: #263f4f; font-size: .92rem; }.timeline-time span { color: #90a0a8; font-size: .66rem; }
+.timeline-track { position: relative; display: flex; justify-content: center; }.timeline-track > span { width: 26px; height: 26px; display: grid; place-items: center; z-index: 1; border: 3px solid #f8fafc; border-radius: 50%; color: #fff; background: #0b6da8; font-size: .65rem; box-shadow: 0 1px 5px #12384a22; }.timeline-track i { position: absolute; top: 25px; bottom: 0; width: 2px; background: #dce8eb; }
+.timeline-entry.reservation .timeline-track > span { background: #ba7a1e; color: #fff4d4; }.timeline-entry.meal .timeline-track > span { background: #b68547; }.timeline-entry.move .timeline-track > span { background: #8498a1; }
+.timeline-card { min-width: 0; padding: 7px 0 25px 19px; margin: 0 0 10px 9px; border-bottom: 1px solid #e2eaed; }.timeline-entry.reservation .timeline-card { padding: 17px; margin: 0 0 16px 9px; border: 1px solid #f0dbad; border-radius: 13px; background: #fffaf0; }.timeline-card-topline { display: flex; align-items: center; justify-content: space-between; gap: 8px; }.timeline-category { color: #6f8691; font-size: .63rem; font-weight: 800; letter-spacing: .1em; }.status-chips { display: flex; gap: 5px; flex-wrap: wrap; }.status-chip { padding: 3px 7px; border: 1px solid #c5e2dc; border-radius: 999px; color: #147769; background: #eaf8f5; font-size: .63rem; font-weight: 700; }.timeline-entry.reservation .status-chip { border-color: #efd59f; color: #95611a; background: #fff2d4; }.timeline-card h3 { margin: 8px 0 6px; color: #1e3544; font-size: 1rem; line-height: 1.38; }.timeline-card h3 small { display: inline-block; margin-left: 8px; color: #7b909a; font-size: .72rem; font-weight: 500; }.timeline-detail, .timeline-address { margin: 0; color: #607682; font-size: .76rem; line-height: 1.65; }.timeline-address { color: #8798a1; margin-top: 3px; }.timeline-actions { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 13px; }.timeline-actions a, .timeline-actions button { display: inline-flex; align-items: center; min-height: 34px; padding: 7px 10px; border: 1px solid #cddfe5; border-radius: 8px; background: #fff; color: #16719d; text-decoration: none; font-size: .7rem; }.timeline-actions button { cursor: pointer; }.timeline-empty { padding: 18px; color: #748892; font-size: .8rem; text-align: center; }.item-highlight .timeline-card { outline: 3px solid #0b6da824; outline-offset: 3px; border-radius: 10px; }
+.itinerary-alternatives { display: grid; grid-template-columns: 1fr auto; gap: 12px; align-items: center; padding: 18px; margin: 18px 0 4px; border: 1px solid #e4ebee; border-radius: 14px; background: #fff; }.itinerary-alternatives .section-label { margin: 0 0 3px; color: #78929d; font-size: .62rem; font-weight: 800; letter-spacing: .12em; }.itinerary-alternatives h3 { margin: 0; color: #294454; font-size: .93rem; }.itinerary-alternatives > .muted, .itinerary-alternatives article { grid-column: 1 / -1; margin: 0; font-size: .78rem; }.itinerary-alternatives article p { margin: 4px 0 0; color: #667c88; }
+
+@media (max-width: 960px) {
+  .app-shell .app-main { display: block; }
+  .app-main { padding: 0 12px calc(var(--mobile-nav-h) + env(safe-area-inset-bottom) + 18px); }.desktop-topbar { display: none; }.trip-main-header { margin: 14px 0 8px; }.trip-version { margin-bottom: 11px; }.itinerary-day-nav { top: 58px; margin: 0 -12px 15px; padding: 9px 12px; }.day-nav-label { display: none; }.day-tabs { flex: 1; }.day-stats { align-self: auto; }.timeline-entry { grid-template-columns: 58px 27px minmax(0, 1fr); }.timeline-card { margin-left: 7px; padding-left: 13px; }.timeline-entry.reservation .timeline-card { margin-left: 7px; }.timeline-time { padding-right: 8px; }.timeline-time strong { font-size: .76rem; }.timeline-track > span { width: 22px; height: 22px; border-width: 2px; }.timeline-track i { top: 21px; }.itinerary-alternatives { grid-template-columns: 1fr; }.plan-tabs { justify-content: flex-start; }
+}
+@media (max-width: 620px) {
+  .main-title { font-size: 1.08rem; }.shell-status-line { font-size: .7rem; }.itinerary-day-nav { gap: 8px; }.day-tab { min-width: 54px; padding: 7px; }.print-button { min-height: 32px; padding: 6px 8px; }.day-hero { display: block; padding: 23px 20px; border-radius: 16px; }.day-hero h2 { font-size: 1.42rem; }.day-stats { margin-top: 18px; }.day-stats span { min-width: 0; flex: 1; }.itinerary-utility { display: grid; align-items: stretch; }.itinerary-search { min-width: 0; }.quick-mode { justify-content: flex-start; }.timeline-card h3 { font-size: .92rem; }.timeline-actions a, .timeline-actions button { min-height: 44px; }.timeline-entry { min-height: 155px; }.timeline-card-topline { align-items: flex-start; }.timeline-category { padding-top: 3px; }.search-results button { grid-template-columns: 34px 1fr; }.search-results button small { grid-column: 2; }.itinerary-alternatives { padding: 15px; }
+}


### PR DESCRIPTION
Closes #89

## Summary

- 將正式 Awaji `TripApp` 改為 ai_kyushu 式的旅行工作區：深色 sidebar、desktop top bar、sticky day selector、day hero 與垂直 timeline。
- 維持 `setouchi-awaji` 的海藍／青綠視覺，所有旅行內容仍直接使用 Canonical public bundle。
- 固定預約與 unknown 以文字和 amber state 顯示；不新增任何景點、地址、時間或預約事實。
- 修正 bundle loader 因 effect dependency 重複載入而持續顯示「資料載入中」的問題。

## Visual evidence

已以 Playwright 檢查 1440×900 與 390×844：desktop sidebar / top bar / hero / timeline 正常；390px 無 horizontal overflow，主要 actions 為 44px，固定預約的 warning 與待補狀態可讀。

## Validation

- `npm run typecheck` PASS
- `npm run lint` PASS
- `npm test` PASS (6 tests)
- `npm run build` PASS
- `npm run test:e2e` PASS
- `python3 -m scripts.agent.collaboration check 89` PASS
