### PR TITLE
fix(web): 改善手機導覽與色彩對比

### DIFF
--- a/web/src/layouts/MobileHeader.tsx
+++ b/web/src/layouts/MobileHeader.tsx
@@ -29,7 +29,7 @@ export function MobileHeader({ title, subtitle, onOpenMenu, isMenuOpen, menuButt
         className="menu-button"
         type="button"
         onClick={onOpenMenu}
-        aria-label="展開導覽選單"
+        aria-label={isMenuOpen ? '導覽選單已展開' : '展開導覽選單'}
         aria-expanded={isMenuOpen}
         aria-controls="mobile-navigation-drawer"
         ref={menuButtonRef}

--- a/web/src/layouts/MobileHeader.tsx
+++ b/web/src/layouts/MobileHeader.tsx
@@ -1,9 +1,12 @@
+import type { RefObject } from 'react'
 import { TripStatusType } from './TripShell'
 
 interface MobileHeaderProps {
   title: string
   subtitle: string
   onOpenMenu: () => void
+  isMenuOpen: boolean
+  menuButtonRef: RefObject<HTMLButtonElement>
   statusText: string
   shellStatus: TripStatusType
 }
@@ -19,11 +22,19 @@ const LABEL_BY_STATUS: Record<TripStatusType, string> = {
   normal: '正常',
 }
 
-export function MobileHeader({ title, subtitle, onOpenMenu, statusText, shellStatus }: MobileHeaderProps) {
+export function MobileHeader({ title, subtitle, onOpenMenu, isMenuOpen, menuButtonRef, statusText, shellStatus }: MobileHeaderProps) {
   return (
     <header className="mobile-topbar">
-      <button className="menu-button" type="button" onClick={onOpenMenu} aria-label="展開導覽選單">
-        導覽
+      <button
+        className="menu-button"
+        type="button"
+        onClick={onOpenMenu}
+        aria-label="展開導覽選單"
+        aria-expanded={isMenuOpen}
+        aria-controls="mobile-navigation-drawer"
+        ref={menuButtonRef}
+      >
+        <span className="menu-icon" aria-hidden="true"><span /><span /><span /></span>
       </button>
       <div className="mobile-topbar-title">
         <p>{title}</p>

--- a/web/src/layouts/TripShell.tsx
+++ b/web/src/layouts/TripShell.tsx
@@ -65,9 +65,23 @@ export default function TripShell({
     : '行程資料載入中'
 
   useEffect(() => {
-    if (!isDrawerOpen && wasDrawerOpen.current) menuButtonRef.current?.focus()
+    if (!isDrawerOpen && wasDrawerOpen.current && window.matchMedia('(max-width: 960px)').matches) {
+      menuButtonRef.current?.focus()
+    }
     wasDrawerOpen.current = isDrawerOpen
   }, [isDrawerOpen])
+
+  useEffect(() => {
+    const desktopViewport = window.matchMedia('(min-width: 961px)')
+    const closeDrawerOnDesktop = (matches: boolean) => {
+      if (matches) setDrawerOpen(false)
+    }
+    const onViewportChange = (event: MediaQueryListEvent) => closeDrawerOnDesktop(event.matches)
+
+    closeDrawerOnDesktop(desktopViewport.matches)
+    desktopViewport.addEventListener('change', onViewportChange)
+    return () => desktopViewport.removeEventListener('change', onViewportChange)
+  }, [setDrawerOpen])
 
   useEffect(() => {
     if (isDrawerOpen) {

--- a/web/src/layouts/TripShell.tsx
+++ b/web/src/layouts/TripShell.tsx
@@ -3,7 +3,6 @@ import { Bundle, toFriendlyStatus } from '../contracts/trip'
 import { SectionDefinition } from '../app/route-registry'
 import { DesktopSidebar } from './DesktopSidebar'
 import { MobileHeader } from './MobileHeader'
-import { MobileNavigation } from './MobileNavigation'
 
 export type TripStatusType =
   | 'normal'
@@ -52,6 +51,8 @@ export default function TripShell({
   children,
 }: TripShellProps) {
   const drawerRef = useRef<HTMLDivElement>(null)
+  const menuButtonRef = useRef<HTMLButtonElement>(null)
+  const wasDrawerOpen = useRef(isDrawerOpen)
   const [currentStatusText, setCurrentStatusText] = useState(statusText[shellStatus])
 
   useEffect(() => {
@@ -62,6 +63,11 @@ export default function TripShell({
   const subtitle = bundle?.date_range
     ? `${bundle.date_range.start_date} ~ ${bundle.date_range.end_date}（${toFriendlyStatus(bundle.status)}）`
     : '行程資料載入中'
+
+  useEffect(() => {
+    if (!isDrawerOpen && wasDrawerOpen.current) menuButtonRef.current?.focus()
+    wasDrawerOpen.current = isDrawerOpen
+  }, [isDrawerOpen])
 
   useEffect(() => {
     if (isDrawerOpen) {
@@ -107,6 +113,8 @@ export default function TripShell({
         title={title}
         subtitle={subtitle}
         onOpenMenu={() => setDrawerOpen(true)}
+        isMenuOpen={isDrawerOpen}
+        menuButtonRef={menuButtonRef}
         statusText={currentStatusText}
         shellStatus={shellStatus}
       />
@@ -158,13 +166,19 @@ export default function TripShell({
         </main>
       </div>
 
-      <MobileNavigation sections={sections} activeSection={activeSection} onNavigate={onNavigateSection} />
-
       {isDrawerOpen ? (
         <div className="drawer-scrim" onClick={() => setDrawerOpen(false)} role="presentation">
-          <aside className="mobile-drawer" role="dialog" aria-label="行程區段導覽" onClick={(event) => event.stopPropagation()} ref={drawerRef}>
+          <aside
+            className="mobile-drawer"
+            id="mobile-navigation-drawer"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="mobile-navigation-title"
+            onClick={(event) => event.stopPropagation()}
+            ref={drawerRef}
+          >
             <div className="drawer-header">
-              <h2>導航</h2>
+              <h2 id="mobile-navigation-title">導航</h2>
               <button type="button" onClick={() => setDrawerOpen(false)} aria-label="關閉導覽">
                 關閉
               </button>
@@ -175,12 +189,14 @@ export default function TripShell({
                   key={section.id}
                   type="button"
                   className={`drawer-nav-item ${section.id === activeSection ? 'is-active' : ''}`}
+                  aria-current={section.id === activeSection ? 'page' : undefined}
                   onClick={() => {
                     onNavigateSection(section.id)
                     setDrawerOpen(false)
                   }}
                 >
-                  {section.label}
+                  <span>{section.label}</span>
+                  {section.id === activeSection ? <small>目前</small> : null}
                 </button>
               ))}
             </nav>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12,7 +12,6 @@
   --error: #a81f2c;
   --muted-bg: #f3f7fd;
   --focus: #0e5ea8;
-  --mobile-nav-h: 68px;
 }
 
 * { box-sizing: border-box; }
@@ -43,7 +42,7 @@ a {
 .app-frame {
   display: flex;
   flex: 1;
-  min-height: calc(100dvh - 58px - var(--mobile-nav-h));
+  min-height: calc(100dvh - 58px);
 }
 
 .trip-sidebar {
@@ -114,7 +113,7 @@ a {
 .app-main {
   flex: 1;
   overflow: auto;
-  padding: 12px 12px calc(var(--mobile-nav-h) + env(safe-area-inset-bottom) + 16px);
+  padding: 12px 12px 28px;
 }
 
 .trip-main-header {
@@ -540,61 +539,55 @@ textarea {
   border-bottom: 1px solid #2b4c70;
   padding: 10px 12px env(safe-area-inset-top) 12px;
   display: grid;
-  grid-template-columns: 64px 1fr auto;
+  grid-template-columns: 44px minmax(0, 1fr) auto;
   align-items: center;
   column-gap: 12px;
 }
 
+.mobile-topbar-title { min-width: 0; }
+.mobile-topbar-title p,
+.mobile-topbar-title small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .mobile-topbar-title p { margin: 0; font-weight: 700; font-size: 1rem; }
-.mobile-topbar-title small { color: #c8d4e6; display: block; margin-top: 2px; font-size: 0.75rem; }
+.mobile-topbar-title small { color: #d7e2e8; display: block; margin-top: 2px; font-size: 0.75rem; }
 
 .menu-button {
+  display: grid;
+  place-items: center;
+  width: 44px;
   height: 44px;
-  min-width: 52px;
-  background: #1d4f79;
+  min-width: 44px;
+  padding: 0;
+  border: 1px solid #87a9b8;
+  border-radius: 10px;
+  color: #fff;
+  background: #173e59;
+  cursor: pointer;
+}
+
+.menu-icon {
+  display: grid;
+  gap: 4px;
+}
+
+.menu-icon span {
+  display: block;
+  width: 21px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
 }
 
 .mobile-status {
   font-size: 0.75rem;
-  color: #bfd7ec;
-  background: rgba(255, 255, 255, 0.12);
+  color: #f0f6f8;
+  background: #294559;
+  border: 1px solid #668594;
   border-radius: 999px;
   padding: 6px 10px;
   white-space: nowrap;
 }
 
-.mobile-status.loading { color: #9fd3ff; }
-
-.mobile-bottom-nav {
-  display: none;
-  position: fixed;
-  inset: auto 0 0 0;
-  z-index: 40;
-  background: rgba(7, 25, 43, 0.98);
-  padding: 8px 10px calc(8px + env(safe-area-inset-bottom));
-  border-top: 1px solid #2b4d73;
-}
-
-.mobile-bottom-track {
-  width: min(1040px, 100%);
-  margin: 0 auto;
-  display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  gap: 6px;
-}
-
-.bottom-nav-item {
-  border: none;
-  border-radius: 999px;
-  padding: 9px 6px;
-  background: #0f3458;
-  min-height: 44px;
-  color: #edf2ff;
-}
-
-.bottom-nav-item.is-active {
-  background: #2e78ca;
-}
+.mobile-status.loading { color: #d8ebf8; }
 
 .drawer-scrim {
   position: fixed;
@@ -602,16 +595,17 @@ textarea {
   background: rgba(8, 13, 24, 0.56);
   z-index: 50;
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
 }
 
 .mobile-drawer {
-  width: min(84vw, 320px);
-  background: #0a2643;
-  color: #edf3ff;
+  width: min(86vw, 336px);
+  background: #0c2235;
+  color: #f5f9fb;
   height: 100%;
-  padding: 12px;
-  box-shadow: -10px 0 24px rgba(4, 13, 29, 0.5);
+  padding: max(14px, env(safe-area-inset-top)) 14px 20px;
+  overflow-y: auto;
+  box-shadow: 12px 0 30px rgba(4, 13, 29, 0.5);
 }
 
 .drawer-header {
@@ -625,6 +619,14 @@ textarea {
   font-size: 1rem;
 }
 
+.drawer-header button {
+  min-width: 56px;
+  min-height: 44px;
+  border: 1px solid #7895a3;
+  color: #f5f9fb;
+  background: #17384e;
+}
+
 .mobile-drawer-nav {
   display: grid;
   gap: 6px;
@@ -632,9 +634,12 @@ textarea {
 }
 
 .drawer-nav-item {
-  border: 1px solid #27527a;
-  background: #12385d;
-  color: #edf4ff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid #587485;
+  background: #152f43;
+  color: #f4f8fa;
   border-radius: 10px;
   text-align: left;
   padding: 10px 12px;
@@ -642,7 +647,17 @@ textarea {
 }
 
 .drawer-nav-item.is-active {
-  border-color: #5ea2f7;
+  border-color: #8bd4da;
+  background: #006d7c;
+  font-weight: 800;
+}
+
+.drawer-nav-item.is-active small {
+  padding: 2px 6px;
+  border-radius: 999px;
+  color: #0c2235;
+  background: #d8f3f1;
+  font-size: .65rem;
 }
 
 @media (max-width: 960px) {
@@ -651,13 +666,12 @@ textarea {
     display: none;
   }
 
-  .mobile-topbar,
-  .mobile-bottom-nav {
-    display: block;
+  .mobile-topbar {
+    display: grid;
   }
 
   .app-frame {
-    min-height: calc(100dvh - 58px - var(--mobile-nav-h));
+    min-height: calc(100dvh - 58px);
   }
 
   .trip-content {
@@ -669,36 +683,17 @@ textarea {
     padding: 10px;
   }
 
-  .mobile-bottom-track {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    overflow-x: auto;
-    overflow-y: hidden;
-    padding-bottom: 2px;
-    scrollbar-width: none;
-  }
-
-  .mobile-bottom-track::-webkit-scrollbar {
-    display: none;
-  }
-
-  .bottom-nav-item {
-    white-space: nowrap;
-    min-width: 72px;
-    font-size: 0.85rem;
-  }
-
   .day-tabs {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .app-main {
-    padding-bottom: calc(var(--mobile-nav-h) + env(safe-area-inset-bottom) + 16px);
+    padding-bottom: calc(24px + env(safe-area-inset-bottom));
   }
 }
 
 @media (min-width: 961px) {
   .mobile-topbar,
-  .mobile-bottom-nav,
   .drawer-scrim {
     display: none;
   }
@@ -714,7 +709,7 @@ textarea {
 
 @media (max-width: 560px) {
   .app-main {
-    padding: 8px 10px 84px;
+    padding: 8px 10px calc(24px + env(safe-area-inset-bottom));
   }
   .grid.two-col {
     grid-template-columns: 1fr;
@@ -727,7 +722,6 @@ textarea {
 
 @media print {
   .app-shell .mobile-topbar,
-  .app-shell .mobile-bottom-nav,
   .app-shell .trip-sidebar,
   .app-shell .drawer-scrim {
     display: none !important;
@@ -797,9 +791,6 @@ button { font-family: inherit; }
 .trip-content { width: min(1120px, 100%); }
 .card, .card-shell { border: 1px solid #e5ecef; border-radius: 16px; padding: 20px; box-shadow: 0 4px 16px rgba(28, 50, 64, .04); }
 .mobile-topbar { background: #0f1e2e; border-bottom: 1px solid #20394d; }
-.mobile-bottom-nav { background: #0f1e2e; border-top: 1px solid #20394d; }
-.bottom-nav-item { background: #182c3d; }
-.bottom-nav-item.is-active { background: #0b6da8; }
 
 .itinerary-workspace { min-width: 0; }
 .itinerary-day-nav { position: sticky; top: 0; z-index: 10; display: flex; align-items: center; gap: 14px; padding: 12px 0; margin-bottom: 20px; background: color-mix(in srgb, #f8fafc 92%, transparent); backdrop-filter: blur(10px); border-bottom: 1px solid #e4ebee; }
@@ -844,7 +835,7 @@ button { font-family: inherit; }
 
 @media (max-width: 960px) {
   .app-shell .app-main { display: block; }
-  .app-main { padding: 0 12px calc(var(--mobile-nav-h) + env(safe-area-inset-bottom) + 18px); }.desktop-topbar { display: none; }.trip-main-header { margin: 14px 0 8px; }.trip-version { margin-bottom: 11px; }.itinerary-day-nav { top: 58px; margin: 0 -12px 15px; padding: 9px 12px; }.day-nav-label { display: none; }.day-tabs { flex: 1; }.day-stats { align-self: auto; }.timeline-entry { grid-template-columns: 58px 27px minmax(0, 1fr); }.timeline-card { margin-left: 7px; padding-left: 13px; }.timeline-entry.reservation .timeline-card { margin-left: 7px; }.timeline-time { padding-right: 8px; }.timeline-time strong { font-size: .76rem; }.timeline-track > span { width: 22px; height: 22px; border-width: 2px; }.timeline-track i { top: 21px; }.itinerary-alternatives { grid-template-columns: 1fr; }.plan-tabs { justify-content: flex-start; }
+  .app-main { padding: 0 12px calc(24px + env(safe-area-inset-bottom)); }.desktop-topbar { display: none; }.trip-main-header { margin: 14px 0 8px; }.trip-version { margin-bottom: 11px; }.itinerary-day-nav { top: 58px; margin: 0 -12px 15px; padding: 9px 12px; }.day-nav-label { display: none; }.day-tabs { flex: 1; }.day-stats { align-self: auto; }.timeline-entry { grid-template-columns: 58px 27px minmax(0, 1fr); }.timeline-card { margin-left: 7px; padding-left: 13px; }.timeline-entry.reservation .timeline-card { margin-left: 7px; }.timeline-time { padding-right: 8px; }.timeline-time strong { font-size: .76rem; }.timeline-track > span { width: 22px; height: 22px; border-width: 2px; }.timeline-track i { top: 21px; }.itinerary-alternatives { grid-template-columns: 1fr; }.plan-tabs { justify-content: flex-start; }
 }
 @media (max-width: 620px) {
   .main-title { font-size: 1.08rem; }.shell-status-line { font-size: .7rem; }.itinerary-day-nav { gap: 8px; }.day-tab { min-width: 54px; padding: 7px; }.print-button { min-height: 32px; padding: 6px 8px; }.day-hero { display: block; padding: 23px 20px; border-radius: 16px; }.day-hero h2 { font-size: 1.42rem; }.day-stats { margin-top: 18px; }.day-stats span { min-width: 0; flex: 1; }.itinerary-utility { display: grid; align-items: stretch; }.itinerary-search { min-width: 0; }.quick-mode { justify-content: flex-start; }.timeline-card h3 { font-size: .92rem; }.timeline-actions a, .timeline-actions button { min-height: 44px; }.timeline-entry { min-height: 155px; }.timeline-card-topline { align-items: flex-start; }.timeline-category { padding-top: 3px; }.search-results button { grid-template-columns: 34px 1fr; }.search-results button small { grid-column: 2; }.itinerary-alternatives { padding: 15px; }
@@ -1026,6 +1017,271 @@ body,
   .lodging-card-main > header { display: grid; }.night-pill { justify-self: start; }.stay-actions > * { flex: 1 1 130px; }
   .reservation-alert { display: grid; }.reservation-card { grid-template-columns: 1fr; padding: 15px; }.reservation-time { display: flex; align-items: baseline; gap: 9px; padding: 0 0 10px; border-right: 0; border-bottom: 1px solid #e6edef; }.reservation-title-row { display: grid; }.reservation-kind { justify-self: start; }.reservation-facts { grid-template-columns: 1fr; }.reservation-actions > * { flex: 1 1 130px; }
   .checklist-progress { width: 100%; height: 64px; display: flex; gap: 10px; }.checklist-groups { grid-template-columns: 1fr; }.packing-toolbar { flex-wrap: wrap; }.packing-toolbar button { margin-left: 0; }.notes-workspace { padding: 15px; }.note-card { grid-template-columns: 1fr; }.note-card .action-row { grid-column: 1; grid-row: auto; }
+}
+
+/* Issue 106 · stronger visual hierarchy and WCAG AA contrast. */
+:root {
+  --bg: #edf2f5;
+  --panel: #ffffff;
+  --panel-strong: #e5edf1;
+  --text: #142f3d;
+  --text-sub: #455e69;
+  --text-muted: #506773;
+  --line: #afc0c8;
+  --line-strong: #718b97;
+  --brand: #0b6da8;
+  --brand-deep: #075f91;
+  --success: #0b6849;
+  --warn: #80520f;
+  --error: #922431;
+  --muted-bg: #f3f7f8;
+}
+
+body,
+.app-main {
+  background: var(--bg);
+}
+
+.desktop-topbar,
+.itinerary-day-nav,
+.handbook-day-tabs {
+  background-color: rgba(255, 255, 255, .96);
+  border-color: #afc0c8;
+}
+
+.desktop-topbar,
+.desktop-status,
+.desktop-travelers {
+  color: #455e69;
+}
+
+.desktop-status,
+.desktop-travelers,
+.desktop-quick-actions button,
+.day-tab,
+.print-button,
+.quick-mode button,
+.plan-tabs button,
+.timeline-actions a,
+.timeline-actions button,
+.handbook-day-tabs button,
+.stay-actions a,
+.stay-actions button,
+.reservation-actions a,
+.reservation-actions button,
+.secondary-button,
+.danger-button,
+.note-editor input,
+.note-editor textarea {
+  border-color: var(--line-strong);
+}
+
+.desktop-quick-actions button,
+.day-tab,
+.print-button,
+.quick-mode button,
+.plan-tabs button,
+.secondary-button {
+  color: #344f5c;
+  background: #fff;
+}
+
+.day-tab.active,
+.handbook-day-tabs button.is-active,
+.stay-actions .primary,
+.reservation-actions .primary {
+  color: #fff;
+  border-color: var(--brand-deep);
+  background: var(--brand-deep);
+}
+
+.card,
+.card-shell,
+.overview-section,
+.map-day-panel,
+.lodging-card,
+.reservation-card,
+.checklist-group,
+.notes-workspace,
+.itinerary-alternatives,
+.search-results {
+  border-color: var(--line);
+  background: #fff;
+  box-shadow: 0 7px 20px rgba(20, 47, 61, .08);
+}
+
+.overview-day-card,
+.route-leg-card,
+.search-results button,
+.stay-dates,
+.timeline-risk,
+.checklist-group > header,
+.note-editor input,
+.note-editor textarea {
+  border-color: #c3d0d6;
+  background: #f3f7f8;
+}
+
+.trip-brand-subtitle,
+.trip-sidebar-status small,
+.trip-sidebar-footer,
+.trip-sidebar-footer small,
+.trip-nav-label,
+.trip-nav-item:not(.is-active) small {
+  color: #b8c8cf;
+}
+
+.trip-nav-item:not(.is-active) {
+  color: #e4edf1;
+}
+
+.trip-nav-item:not(.is-active) .trip-nav-icon {
+  color: #9fe3dd;
+}
+
+.page-intro p,
+.data-footnote,
+.honest-inline,
+.day-nav-label,
+.itinerary-search,
+.quick-mode,
+.plan-tabs,
+.search-results p,
+.search-results button small,
+.timeline-time span,
+.timeline-category,
+.timeline-card h3 small,
+.timeline-detail,
+.timeline-address,
+.timeline-empty,
+.itinerary-alternatives .section-label,
+.itinerary-alternatives article p,
+.overview-day-number,
+.overview-day-copy > p,
+.overview-day-foot,
+.overview-stay-list p,
+.overview-stay-list small,
+.overview-alert-list small,
+.overview-footer,
+.timeline-risk p,
+.timeline-context,
+.timeline-inline-alternatives,
+.map-day-header p:not(.eyebrow),
+.route-leg-index,
+.route-leg-topline,
+.route-endpoints small,
+.route-leg-facts dt,
+.lodging-route-strip small,
+.lodging-card-number,
+.lodging-card-main header p,
+.lodging-photo figcaption,
+.stay-dates small,
+.stay-dates span,
+.stay-address small,
+.stay-boundary-note,
+.stay-note,
+.reservation-day > header,
+.reservation-time span,
+.reservation-kind,
+.reservation-facts dt,
+.checklist-progress span,
+.checklist-group header small,
+.checklist-copy small,
+.checklist-copy p,
+.reference-note,
+.checklist-group li > a,
+.note-card small,
+.note-card p {
+  color: var(--text-muted);
+}
+
+.eyebrow,
+.overview-day-number strong,
+.section-heading > a,
+.section-heading > span,
+.timeline-actions a,
+.timeline-actions button,
+.timeline-inline-alternatives a,
+.lodging-photo a,
+.stay-actions a,
+.stay-actions button,
+.reservation-actions a,
+.reservation-actions button {
+  color: var(--brand-deep);
+}
+
+.overview-day-route i,
+.stay-dates > i,
+.stay-address > span,
+.route-endpoints > span {
+  color: #006d7c;
+}
+
+.overview-warning,
+.timeline-context.needs-recheck,
+.route-risk-note,
+.reservation-alert,
+.reservation-risk {
+  color: #65430f;
+  border-color: #c58a2e;
+  background: #fff4de;
+}
+
+.warning-text,
+.overview-alert-list > a strong,
+.reservation-time strong,
+.source-chip.fallback,
+.checklist-copy .fallback-note {
+  color: var(--warn);
+}
+
+.timeline-track i,
+.progress-track {
+  background: #aabdc5;
+}
+
+.custom-checkbox {
+  border-color: var(--line-strong);
+}
+
+.day-answer-grid > div,
+.day-stats span {
+  border-color: #7897a4;
+  background: rgba(5, 23, 34, .78);
+}
+
+.day-answer-grid span,
+.day-kicker,
+.trip-hero-eyebrow {
+  color: #9fe3dd;
+}
+
+.day-answer-grid small,
+.day-stats span,
+.day-hero p,
+.trip-hero-meta,
+.trip-overview-hero .hero-summary {
+  color: #d2e4e3;
+}
+
+.status-pill {
+  background: rgba(4, 23, 34, .72);
+}
+
+.hero-brief {
+  border-color: #7897a4;
+  background: rgba(4, 23, 34, .84);
+}
+
+.hero-brief > p,
+.hero-brief dt,
+.hero-brief small {
+  color: #b8c8cf;
+}
+
+@media (max-width: 960px) {
+  .app-frame { min-height: calc(100dvh - 65px); }
+  .app-main { background: var(--bg); }
 }
 
 /* Touch targets: keep primary mobile controls usable after compact theme overrides. */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -486,7 +486,7 @@ button:focus-visible {
 }
 
 button:focus-visible {
-  outline: 2px solid #9dd3ff;
+  outline: 3px solid #075f91;
   outline-offset: 2px;
 }
 
@@ -1139,7 +1139,18 @@ body,
   color: #9fe3dd;
 }
 
+.trip-nav-item.is-active small {
+  color: #fff;
+}
+
+.mobile-topbar button:focus-visible,
+.mobile-drawer button:focus-visible,
+.trip-sidebar button:focus-visible {
+  outline-color: #9fe3dd;
+}
+
 .page-intro p,
+.page-intro-stats span,
 .data-footnote,
 .honest-inline,
 .day-nav-label,
@@ -1217,6 +1228,11 @@ body,
   color: #006d7c;
 }
 
+.stay-sequence,
+.lodging-route-strip span {
+  background: #006d7c;
+}
+
 .overview-warning,
 .timeline-context.needs-recheck,
 .route-risk-note,
@@ -1241,6 +1257,16 @@ body,
 }
 
 .custom-checkbox {
+  border-color: var(--line-strong);
+}
+
+.checklist-group input:focus-visible + .custom-checkbox {
+  outline: 3px solid var(--brand-deep);
+  outline-offset: 2px;
+}
+
+.note-editor input,
+.note-editor textarea {
   border-color: var(--line-strong);
 }
 

--- a/web/tests/e2e.mjs
+++ b/web/tests/e2e.mjs
@@ -141,7 +141,7 @@ try {
 
   await openRoute(mobile, 'overview')
   if (await mobile.locator('.mobile-bottom-nav').count()) throw new Error('mobile bottom navigation must not be rendered')
-  const menuButton = mobile.getByRole('button', { name: '展開導覽選單' })
+  const menuButton = mobile.locator('.menu-button')
   await assertTouchTargets(mobile, '.menu-button', 'hamburger menu')
   await assertStyleContrast(mobile, '.menu-button', 'color', '.menu-button', 'backgroundColor', 4.5, 'hamburger icon')
   await assertStyleContrast(mobile, '.menu-button', 'borderTopColor', '.mobile-topbar', 'backgroundColor', 3, 'hamburger boundary')
@@ -150,6 +150,7 @@ try {
   const drawer = mobile.locator('#mobile-navigation-drawer')
   await drawer.waitFor({ state: 'visible' })
   if (await menuButton.getAttribute('aria-expanded') !== 'true') throw new Error('hamburger menu did not expose its expanded state')
+  if (await menuButton.getAttribute('aria-label') !== '導覽選單已展開') throw new Error('hamburger menu did not expose its expanded accessible name')
   if (!(await drawer.locator('[aria-current="page"]').textContent())?.includes('目前')) throw new Error('drawer did not label the current section')
   await assertTouchTargets(mobile, '.drawer-nav-item', 'drawer navigation')
   await mobile.keyboard.press('Escape')
@@ -158,6 +159,14 @@ try {
   if (!(await menuButton.evaluate((element) => element === document.activeElement))) throw new Error('focus did not return to the hamburger menu after closing the drawer')
   await assertTextContrast(mobile, '.overview-day-copy > p', 4.5, 'overview secondary text')
   await assertTextContrast(mobile, '.overview-footer span', 4.5, 'overview footer text')
+  await assertTextContrast(mobile, '.stay-sequence', 4.5, 'overview lodging sequence')
+  await menuButton.click()
+  await drawer.waitFor({ state: 'visible' })
+  await mobile.setViewportSize({ width: 1024, height: 844 })
+  await drawer.waitFor({ state: 'detached' })
+  await mobile.setViewportSize({ width: 390, height: 844 })
+  await menuButton.waitFor({ state: 'visible' })
+  if (await menuButton.getAttribute('aria-expanded') !== 'false') throw new Error('drawer state remained open after crossing the desktop breakpoint')
 
   await openRoute(mobile, 'sources')
   await mobile.locator('h1, h2').filter({ hasText: '資料來源' }).waitFor({ state: 'attached' })
@@ -174,6 +183,8 @@ try {
   await assertTextContrast(mobile, '.timeline-time span', 4.5, 'timeline secondary time')
   await assertTextContrast(mobile, '.timeline-detail', 4.5, 'timeline detail')
   await assertTouchTargets(mobile, '.day-tab', 'day tab')
+  await mobile.locator('.day-tab').first().focus()
+  await assertStyleContrast(mobile, '.day-tab:focus-visible', 'outlineColor', '.itinerary-day-nav', 'backgroundColor', 3, 'light control focus indicator')
   await assertTouchTargets(mobile, '.print-button', 'print')
   await assertTouchTargets(mobile, '.quick-mode button', 'quick mode')
   await assertTouchTargets(mobile, '.timeline-actions a, .timeline-actions button', 'timeline action')
@@ -194,12 +205,17 @@ try {
   if (wrap.scrollWidth > wrap.clientWidth || wrap.overflowWrap !== 'anywhere') {
     throw new Error(`long Japanese lodging name did not wrap safely: ${JSON.stringify(wrap)}`)
   }
+  await assertTextContrast(mobile, '.page-intro-stats span', 4.5, 'lodging summary count')
+  await assertTextContrast(mobile, '.lodging-route-strip span', 4.5, 'lodging route sequence')
   await assertTextContrast(mobile, '.stay-note', 4.5, 'lodging note')
 
   await openRoute(mobile, 'packing')
   if (await mobile.getByRole('checkbox').count() !== 30) throw new Error('spreadsheet checklist did not render 30 items')
   await mobile.getByText('預約 Ocean Terrace', { exact: true }).waitFor()
   await assertTextContrast(mobile, '.checklist-copy p', 4.5, 'packing detail')
+  await assertStyleContrast(mobile, '.note-editor input', 'borderTopColor', '.note-editor input', 'backgroundColor', 3, 'note input boundary')
+  await mobile.getByRole('checkbox').first().focus()
+  await assertStyleContrast(mobile, '.checklist-group input:focus-visible + .custom-checkbox', 'outlineColor', '.custom-checkbox', 'backgroundColor', 3, 'checkbox focus indicator')
   await mobileContext.close()
 
   const desktopContext = await browser.newContext({ viewport: { width: 1440, height: 900 } })
@@ -211,6 +227,7 @@ try {
     await desktop.locator('.app-main').waitFor({ state: 'visible' })
     await assertNoHorizontalOverflow(desktop, `1440px ${route}`)
   }
+  await assertTextContrast(desktop, '.trip-nav-item.is-active small', 4.5, 'active desktop navigation description')
   await desktopContext.close()
 
   const routeContext = await browser.newContext({ viewport: { width: 390, height: 844 } })

--- a/web/tests/e2e.mjs
+++ b/web/tests/e2e.mjs
@@ -77,6 +77,59 @@ async function assertTouchTargets(page, selector, label) {
   }
 }
 
+function contrastRatio(foreground, background, label) {
+  const parseRgb = (value) => {
+    const channels = value.match(/[\d.]+/g)?.map(Number)
+    if (!channels || channels.length < 3) throw new Error(`${label} has unsupported color: ${value}`)
+    return channels.slice(0, 3)
+  }
+  const luminance = (value) => {
+    const channels = parseRgb(value).map((channel) => {
+      const normalized = channel / 255
+      return normalized <= 0.04045 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4
+    })
+    return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
+  }
+  const foregroundLuminance = luminance(foreground)
+  const backgroundLuminance = luminance(background)
+  return (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) / (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+}
+
+function assertMinimumContrast(colors, minimum, label) {
+  const ratio = contrastRatio(colors.foreground, colors.background, label)
+  if (ratio < minimum) {
+    throw new Error(`${label} contrast is ${ratio.toFixed(2)}:1 (${colors.foreground} on ${colors.background}); expected at least ${minimum}:1`)
+  }
+}
+
+async function assertStyleContrast(page, foregroundSelector, foregroundProperty, backgroundSelector, backgroundProperty, minimum, label) {
+  const colors = await page.evaluate(({ foregroundSelector, foregroundProperty, backgroundSelector, backgroundProperty }) => {
+    const foreground = document.querySelector(foregroundSelector)
+    const background = document.querySelector(backgroundSelector)
+    if (!foreground || !background) return null
+    return {
+      foreground: getComputedStyle(foreground)[foregroundProperty],
+      background: getComputedStyle(background)[backgroundProperty],
+    }
+  }, { foregroundSelector, foregroundProperty, backgroundSelector, backgroundProperty })
+  if (!colors) throw new Error(`${label} contrast elements were not rendered`)
+  assertMinimumContrast(colors, minimum, label)
+}
+
+async function assertTextContrast(page, selector, minimum, label) {
+  const colors = await page.locator(selector).first().evaluate((element) => {
+    let background = element
+    while (background.parentElement && getComputedStyle(background).backgroundColor === 'rgba(0, 0, 0, 0)') {
+      background = background.parentElement
+    }
+    return {
+      foreground: getComputedStyle(element).color,
+      background: getComputedStyle(background).backgroundColor,
+    }
+  })
+  assertMinimumContrast(colors, minimum, label)
+}
+
 let browser
 try {
   await waitForServer()
@@ -85,6 +138,26 @@ try {
   const mobileContext = await browser.newContext({ viewport: { width: 390, height: 844 } })
   const mobile = await mobileContext.newPage()
   mobile.setDefaultTimeout(10000)
+
+  await openRoute(mobile, 'overview')
+  if (await mobile.locator('.mobile-bottom-nav').count()) throw new Error('mobile bottom navigation must not be rendered')
+  const menuButton = mobile.getByRole('button', { name: '展開導覽選單' })
+  await assertTouchTargets(mobile, '.menu-button', 'hamburger menu')
+  await assertStyleContrast(mobile, '.menu-button', 'color', '.menu-button', 'backgroundColor', 4.5, 'hamburger icon')
+  await assertStyleContrast(mobile, '.menu-button', 'borderTopColor', '.mobile-topbar', 'backgroundColor', 3, 'hamburger boundary')
+  if (await menuButton.getAttribute('aria-expanded') !== 'false') throw new Error('hamburger menu did not expose its collapsed state')
+  await menuButton.click()
+  const drawer = mobile.locator('#mobile-navigation-drawer')
+  await drawer.waitFor({ state: 'visible' })
+  if (await menuButton.getAttribute('aria-expanded') !== 'true') throw new Error('hamburger menu did not expose its expanded state')
+  if (!(await drawer.locator('[aria-current="page"]').textContent())?.includes('目前')) throw new Error('drawer did not label the current section')
+  await assertTouchTargets(mobile, '.drawer-nav-item', 'drawer navigation')
+  await mobile.keyboard.press('Escape')
+  await drawer.waitFor({ state: 'detached' })
+  if (await menuButton.getAttribute('aria-expanded') !== 'false') throw new Error('hamburger menu did not expose its collapsed state after Escape')
+  if (!(await menuButton.evaluate((element) => element === document.activeElement))) throw new Error('focus did not return to the hamburger menu after closing the drawer')
+  await assertTextContrast(mobile, '.overview-day-copy > p', 4.5, 'overview secondary text')
+  await assertTextContrast(mobile, '.overview-footer span', 4.5, 'overview footer text')
 
   await openRoute(mobile, 'sources')
   await mobile.locator('h1, h2').filter({ hasText: '資料來源' }).waitFor({ state: 'attached' })
@@ -98,6 +171,8 @@ try {
   }
 
   await openRoute(mobile, 'today/2026-08-29')
+  await assertTextContrast(mobile, '.timeline-time span', 4.5, 'timeline secondary time')
+  await assertTextContrast(mobile, '.timeline-detail', 4.5, 'timeline detail')
   await assertTouchTargets(mobile, '.day-tab', 'day tab')
   await assertTouchTargets(mobile, '.print-button', 'print')
   await assertTouchTargets(mobile, '.quick-mode button', 'quick mode')
@@ -119,10 +194,12 @@ try {
   if (wrap.scrollWidth > wrap.clientWidth || wrap.overflowWrap !== 'anywhere') {
     throw new Error(`long Japanese lodging name did not wrap safely: ${JSON.stringify(wrap)}`)
   }
+  await assertTextContrast(mobile, '.stay-note', 4.5, 'lodging note')
 
   await openRoute(mobile, 'packing')
   if (await mobile.getByRole('checkbox').count() !== 30) throw new Error('spreadsheet checklist did not render 30 items')
   await mobile.getByText('預約 Ocean Terrace', { exact: true }).waitFor()
+  await assertTextContrast(mobile, '.checklist-copy p', 4.5, 'packing detail')
   await mobileContext.close()
 
   const desktopContext = await browser.newContext({ viewport: { width: 1440, height: 900 } })


### PR DESCRIPTION
## 變更摘要

### 一句話摘要

將淡路島旅行手冊的手機導覽改為三條槓側滑選單，並依 WCAG 2.2 AA 強化整體色彩對比與資訊層級。

### Issue / MR-first task 與 acceptance criteria

- Issue：`#106`
- [x] 已在本 PR 寫清楚背景、scope、acceptance criteria、write ownership、風險、依賴與 validation
- [x] 手機與平板不再顯示固定完整底部選單
- [x] 頂部改為 44×44 三條槓按鈕，並可展開完整側滑選單
- [x] 選擇項目、Escape 或關閉操作可收合，焦點會返回選單按鈕
- [x] `aria-expanded`、`aria-controls`、`aria-current`、dialog label 與焦點圈選完整
- [x] 桌面側邊導覽維持原有流程
- [x] 代表性一般文字達 4.5:1，三條槓邊界達 3:1，狀態不只依賴色彩
- [x] 卡片、頁面背景、控制、提醒與一般資訊建立一致的深淺層級
- [x] E2E 覆蓋手機選單、觸控尺寸、焦點與 computed-color 對比

### Agent workspace

- Branch：`agent/issue-106-mobile-hamburger-menu`
- Worktree：`../.worktrees/ai-travel-planner/issue-106-mobile-hamburger-menu`
- Declared write ownership：
  - `web/src/layouts/TripShell.tsx`
  - `web/src/layouts/MobileHeader.tsx`
  - `web/src/styles.css`
  - `web/tests/e2e.mjs`
- [x] `python3 -m scripts.agent.collaboration check 106` 通過
- [x] Actual changed files 全部位於 declared write ownership

### 風險與角色

- Risk：`high`
- Implementation roles：`core.explorer`、`core.architect`、`core.planner`、`core.executor`、`core.test-engineer`
- Independent review roles：`core.spec-reviewer`、`core.code-reviewer`、`core.verifier`
- Domain reviewers：不適用；未觸及 schema、planner、optimizer、validator、source provider

### Exact evidence

- Base SHA：`4146b458dd3447e61ef6a3a4b3997ac5f59fa325`
- Exact head SHA：`66cb496e7b5e95cdacbc022ced5cbdb952cce8c8`
- Local test commands and results：
  - `npm --prefix web run typecheck`：PASS
  - `npm --prefix web run lint`：PASS
  - `npm --prefix web test`：PASS（22 tests）
  - `npm --prefix web run test:e2e`：PASS
  - `python3 scripts/validate_agent_collaboration.py`：PASS
- [x] Handoff evidence 綁定目前 pushed exact head SHA
- [x] PR 是 regular non-Draft 狀態
- [x] 沒有未解決的 blocking finding

第一輪 independent review findings 已在目前 head 修正：

- 補齊小字、住宿序號與 active sidebar 描述的 4.5:1 對比
- 抽屜跨 960px breakpoint 時同步關閉 state，避免重新顯示時焦點落在 dialog 外
- 淺色按鈕與 checkbox focus indicator 改為至少 3:1
- 備忘 input／textarea 邊界改為至少 3:1
- E2E 新增上述 computed-color 與 breakpoint regression coverage

目前 exact head 的 independent re-review：

- `core.spec-reviewer`：PASS，無 blocking finding
- `core.code-reviewer`：PASS，無 blocking finding
- `core.verifier`：PASS，無 blocking finding；另掃描 11 個 route，最低正常文字為 4.61:1

### Project correctness gates

- [x] Canonical Trip 仍是唯一 source of truth
- [x] Provider raw payload 未進入 planner/canonical model
- [x] Unknown route 未視為 0 分鐘
- [x] Unknown opening hours 未視為營業
- [x] Deterministic validator 仍是 final correctness gate
- [x] API credential 未出現在 log、Trip JSON 或 rendered HTML

### CI

- [x] `framework`
- [x] `python`
- [x] `website`
- [x] `pytest`

### Merge boundary

- [x] 使用者已在本次請求明確授權持續推進直到 merged；不使用 auto-merge

Closes #106
