### PR TITLE
修正淡路行程總覽旅客與行前狀態文案

### DIFF
--- a/web/public/trip-registry.json
+++ b/web/public/trip-registry.json
@@ -10,7 +10,7 @@
       "end_date": "2026-08-31"
     },
     "duration_days": 5,
-    "travelers_summary": "2 位大人 + 1 位小孩",
+    "travelers_summary": "6 大 1 小",
     "theme_id": "setouchi-awaji",
     "status": "published",
     "readiness": "incomplete",
@@ -22,8 +22,8 @@
       "gradient": "linear-gradient(130deg, #0b4a6f 0%, #2e90dc 55%, #79b8f8 100%)",
       "fallback": "淡路海岸晨霧"
     },
-    "hero_summary": "旅前資料待補，重點已可閱讀首屏。",
-    "key_messages": ["行程主題與路線已穩定。", "固定預約待核對。"],
+    "hero_summary": "行程已建立；出發前請確認道路時間、天候、營運、停車與訂位狀態。",
+    "key_messages": ["行程主題與路線已穩定。", "道路、營運與訂位狀態需於出發前重查。"],
     "critical_alert_count": 2
   },
   {

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -13,7 +13,7 @@ interface OverviewPageProps {
 }
 function resolveStatusBadge(readiness: TripCatalogEntry['readiness']): { className: string; text: string } {
   if (readiness === 'ready') return { className: 'status-pill status-ready', text: '可出發' }
-  if (readiness === 'incomplete') return { className: 'status-pill status-incomplete', text: '部分待確認' }
+  if (readiness === 'incomplete') return { className: 'status-pill status-incomplete', text: '行前需確認' }
   return { className: 'status-pill status-blocked', text: '有關鍵阻斷' }
 }
 
@@ -82,7 +82,9 @@ export function OverviewPage({ bundle, trip }: OverviewPageProps) {
   const dateText = trip
     ? `${trip.date_range.start_date} — ${trip.date_range.end_date} · ${trip.duration_days} 天`
     : bundle ? `${bundle.date_range.start_date} — ${bundle.date_range.end_date} · ${bundle.days.length} 天` : '行程資料載入中'
-  const travelersText = trip?.travelers_summary || (bundle ? `${bundle.traveler_profile.adults} 位大人 · ${bundle.traveler_profile.children_count} 位孩童` : '旅客資料載入中')
+  const travelersText = bundle
+    ? `${bundle.traveler_profile.adults} 大 ${bundle.traveler_profile.children_count} 小`
+    : trip?.travelers_summary || '旅客資料載入中'
 
   if (!bundle) {
     return (
@@ -141,7 +143,6 @@ export function OverviewPage({ bundle, trip }: OverviewPageProps) {
             <div><dt>住宿</dt><dd>{lodgingCards.length} 處</dd></div>
             <div><dt>逐段交通</dt><dd>{bundle.transport_legs?.length || 0} 段</dd></div>
           </dl>
-          <small>資料快照 {bundle.meta.generated_at}</small>
         </aside>
       </article>
 

--- a/web/tests/handbook.test.tsx
+++ b/web/tests/handbook.test.tsx
@@ -4,8 +4,10 @@ import type { Bundle } from '../src/contracts/trip'
 import { buildMapsDirectionsLink, buildRouteDirectionChunks } from '../src/lib/google-maps-links'
 import { groupContiguousLegs, MapPage } from '../src/pages/MapPage'
 import { heroNextItem, ItineraryPage } from '../src/pages/ItineraryPage'
+import { OverviewPage } from '../src/pages/OverviewPage'
 import { PackingPage } from '../src/pages/PackingPage'
 import { buildReservationCalendarIcs } from '../src/pages/ReservationsPage'
+import type { TripCatalogEntry } from '../src/contracts/trip-registry'
 
 const dates = ['2026-08-27', '2026-08-28', '2026-08-29', '2026-08-30', '2026-08-31']
 const storage = new Map<string, string>()
@@ -190,6 +192,31 @@ describe('Issue 97 travel handbook', () => {
     expect(screen.queryByText(/Plan A \/ B \/ C/)).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('tab', { name: /D5/ }))
     expect(onNavigate).toHaveBeenCalledWith({ section: 'today', day: dates[4], item: undefined })
+  })
+
+  it('uses canonical traveler facts and explains pre-trip readiness on overview', () => {
+    const canonicalBundle = {
+      ...bundle,
+      traveler_profile: { ...bundle.traveler_profile, adults: 6 },
+    }
+    const staleRegistryEntry = {
+      title: '淡路五日',
+      destination_regions: ['淡路島'],
+      date_range: { start_date: dates[0], end_date: dates[4] },
+      duration_days: 5,
+      travelers_summary: '2 位大人 + 1 位小孩',
+      status: 'published',
+      readiness: 'incomplete',
+      cover_media: { kind: 'gradient', gradient: 'linear-gradient(#123, #456)' },
+      hero_summary: '行程已建立；出發前請確認道路時間、天候、營運、停車與訂位狀態。',
+    } as TripCatalogEntry
+
+    render(<OverviewPage bundle={canonicalBundle} trip={staleRegistryEntry} />)
+
+    expect(screen.getByText('6 大 1 小')).toBeInTheDocument()
+    expect(screen.getByText('行前需確認')).toBeInTheDocument()
+    expect(screen.getByText(/道路時間、天候、營運、停車與訂位狀態/)).toBeInTheDocument()
+    expect(screen.queryByText(/資料快照/)).not.toBeInTheDocument()
   })
 
   it('does not wrap the next-stop hero back to breakfast after the day ends', () => {


### PR DESCRIPTION
## 變更
- Overview 以 Canonical Trip 顯示 6 大 1 小，避免 registry 舊資料覆蓋正確人數。
- 將「部分待確認」改為「行前需確認」，並說明道路、天候、營運、停車與訂位需於出發前重查。
- 移除 Overview 的資料快照時間戳。
- 更新淡路旅程 registry 摘要與旅客人數，補上回歸測試。

## 驗證
- `npm test`：18/18 passed
- `npm run typecheck`：passed
- `npm run lint`：passed
- `npm run build`：passed
- `npm run test:e2e`：passed

Head: 9936387