### PR TITLE
更新淡路島 2026/8/27 潮汐與動態資料

### DIFF
--- a/scripts/build_awaji_public_bundle.py
+++ b/scripts/build_awaji_public_bundle.py
@@ -478,8 +478,28 @@ def _bundle_conditions(trip: dict) -> dict[str, Any]:
             "status": _as_status(tide.get("status")),
             "status_label": _safe_str(tide.get("status_label")) or _safe_str(tide.get("state")),
             "summary": _safe_str(tide.get("summary")),
+            "provider": _safe_str(tide.get("provider")),
+            "source_url": _safe_str(tide.get("source_url")),
             "last_checked": _safe_str(tide.get("last_checked")),
             "recheck_at": _safe_str(tide.get("recheck_at")),
+            "station": _safe_str(tide.get("station")),
+            "days": [
+                {
+                    "date": _safe_str(day.get("date")),
+                    "tide_type": _safe_str(day.get("tide_type")),
+                    "events": [
+                        {
+                            "kind": _safe_str(event.get("kind")),
+                            "time": _safe_str(event.get("time")),
+                            "height_cm": event.get("height_cm"),
+                        }
+                        for event in _as_list(day.get("events"))
+                        if isinstance(event, dict)
+                    ],
+                }
+                for day in _as_list(tide.get("days"))
+                if isinstance(day, dict)
+            ],
         },
         "closures": [
             {

--- a/trips/awaji-naruto-tokushima-kobe-2026/public-bundle.json
+++ b/trips/awaji-naruto-tokushima-kobe-2026/public-bundle.json
@@ -33,12 +33,148 @@
     "closures": [],
     "freshness": "unknown",
     "tide": {
-      "status": "unknown",
-      "status_label": "官方未確認"
+      "days": [
+        {
+          "date": "2026-08-27",
+          "events": [
+            {
+              "height_cm": 154,
+              "kind": "high",
+              "time": "05:25"
+            },
+            {
+              "height_cm": 42,
+              "kind": "low",
+              "time": "12:16"
+            },
+            {
+              "height_cm": 156,
+              "kind": "high",
+              "time": "18:57"
+            }
+          ],
+          "tide_type": "大潮"
+        },
+        {
+          "date": "2026-08-28",
+          "events": [
+            {
+              "height_cm": 93,
+              "kind": "low",
+              "time": "00:16"
+            },
+            {
+              "height_cm": 162,
+              "kind": "high",
+              "time": "06:07"
+            },
+            {
+              "height_cm": 160,
+              "kind": "high",
+              "time": "19:16"
+            },
+            {
+              "height_cm": 41,
+              "kind": "low",
+              "time": "12:42"
+            }
+          ],
+          "tide_type": "大潮"
+        },
+        {
+          "date": "2026-08-29",
+          "events": [
+            {
+              "height_cm": 83,
+              "kind": "low",
+              "time": "00:48"
+            },
+            {
+              "height_cm": 168,
+              "kind": "high",
+              "time": "06:47"
+            },
+            {
+              "height_cm": 164,
+              "kind": "high",
+              "time": "19:39"
+            },
+            {
+              "height_cm": 43,
+              "kind": "low",
+              "time": "13:09"
+            }
+          ],
+          "tide_type": "大潮"
+        },
+        {
+          "date": "2026-08-30",
+          "events": [
+            {
+              "height_cm": 73,
+              "kind": "low",
+              "time": "01:22"
+            },
+            {
+              "height_cm": 169,
+              "kind": "high",
+              "time": "07:28"
+            },
+            {
+              "height_cm": 165,
+              "kind": "high",
+              "time": "20:03"
+            },
+            {
+              "height_cm": 50,
+              "kind": "low",
+              "time": "13:38"
+            }
+          ],
+          "tide_type": "大潮"
+        },
+        {
+          "date": "2026-08-31",
+          "events": [
+            {
+              "height_cm": 67,
+              "kind": "low",
+              "time": "02:00"
+            },
+            {
+              "height_cm": 166,
+              "kind": "high",
+              "time": "08:10"
+            },
+            {
+              "height_cm": 165,
+              "kind": "high",
+              "time": "20:29"
+            },
+            {
+              "height_cm": 62,
+              "kind": "low",
+              "time": "14:08"
+            }
+          ],
+          "tide_type": "大潮"
+        }
+      ],
+      "last_checked": "2026-08-24T19:09:15+09:00",
+      "provider": "日本氣象廳",
+      "recheck_at": null,
+      "source_url": "https://www.data.jma.go.jp/kaiyou/db/tide/suisan/suisan.php?LV=DL&S_HILO=on&de=04&ds=21&me=09&ms=08&stn=ST&ye=2026&ys=2026",
+      "station": "洲本（SUMOTO）",
+      "status": "confirmed",
+      "status_label": "官方預測已取得",
+      "summary": "日本氣象廳洲本潮位表：2026/8/27–8/31 預測潮汐。"
     },
     "weather": {
+      "last_checked": null,
+      "recheck_at": null,
       "status": "unknown",
-      "status_label": "官方未確認"
+      "status_label": null,
+      "summary": null
     }
   },
   "critical_alerts": [
@@ -1126,8 +1262,8 @@
   },
   "local_timezone": "Asia/Tokyo",
   "meta": {
-    "bundle_sha256": "edcd3ae0802e50af8cbde027b62fcac3044e703b37fa63775b8d0b4b7776c503",
-    "generated_at": "2026-08-24T07:49:37+00:00",
+    "bundle_sha256": "2ddb8207bf4c36791567bb30320ee479ac17b062cc02e7890e98c8aa5bb7443e",
+    "generated_at": "2026-08-24T10:10:01+00:00",
     "source_coverage": {
       "days": 5,
       "places": 52,
@@ -1135,7 +1271,7 @@
       "selected_hotels": 3
     },
     "source_path": "trips/awaji-naruto-tokushima-kobe-2026/trip.json",
-    "source_sha256": "8afe84c96916e2c10763dd4069cac21ff249fe6ad2fa0edb3d164b16033eb107",
+    "source_sha256": "d113dc9fc54c67eeb6b27e111f3ff89738dd4e67c8f623ed9abb228ebc84882f",
     "trip_schema": "trip-v1"
   },
   "operations": {

--- a/trips/awaji-naruto-tokushima-kobe-2026/trip.json
+++ b/trips/awaji-naruto-tokushima-kobe-2026/trip.json
@@ -1393,6 +1393,24 @@
       }
     ]
   },
+  "conditions": {
+    "tide": {
+      "status": "confirmed",
+      "status_label": "官方預測已取得",
+      "summary": "日本氣象廳洲本潮位表：2026/8/27–8/31 預測潮汐。",
+      "provider": "日本氣象廳",
+      "source_url": "https://www.data.jma.go.jp/kaiyou/db/tide/suisan/suisan.php?LV=DL&S_HILO=on&de=04&ds=21&me=09&ms=08&stn=ST&ye=2026&ys=2026",
+      "last_checked": "2026-08-24T19:09:15+09:00",
+      "station": "洲本（SUMOTO）",
+      "days": [
+        {"date":"2026-08-27","tide_type":"大潮","events":[{"kind":"high","time":"05:25","height_cm":154},{"kind":"low","time":"12:16","height_cm":42},{"kind":"high","time":"18:57","height_cm":156}]},
+        {"date":"2026-08-28","tide_type":"大潮","events":[{"kind":"low","time":"00:16","height_cm":93},{"kind":"high","time":"06:07","height_cm":162},{"kind":"high","time":"19:16","height_cm":160},{"kind":"low","time":"12:42","height_cm":41}]},
+        {"date":"2026-08-29","tide_type":"大潮","events":[{"kind":"low","time":"00:48","height_cm":83},{"kind":"high","time":"06:47","height_cm":168},{"kind":"high","time":"19:39","height_cm":164},{"kind":"low","time":"13:09","height_cm":43}]},
+        {"date":"2026-08-30","tide_type":"大潮","events":[{"kind":"low","time":"01:22","height_cm":73},{"kind":"high","time":"07:28","height_cm":169},{"kind":"high","time":"20:03","height_cm":165},{"kind":"low","time":"13:38","height_cm":50}]},
+        {"date":"2026-08-31","tide_type":"大潮","events":[{"kind":"low","time":"02:00","height_cm":67},{"kind":"high","time":"08:10","height_cm":166},{"kind":"high","time":"20:29","height_cm":165},{"kind":"low","time":"14:08","height_cm":62}]}
+      ]
+    }
+  },
   "selected": {
     "hotel_place_ids": [
       "awaji-riverside-hotel",

--- a/web/public/trips/awaji-2026/public-bundle.json
+++ b/web/public/trips/awaji-2026/public-bundle.json
@@ -33,12 +33,148 @@
     "closures": [],
     "freshness": "unknown",
     "tide": {
-      "status": "unknown",
-      "status_label": "官方未確認"
+      "days": [
+        {
+          "date": "2026-08-27",
+          "events": [
+            {
+              "height_cm": 154,
+              "kind": "high",
+              "time": "05:25"
+            },
+            {
+              "height_cm": 42,
+              "kind": "low",
+              "time": "12:16"
+            },
+            {
+              "height_cm": 156,
+              "kind": "high",
+              "time": "18:57"
+            }
+          ],
+          "tide_type": "大潮"
+        },
+        {
+          "date": "2026-08-28",
+          "events": [
+            {
+              "height_cm": 93,
+              "kind": "low",
+              "time": "00:16"
+            },
+            {
+              "height_cm": 162,
+              "kind": "high",
+              "time": "06:07"
+            },
+            {
+              "height_cm": 160,
+              "kind": "high",
+              "time": "19:16"
+            },
+            {
+              "height_cm": 41,
+              "kind": "low",
+              "time": "12:42"
+            }
+          ],
+          "tide_type": "大潮"
+        },
+        {
+          "date": "2026-08-29",
+          "events": [
+            {
+              "height_cm": 83,
+              "kind": "low",
+              "time": "00:48"
+            },
+            {
+              "height_cm": 168,
+              "kind": "high",
+              "time": "06:47"
+            },
+            {
+              "height_cm": 164,
+              "kind": "high",
+              "time": "19:39"
+            },
+            {
+              "height_cm": 43,
+              "kind": "low",
+              "time": "13:09"
+            }
+          ],
+          "tide_type": "大潮"
+        },
+        {
+          "date": "2026-08-30",
+          "events": [
+            {
+              "height_cm": 73,
+              "kind": "low",
+              "time": "01:22"
+            },
+            {
+              "height_cm": 169,
+              "kind": "high",
+              "time": "07:28"
+            },
+            {
+              "height_cm": 165,
+              "kind": "high",
+              "time": "20:03"
+            },
+            {
+              "height_cm": 50,
+              "kind": "low",
+              "time": "13:38"
+            }
+          ],
+          "tide_type": "大潮"
+        },
+        {
+          "date": "2026-08-31",
+          "events": [
+            {
+              "height_cm": 67,
+              "kind": "low",
+              "time": "02:00"
+            },
+            {
+              "height_cm": 166,
+              "kind": "high",
+              "time": "08:10"
+            },
+            {
+              "height_cm": 165,
+              "kind": "high",
+              "time": "20:29"
+            },
+            {
+              "height_cm": 62,
+              "kind": "low",
+              "time": "14:08"
+            }
+          ],
+          "tide_type": "大潮"
+        }
+      ],
+      "last_checked": "2026-08-24T19:09:15+09:00",
+      "provider": "日本氣象廳",
+      "recheck_at": null,
+      "source_url": "https://www.data.jma.go.jp/kaiyou/db/tide/suisan/suisan.php?LV=DL&S_HILO=on&de=04&ds=21&me=09&ms=08&stn=ST&ye=2026&ys=2026",
+      "station": "洲本（SUMOTO）",
+      "status": "confirmed",
+      "status_label": "官方預測已取得",
+      "summary": "日本氣象廳洲本潮位表：2026/8/27–8/31 預測潮汐。"
     },
     "weather": {
+      "last_checked": null,
+      "recheck_at": null,
       "status": "unknown",
-      "status_label": "官方未確認"
+      "status_label": null,
+      "summary": null
     }
   },
   "critical_alerts": [
@@ -1126,8 +1262,8 @@
   },
   "local_timezone": "Asia/Tokyo",
   "meta": {
-    "bundle_sha256": "edcd3ae0802e50af8cbde027b62fcac3044e703b37fa63775b8d0b4b7776c503",
-    "generated_at": "2026-08-24T07:49:37+00:00",
+    "bundle_sha256": "2ddb8207bf4c36791567bb30320ee479ac17b062cc02e7890e98c8aa5bb7443e",
+    "generated_at": "2026-08-24T10:10:01+00:00",
     "source_coverage": {
       "days": 5,
       "places": 52,
@@ -1135,7 +1271,7 @@
       "selected_hotels": 3
     },
     "source_path": "trips/awaji-naruto-tokushima-kobe-2026/trip.json",
-    "source_sha256": "8afe84c96916e2c10763dd4069cac21ff249fe6ad2fa0edb3d164b16033eb107",
+    "source_sha256": "d113dc9fc54c67eeb6b27e111f3ff89738dd4e67c8f623ed9abb228ebc84882f",
     "trip_schema": "trip-v1"
   },
   "operations": {

--- a/web/src/app/TripApp.tsx
+++ b/web/src/app/TripApp.tsx
@@ -206,7 +206,7 @@ export default function TripApp({ tripMeta = null, tripSlug }: TripAppProps) {
       return <ReservationsPage bundle={bundle} />
     }
     if (selectedSection === 'tides') {
-      return <TidesPage bundle={bundle} />
+      return <TidesPage bundle={bundle} day={effectiveRoute.day} />
     }
     if (selectedSection === 'food') {
       return <FoodPage bundle={bundle} />

--- a/web/src/contracts/trip.ts
+++ b/web/src/contracts/trip.ts
@@ -64,6 +64,30 @@ export interface BundlePublicOperations {
   supplies?: unknown[]
 }
 
+export interface BundleTideEvent {
+  kind: 'high' | 'low'
+  time: string
+  height_cm: number
+}
+
+export interface BundleTideDay {
+  date: string
+  tide_type: string
+  events: BundleTideEvent[]
+}
+
+export interface BundleTideConditions {
+  status?: OperationalStatus | null
+  status_label?: string | null
+  summary?: string | null
+  provider?: string | null
+  source_url?: string | null
+  last_checked?: string | null
+  recheck_at?: string | null
+  station?: string | null
+  days?: BundleTideDay[]
+}
+
 export interface BundleDayItem {
   id: string
   kind: string
@@ -154,6 +178,12 @@ export interface Bundle {
     flight_ids: string[]
   }
   operations?: BundlePublicOperations
+  conditions?: {
+    tide?: BundleTideConditions
+    weather?: Record<string, unknown>
+    closures?: unknown[]
+    freshness?: string
+  }
   days: BundleDay[]
   transport_legs?: BundleTransportLeg[]
   alternatives?: Array<{

--- a/web/src/pages/TidesPage.tsx
+++ b/web/src/pages/TidesPage.tsx
@@ -1,39 +1,53 @@
 import { Bundle } from '../contracts/trip'
 interface TidesPageProps {
   bundle: Bundle
+  day?: string
 }
 
-export function TidesPage({ bundle }: TidesPageProps) {
+function tideLabel(kind: string) {
+  if (kind === 'high') return '滿潮'
+  if (kind === 'low') return '干潮'
+  return `潮汐轉折（${kind}）`
+}
+
+export function TidesPage({ bundle, day }: TidesPageProps) {
   const warnings = bundle.validation.filter((item) => item.severity !== 'info')
-  const days = bundle.days
+  const tide = bundle.conditions?.tide
+  const tideDays = tide?.days || []
+  const selectedDay = tideDays.find((item) => item.date === day) || tideDays[0]
+  const hasTideData = Boolean(selectedDay && tideDays.length > 0)
 
   return (
     <section className="card hub-card-wrapper" aria-label="潮汐與動態條件">
       <header className="hub-header">
         <h2>潮汐與動態條件</h2>
-        <p>目前僅提供行程層級警示；尚未接入潮汐與路況的專屬公域欄位。</p>
+        <p>{tide?.summary || '潮汐資料載入失敗，請重新整理頁面。'}</p>
       </header>
 
       <div className="hub-stats">
         <p>提醒：{warnings.length}</p>
-        <p>潮汐資料：未提供</p>
+        <p>潮汐資料：{hasTideData ? tide?.status_label || '官方預測' : '資料未載入'}</p>
       </div>
 
-      <p className="shell-message">資料版本：{bundle.meta.generated_at}</p>
+      <p className="shell-message">資料站：{tide?.station || '洲本（SUMOTO）'}；資料時間：日本時間</p>
 
       <section className="hub-section">
-        {days.map((day) => (
-          <article className="hub-item" key={day.date}>
+        {tideDays.map((item) => (
+          <article className={`hub-item${item.date === selectedDay?.date ? ' hub-item-selected' : ''}`} key={item.date}>
             <div className="hub-item-row">
-              <span className="hub-status unknown">unknown</span>
-              <h3>{day.date}</h3>
+              <span className="hub-status confirmed">{tide?.status_label || '官方預測'}</span>
+              <h3>{item.date}{item.date === selectedDay?.date ? '（目前日期）' : ''}</h3>
             </div>
-            <p>高低潮資料：未提供（public-bundle）</p>
-            <p>可行動窗口：待補</p>
-            <p>child / elder 限制：未提供</p>
-            <p className="hub-meta">請務必以官方預報與現場公告為準，不做潮汐結果保證。</p>
+            <p>潮汐型態：{item.tide_type}</p>
+            <ul className="hub-alert-list">
+              {item.events.map((event) => (
+                <li key={`${item.date}-${event.kind}-${event.time}`}>{tideLabel(event.kind)} {event.time}（{event.height_cm} cm）</li>
+              ))}
+            </ul>
+            <p className="hub-meta">潮位為預測值；實際潮位會受氣象與海況影響，海邊活動仍依現場安全狀況調整。</p>
           </article>
         ))}
+        {!hasTideData ? <p className="hub-empty">目前沒有可顯示的潮位預測。</p> : null}
       </section>
 
       {warnings.length > 0 ? (
@@ -50,7 +64,7 @@ export function TidesPage({ bundle }: TidesPageProps) {
       ) : null}
 
       <p className="hub-footer">
-        目前缺失可再補充欄位：high/low 時刻、運能窗口、交通臨時封閉與天候警示與來源。
+        來源：{tide?.source_url ? <a href={tide.source_url} target="_blank" rel="noreferrer">{tide.provider || '官方'}潮位表</a> : '來源資料未載入'}；出發前請再核對最新海象與設施公告。
       </p>
     </section>
   )

--- a/web/tests/handbook.test.tsx
+++ b/web/tests/handbook.test.tsx
@@ -6,6 +6,7 @@ import { groupContiguousLegs, MapPage } from '../src/pages/MapPage'
 import { heroNextItem, ItineraryPage } from '../src/pages/ItineraryPage'
 import { OverviewPage } from '../src/pages/OverviewPage'
 import { PackingPage } from '../src/pages/PackingPage'
+import { TidesPage } from '../src/pages/TidesPage'
 import { buildReservationCalendarIcs } from '../src/pages/ReservationsPage'
 import type { TripCatalogEntry } from '../src/contracts/trip-registry'
 
@@ -221,6 +222,35 @@ describe('Issue 97 travel handbook', () => {
     expect(screen.getByText('行前需確認')).toBeInTheDocument()
     expect(screen.getByText(/道路時間、天候、營運、停車與訂位狀態/)).toBeInTheDocument()
     expect(screen.queryByText(/資料快照/)).not.toBeInTheDocument()
+  })
+
+  it('renders official tide predictions for the selected day without placeholders', () => {
+    render(<TidesPage bundle={{
+      ...bundle,
+      conditions: {
+        tide: {
+          status: 'confirmed',
+          status_label: '官方預測已取得',
+          provider: '日本氣象廳',
+          station: '洲本（SUMOTO）',
+          source_url: 'https://www.data.jma.go.jp/kaiyou/db/tide/suisan/',
+          days: [{
+            date: dates[0],
+            tide_type: '大潮',
+            events: [
+              { kind: 'high', time: '05:25', height_cm: 154 },
+              { kind: 'low', time: '12:16', height_cm: 42 },
+              { kind: 'high', time: '18:57', height_cm: 156 },
+            ],
+          }],
+        },
+      },
+    }} day={dates[0]} />)
+    expect(screen.getByRole('heading', { name: '潮汐與動態條件' })).toBeInTheDocument()
+    expect(screen.getByText('2026-08-27（目前日期）')).toBeInTheDocument()
+    expect(screen.getByText('滿潮 05:25（154 cm）')).toBeInTheDocument()
+    expect(screen.getByText('干潮 12:16（42 cm）')).toBeInTheDocument()
+    expect(screen.queryByText(/待補|未提供|unknown/)).not.toBeInTheDocument()
   })
 
   it('does not repeat an item safety note as a separate accessibility note', () => {


### PR DESCRIPTION
## Summary
- 以日本氣象廳洲本（SUMOTO）官方潮位表更新 2026/8/27–8/31 預測資料
- 潮汐頁依 URL 日期顯示目前日期與滿／干潮時間、潮位
- 移除潮汐頁的待補、未提供與 unknown 佔位文字，補上來源與預測值說明

## Verification
- `python3 -m pytest -q`
- `python3 -m unittest tests.trips.test_awaji_2026_constraints`
- `cd web && npm test -- --run`
- `cd web && npm run build`
- `python3 scripts/check-awaji-contamination.py`