### PR TITLE
移除全站資料快照時間戳

### DIFF
--- a/web/src/app/TripApp.tsx
+++ b/web/src/app/TripApp.tsx
@@ -234,8 +234,6 @@ export default function TripApp({ tripMeta = null, tripSlug }: TripAppProps) {
 
   const statusLabel = toFriendlyStatus(bundleLoader.bundle?.status || 'warning')
   const renderBundleLoading = !bundleLoader.bundle && shellStatus === 'loading'
-  const tripVersion = bundleLoader.bundle?.meta?.generated_at || '--'
-
   const titleInfo = useMemo(() => `行程狀態：${statusLabel}`, [statusLabel])
 
   if (renderBundleLoading) {
@@ -243,7 +241,6 @@ export default function TripApp({ tripMeta = null, tripSlug }: TripAppProps) {
       <TripShell
         bundle={null}
         shellStatus="loading"
-        tripVersion={tripVersion}
         pageTitleId={pageTitleId}
         sections={SECTION_DEFINITIONS}
         activeSection={selectedSection}
@@ -266,7 +263,6 @@ export default function TripApp({ tripMeta = null, tripSlug }: TripAppProps) {
     <TripShell
       bundle={bundleLoader.bundle}
       shellStatus={shellStatus}
-      tripVersion={tripVersion}
       pageTitleId={pageTitleId}
       sections={SECTION_DEFINITIONS}
       activeSection={selectedSection}

--- a/web/src/layouts/TripShell.tsx
+++ b/web/src/layouts/TripShell.tsx
@@ -18,7 +18,6 @@ export type TripStatusType =
 interface TripShellProps {
   bundle: Bundle | null
   shellStatus: TripStatusType
-  tripVersion: string
   pageTitleId: string
   sections: SectionDefinition[]
   activeSection: string
@@ -43,7 +42,6 @@ const statusText: Record<TripStatusType, string> = {
 export default function TripShell({
   bundle,
   shellStatus,
-  tripVersion,
   pageTitleId,
   sections,
   activeSection,
@@ -145,7 +143,6 @@ export default function TripShell({
           </header>
 
           <section className="trip-content">
-            <span className="trip-version">資料快照：{tripVersion || '--'}</span>
             {(shellStatus === 'invalid' || shellStatus === 'critical' || shellStatus === 'route-not-found') && (
               <p className="shell-message">
                 {shellStatus === 'invalid'

--- a/web/src/pages/LodgingPage.tsx
+++ b/web/src/pages/LodgingPage.tsx
@@ -145,7 +145,7 @@ export function LodgingPage({ bundle }: LodgingPageProps) {
       </div>
 
       {lodgings.length === 0 ? <div className="honest-empty"><strong>尚無住宿主鍵</strong><p>Canonical Trip 目前未列出住宿，頁面不會自行猜測。</p></div> : null}
-      <footer className="data-footnote">資料快照：{bundle.meta.generated_at}。入住與退房以 Canonical Trip 已知時間為準。</footer>
+      <footer className="data-footnote">入住與退房以 Canonical Trip 已知時間為準。</footer>
     </section>
   )
 }

--- a/web/src/pages/ReservationsPage.tsx
+++ b/web/src/pages/ReservationsPage.tsx
@@ -161,7 +161,7 @@ export function ReservationsPage({ bundle }: ReservationsPageProps) {
       </div>
 
       {bundle.reservations.length === 0 ? <div className="honest-empty"><strong>Canonical Trip 尚無預約紀錄</strong><p>頁面不會從一般行程文字自行推定已預約。固定行程仍可在每日時間軸查看。</p><a href="#/today">查看每日行程</a></div> : null}
-      <footer className="data-footnote">資料快照：{bundle.meta.generated_at}。場次與營業狀態請以官方最新通知為準。</footer>
+      <footer className="data-footnote">場次與營業狀態請以官方最新通知為準。</footer>
     </section>
   )
 }


### PR DESCRIPTION
## 變更
- 移除共用頁首的資料快照時間戳，避免 Overview 仍顯示被要求刪除的時間資訊。
- 移除住宿與預約頁 footer 的資料快照時間戳，保留實際操作提醒。

## 驗證
- `npm test`：18/18 passed
- `npm run typecheck`：passed
- `npm run lint`：passed
- `npm run build`：passed
- `npm run test:e2e`：passed
- `rg -n "資料快照" web/src web/public`：無 production source residue

Head: 1d2037b