### PR TITLE
整理行程時間軸重複提醒

### DIFF
--- a/web/src/pages/ItineraryPage.tsx
+++ b/web/src/pages/ItineraryPage.tsx
@@ -63,14 +63,49 @@ function timeLabel(value: string | null): string {
   return value.match(/T(\d{2}:\d{2})/)?.[1] || value
 }
 
+function comparableText(value: string): string {
+  return value.toLowerCase().replace(/[\s「」（）()]+/g, '')
+}
+
+function textClauses(value: string): string[] {
+  return value.split(/[，。；：:、／/·・]+/).map(comparableText).filter(Boolean)
+}
+
+function negationMarkers(value: string): string[] {
+  return ['不可', '不能', '無法', '禁止', '避免', '不宜', '不得', '不要', '沒有', '不適用', '不適合', '不通行', '不建議', '不', '未', '非']
+    .filter((marker) => value.includes(marker))
+}
+
+function isSubsequence(needle: string, haystack: string): boolean {
+  let cursor = 0
+  for (const character of needle) {
+    const foundAt = haystack.indexOf(character, cursor)
+    if (foundAt < 0) return false
+    cursor = foundAt + 1
+  }
+  return true
+}
+
+function accessibilityNoteCovered(itemNotes: string | undefined, accessibilityNotes: string | null | undefined): boolean {
+  if (!itemNotes || !accessibilityNotes) return false
+  const noteClauses = textClauses(itemNotes)
+  const accessibilityClauses = textClauses(accessibilityNotes)
+  return accessibilityClauses.length > 0 && accessibilityClauses.every((clause) =>
+    noteClauses.some((noteClause) => {
+      if (JSON.stringify(negationMarkers(noteClause)) !== JSON.stringify(negationMarkers(clause))) return false
+      return noteClause.includes(clause) || isSubsequence(clause, noteClause)
+    }),
+  )
+}
+
 function itemState(item: BundleDayItem, reservationUnresolved: boolean, leg?: BundleTransportLeg): string[] {
   const states: string[] = []
   if (item.fixed || item.kind === 'reservation' || item.kind === 'flight') states.push('固定')
   if (item.optional || item.kind === 'optional' || item.notes?.toLowerCase().includes('optional')) states.push('可選')
   if (item.cancelable || item.notes?.includes('可取消')) states.push('可取消')
-  if (leg && leg.status !== 'estimated') states.push(operationalStatusLabel(leg.status))
+  if (leg) states.push(operationalStatusLabel(leg.status))
   if (item.unresolved || reservationUnresolved || !item.start_at || !item.end_at) states.push('待補')
-  return [...new Set(states.length ? states : ['規劃項目'])]
+  return [...new Set(states)]
 }
 
 function itemVisualKind(item: BundleDayItem, reservationLinked = false): 'reservation' | 'meal' | 'move' | 'place' {
@@ -259,7 +294,7 @@ export function ItineraryPage({ bundle, route, onNavigate }: ItineraryPageProps)
           const itemCopied = copiedId === `${selectedDay.date}-${item.id}`
           const title = leg ? `${leg.from_label} → ${leg.to_label}` : findPlaceLabel(bundle.places, item.place_id)
           const detail = leg
-            ? `${leg.estimated_duration_minutes == null ? '車程尚未確認' : `約 ${leg.estimated_duration_minutes} 分鐘`} · ${leg.note || '尚無專屬導航提醒'}`
+            ? leg.estimated_duration_minutes == null ? '車程尚未確認' : `約 ${leg.estimated_duration_minutes} 分鐘`
             : item.notes || `停留 ${item.expected_stay_minutes == null ? '尚未提供' : `${item.expected_stay_minutes} 分鐘`} · 前段移動 ${item.transfer_minutes == null ? '尚未提供' : `${item.transfer_minutes} 分鐘`}`
           const mapsHref = leg ? legDirectionsLink(bundle, leg) : place?.google_maps_url || buildMapsLink(place?.maps_query || place?.name || item.place_id)
           const copyValue = leg ? `${leg.from_label} → ${leg.to_label}` : `${title} ${findPlaceAddress(bundle.places, item.place_id)}`
@@ -278,7 +313,7 @@ export function ItineraryPage({ bundle, route, onNavigate }: ItineraryPageProps)
               {leg ? <div className="timeline-risk">{leg.status !== 'estimated' ? <span className={operationalStatusClass(leg.status)}>{operationalStatusLabel(leg.status)}</span> : null}<p><strong>風險／延誤切點：</strong>{leg.note || '未提供；出發前以 Google Maps 即時路況確認。'}</p></div> : null}
               {!leg && place?.opening_hours_note ? <p className={`timeline-context ${fieldNeedsRecheck(place, 'opening_hours_note') ? 'needs-recheck' : ''}`}><strong>營業時間：</strong>{place.opening_hours_note}</p> : null}
               {!leg && place?.parking ? <p className={`timeline-context ${fieldNeedsRecheck(place, 'parking') ? 'needs-recheck' : ''}`}><strong>停車：</strong>{place.parking}</p> : null}
-              {place?.accessibility_notes ? <p className="timeline-context"><strong>家庭／無障礙：</strong>{place.accessibility_notes}</p> : null}
+              {place?.accessibility_notes && !accessibilityNoteCovered(item.notes, place.accessibility_notes) ? <p className="timeline-context"><strong>家庭／無障礙：</strong>{place.accessibility_notes}</p> : null}
               {!leg && itemAlternatives.length ? <div className="timeline-inline-alternatives"><strong>試算表備案：</strong>{itemAlternatives.map((alternative) => <a key={alternative.id} href={alternative.google_maps_url || buildMapsLink(alternative.maps_query || alternative.address || alternative.name || alternative.id)} target="_blank" rel="noreferrer">{alternative.name || alternative.id}</a>)}</div> : null}
               <div className="timeline-actions">
                 <a href={mapsHref} target="_blank" rel="noreferrer">{leg ? '逐段導航' : '導航地圖'}</a>

--- a/web/tests/handbook.test.tsx
+++ b/web/tests/handbook.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Bundle } from '../src/contracts/trip'
 import { buildMapsDirectionsLink, buildRouteDirectionChunks } from '../src/lib/google-maps-links'
@@ -186,9 +186,13 @@ describe('Issue 97 travel handbook', () => {
     expect(screen.getByText('主要風險')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: '洲本城' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: '鳴門公園' })).toBeInTheDocument()
-    // Dynamic facts remain visibly sourced without an opaque "estimated" badge.
+    // Dynamic facts remain visibly sourced and transport estimates are not repeated in the risk note.
     expect(screen.getByText(/營業時間：/)).toBeInTheDocument()
     expect(screen.getByText(/停車：/)).toBeInTheDocument()
+    const firstTransportCard = screen.getByRole('heading', { name: /神戶機場 → 淡路住宿/ }).closest('.timeline-entry')
+    expect(firstTransportCard).not.toBeNull()
+    expect(within(firstTransportCard as HTMLElement).getAllByText(/若延誤 20 分鐘/)).toHaveLength(1)
+    expect(screen.queryByText('規劃項目', { exact: true })).not.toBeInTheDocument()
     expect(screen.queryByText(/Plan A \/ B \/ C/)).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('tab', { name: /D5/ }))
     expect(onNavigate).toHaveBeenCalledWith({ section: 'today', day: dates[4], item: undefined })
@@ -217,6 +221,75 @@ describe('Issue 97 travel handbook', () => {
     expect(screen.getByText('行前需確認')).toBeInTheDocument()
     expect(screen.getByText(/道路時間、天候、營運、停車與訂位狀態/)).toBeInTheDocument()
     expect(screen.queryByText(/資料快照/)).not.toBeInTheDocument()
+  })
+
+  it('does not repeat an item safety note as a separate accessibility note', () => {
+    const duplicateBundle: Bundle = {
+      ...bundle,
+      days: bundle.days.map((day, dayIndex) => dayIndex === 0
+        ? {
+          ...day,
+          items: day.items.map((item, itemIndex) => itemIndex === 1
+            ? { ...item, notes: '只做安全平坦海邊短走；高溫、強風、下雨或長輩幼兒疲累即取消，保留緩衝。' }
+            : item),
+        }
+        : day),
+      places: bundle.places?.map((place, placeIndex) => placeIndex === 1
+        ? { ...place, accessibility_notes: '只做海邊短走；高溫、強風、下雨或長輩幼兒疲累即取消。' }
+        : place),
+    }
+
+    render(<ItineraryPage bundle={duplicateBundle} route={{ section: 'today', day: dates[0], raw: `today/${dates[0]}` }} onNavigate={vi.fn()} />)
+
+    expect(screen.queryByText(/家庭／無障礙：只做海邊短走/)).not.toBeInTheDocument()
+    expect(screen.getByText(/只做安全平坦海邊短走/)).toBeInTheDocument()
+  })
+
+  it('keeps accessibility notes when item notes contain conflicting guidance', () => {
+    const conflictingBundle: Bundle = {
+      ...bundle,
+      days: bundle.days.map((day, dayIndex) => dayIndex === 0
+        ? {
+          ...day,
+          items: day.items.map((item, itemIndex) => itemIndex === 1
+            ? { ...item, notes: '輪椅不可通行。' }
+            : item),
+        }
+        : day),
+      places: bundle.places?.map((place, placeIndex) => placeIndex === 1
+        ? { ...place, accessibility_notes: '輪椅可通行。' }
+        : place),
+    }
+
+    render(<ItineraryPage bundle={conflictingBundle} route={{ section: 'today', day: dates[0], raw: `today/${dates[0]}` }} onNavigate={vi.fn()} />)
+
+    const conflictingCard = document.getElementById('item-visit-b')
+    expect(conflictingCard).not.toBeNull()
+    expect(within(conflictingCard as HTMLElement).getByText('家庭／無障礙：')).toBeInTheDocument()
+    expect(within(conflictingCard as HTMLElement).getByText('輪椅可通行。')).toBeInTheDocument()
+  })
+
+  it('keeps accessibility notes when item notes use implicit negation', () => {
+    const conflictingBundle: Bundle = {
+      ...bundle,
+      days: bundle.days.map((day, dayIndex) => dayIndex === 0
+        ? {
+          ...day,
+          items: day.items.map((item, itemIndex) => itemIndex === 1
+            ? { ...item, notes: '輪椅不適用。' }
+            : item),
+        }
+        : day),
+      places: bundle.places?.map((place, placeIndex) => placeIndex === 1
+        ? { ...place, accessibility_notes: '輪椅適用。' }
+        : place),
+    }
+
+    render(<ItineraryPage bundle={conflictingBundle} route={{ section: 'today', day: dates[0], raw: `today/${dates[0]}` }} onNavigate={vi.fn()} />)
+
+    const conflictingCard = document.getElementById('item-visit-b')
+    expect(conflictingCard).not.toBeNull()
+    expect(within(conflictingCard as HTMLElement).getByText('輪椅適用。')).toBeInTheDocument()
   })
 
   it('does not wrap the next-stop hero back to breakfast after the day ends', () => {


### PR DESCRIPTION
## 變更
- 交通卡摘要只顯示預估時長，詳細提醒集中在風險／延誤切點。
- 景點 item notes 已涵蓋家庭安全內容時，不再重複渲染 accessibility note。
- 移除沒有實際狀態意義的「規劃項目」fallback；交通腿改顯示實際估計狀態。
- 新增交通提醒與家庭安全提醒的去重回歸測試。

## 驗證
- `npm test`：19/19 passed
- `npm run typecheck`：passed
- `npm run lint`：passed
- `npm run build`：passed
- `npm run test:e2e`：passed

Head: 4e90c2e