### PR TITLE
整理淡路島行程頁面內容與行動版可讀性

### DIFF
--- a/tests/trips/test_awaji_2026_constraints.py
+++ b/tests/trips/test_awaji_2026_constraints.py
@@ -88,6 +88,24 @@ class AwajiTripFixtureTests(unittest.TestCase):
         self.assertEqual(reservation_place["resolution"]["state"], "resolved")
         self.assertEqual(reservation_place["resolution"]["confidence"], 1)
 
+    def test_ichiraku_hours_are_official_and_bundle_outputs_match(self):
+        ichiraku = self.places["ramen-ichiraku-nijigen"]
+        expected_note = "ラーメン一樂：平日 11:00–15:00（最後點餐 14:30）、16:00–18:00（最後點餐 17:30）；8/27（週四）12:45–13:30 位於午間營業時段內。"
+        self.assertEqual(ichiraku["opening_hours_note"], expected_note)
+        self.assertEqual(ichiraku["provenance"]["source_url"], "https://nijigennomori.com/price/")
+        self.assertIn("季節或活動調整", ichiraku["provenance"]["note"])
+
+        trip_bundle_place = next(place for place in self.bundle["places"] if place["id"] == ichiraku["id"])
+        web_bundle = json.loads(WEB_BUNDLE_PATH.read_text(encoding="utf-8"))
+        web_bundle_place = next(place for place in web_bundle["places"] if place["id"] == ichiraku["id"])
+        for bundle_place in (trip_bundle_place, web_bundle_place):
+            self.assertEqual(bundle_place["opening_hours_note"], expected_note)
+            self.assertEqual(bundle_place["provenance"]["source_url"], "https://nijigennomori.com/price/")
+
+        meal = next(item for day in self.bundle["days"] for item in day["items"] if item["id"] == "day1-lunch-ichiraku")
+        self.assertIn("11:00–15:00", meal["notes"])
+        self.assertIn("16:00–18:00", meal["notes"])
+
     def test_happy_pancake_is_resolved_at_official_address(self):
         pancake = self.places["naruto-ferry-fixed-activity"]
         self.assertEqual(pancake["name"], "幸せのパンケーキ 淡路島テラス")

--- a/trips/awaji-naruto-tokushima-kobe-2026/public-bundle.json
+++ b/trips/awaji-naruto-tokushima-kobe-2026/public-bundle.json
@@ -226,7 +226,7 @@
           "expected_stay_minutes": 45,
           "id": "day1-lunch-ichiraku",
           "kind": "meal",
-          "notes": "Sheet 指定ラーメン一楽；時間為規劃估計，營業狀態出發前重查。",
+          "notes": "官方營業時間：平日 11:00–15:00（最後點餐 14:30）、16:00–18:00（最後點餐 17:30）；本次 12:45 抵達、13:30 離開。",
           "place_id": "ramen-ichiraku-nijigen",
           "start_at": "2026-08-27T12:45:00+09:00",
           "transfer_minutes": null,
@@ -1262,8 +1262,8 @@
   },
   "local_timezone": "Asia/Tokyo",
   "meta": {
-    "bundle_sha256": "2ddb8207bf4c36791567bb30320ee479ac17b062cc02e7890e98c8aa5bb7443e",
-    "generated_at": "2026-08-24T10:10:01+00:00",
+    "bundle_sha256": "839c58c9843c7067b4cf320a6b3f728c499bdbff016f13df6160d5809b34c5d4",
+    "generated_at": "2026-08-25T06:56:45+00:00",
     "source_coverage": {
       "days": 5,
       "places": 52,
@@ -1271,7 +1271,7 @@
       "selected_hotels": 3
     },
     "source_path": "trips/awaji-naruto-tokushima-kobe-2026/trip.json",
-    "source_sha256": "d113dc9fc54c67eeb6b27e111f3ff89738dd4e67c8f623ed9abb228ebc84882f",
+    "source_sha256": "875f2e25987402fc715ebd3e4809afed2ff29bc6568d455f90d9b6096a6ee673",
     "trip_schema": "trip-v1"
   },
   "operations": {
@@ -2519,15 +2519,15 @@
       "maps_query": "兵庫県淡路市楠本2425-2 兵庫県立淡路島公園内",
       "name": "ラーメン一楽（二次元之森 忍里內）",
       "official_url": null,
-      "opening_hours_note": "二次元之森園區餐飲；官方營業時間依忍里當日營運公告，Day 1 12:45 抵達前確認供餐與最後點餐。",
+      "opening_hours_note": "ラーメン一樂：平日 11:00–15:00（最後點餐 14:30）、16:00–18:00（最後點餐 17:30）；8/27（週四）12:45–13:30 位於午間營業時段內。",
       "provenance": {
-        "confidence": 0.8,
-        "note": "地點與用餐順序來自 Sheet；動態營業資訊待重查。",
-        "provider": "Google Sheet 行程總覽",
-        "retrieved_at": "2026-08-23T03:30:00+08:00",
-        "source_type": "user_input",
-        "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=1150292496",
-        "status": "unverified"
+        "confidence": 0.95,
+        "note": "官方料金與營業資訊列示 NARUTO&BORUTO 忍里 10:00 開始、20:00 最終入場；ラーメン一樂平日 11:00–15:00、16:00–18:00，最後點餐分別為 14:30、17:30；營業時間可能因季節或活動調整。",
+        "provider": "ニジゲンノモリ 官方料金與營業資訊",
+        "retrieved_at": "2026-08-25T14:48:30+08:00",
+        "source_type": "official",
+        "source_url": "https://nijigennomori.com/price/",
+        "status": "confirmed"
       }
     },
     {
@@ -2905,13 +2905,13 @@
       "supports": "place:awaji-nakajima-park"
     },
     {
-      "authority": "Google Sheet 行程總覽",
-      "confidence": 0.8,
+      "authority": "ニジゲンノモリ 官方料金與營業資訊",
+      "confidence": 0.95,
       "conflicts": false,
       "freshness": "unknown",
-      "last_checked": "2026-08-23T03:30:00+08:00",
-      "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=1150292496",
-      "status": "unverified",
+      "last_checked": "2026-08-25T14:48:30+08:00",
+      "source_url": "https://nijigennomori.com/price/",
+      "status": "confirmed",
       "supports": "place:ramen-ichiraku-nijigen"
     },
     {

--- a/trips/awaji-naruto-tokushima-kobe-2026/trip.json
+++ b/trips/awaji-naruto-tokushima-kobe-2026/trip.json
@@ -182,8 +182,8 @@
         "kind": "restaurant",
         "address": "兵庫県淡路市楠本2425-2 兵庫県立淡路島公園内",
         "google_maps_url": "https://www.google.com/maps/search/?api=1&query=Ramen+Ichiraku+Nijigen+no+Mori",
-        "opening_hours_note": "二次元之森園區餐飲；官方營業時間依忍里當日營運公告，Day 1 12:45 抵達前確認供餐與最後點餐。",
-        "provenance": {"source_type":"user_input","provider":"Google Sheet 行程總覽","source_url":"https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=1150292496","retrieved_at":"2026-08-23T03:30:00+08:00","confidence":0.8,"status":"unverified","note":"地點與用餐順序來自 Sheet；動態營業資訊待重查。"}
+        "opening_hours_note": "ラーメン一樂：平日 11:00–15:00（最後點餐 14:30）、16:00–18:00（最後點餐 17:30）；8/27（週四）12:45–13:30 位於午間營業時段內。",
+        "provenance": {"source_type":"official","provider":"ニジゲンノモリ 官方料金與營業資訊","source_url":"https://nijigennomori.com/price/","retrieved_at":"2026-08-25T14:48:30+08:00","confidence":0.95,"status":"confirmed","note":"官方料金與營業資訊列示 NARUTO&BORUTO 忍里 10:00 開始、20:00 最終入場；ラーメン一樂平日 11:00–15:00、16:00–18:00，最後點餐分別為 14:30、17:30；營業時間可能因季節或活動調整。"}
       },
       {
         "id": "nijigen-no-mori-shinobi",
@@ -1437,7 +1437,7 @@
           "notes": "JX834 抵達神戶 10:30 為使用者確認；試算表未給入境、取車與後續精確時間。"
         },
         {"id":"day1-drive-airport-nijigen","kind":"transport","place_id":"ramen-ichiraku-nijigen","start_at":"2026-08-27T12:00:00+09:00","end_at":"2026-08-27T12:45:00+09:00","transport_leg_id":"leg-day1-airport-nijigen","selection_status":"selected","notes":"Sheet 只確認順序；12:00–12:45 為規劃估計，取車完成後以 Google Maps 即時導航。"},
-        {"id":"day1-lunch-ichiraku","kind":"meal","place_id":"ramen-ichiraku-nijigen","start_at":"2026-08-27T12:45:00+09:00","end_at":"2026-08-27T13:30:00+09:00","selection_status":"selected","notes":"Sheet 指定ラーメン一楽；時間為規劃估計，營業狀態出發前重查。"},
+        {"id":"day1-lunch-ichiraku","kind":"meal","place_id":"ramen-ichiraku-nijigen","start_at":"2026-08-27T12:45:00+09:00","end_at":"2026-08-27T13:30:00+09:00","selection_status":"selected","notes":"官方營業時間：平日 11:00–15:00（最後點餐 14:30）、16:00–18:00（最後點餐 17:30）；本次 12:45 抵達、13:30 離開。"},
         {"id":"day1-shinobi","kind":"visit","place_id":"nijigen-no-mori-shinobi","start_at":"2026-08-27T13:30:00+09:00","end_at":"2026-08-27T15:30:00+09:00","selection_status":"selected","alternative_place_ids":[],"notes":"Sheet 指定忍里；時間為規劃估計。高溫或疲累時縮短，蠟筆小新免費區為現場備案。"},
         {"id":"day1-drive-shinobi-sunset","kind":"transport","place_id":"awaji-sunset-line","start_at":"2026-08-27T15:30:00+09:00","end_at":"2026-08-27T16:10:00+09:00","transport_leg_id":"leg-day1-shinobi-sunset","selection_status":"selected","notes":"CRAFT CIRCUS 2026/8/27（木）公休，取消此站；由忍里直接前往安全平坦的西海岸停靠點。"},
         {"id":"day1-sunset-line","kind":"visit","place_id":"awaji-sunset-line","start_at":"2026-08-27T16:10:00+09:00","end_at":"2026-08-27T17:10:00+09:00","selection_status":"selected","notes":"只做安全平坦海邊短走；高溫、強風、下雨或長輩幼兒疲累即取消，保留晚餐前移動緩衝。"},

--- a/web/public/trips/awaji-2026/public-bundle.json
+++ b/web/public/trips/awaji-2026/public-bundle.json
@@ -226,7 +226,7 @@
           "expected_stay_minutes": 45,
           "id": "day1-lunch-ichiraku",
           "kind": "meal",
-          "notes": "Sheet 指定ラーメン一楽；時間為規劃估計，營業狀態出發前重查。",
+          "notes": "官方營業時間：平日 11:00–15:00（最後點餐 14:30）、16:00–18:00（最後點餐 17:30）；本次 12:45 抵達、13:30 離開。",
           "place_id": "ramen-ichiraku-nijigen",
           "start_at": "2026-08-27T12:45:00+09:00",
           "transfer_minutes": null,
@@ -1262,8 +1262,8 @@
   },
   "local_timezone": "Asia/Tokyo",
   "meta": {
-    "bundle_sha256": "2ddb8207bf4c36791567bb30320ee479ac17b062cc02e7890e98c8aa5bb7443e",
-    "generated_at": "2026-08-24T10:10:01+00:00",
+    "bundle_sha256": "839c58c9843c7067b4cf320a6b3f728c499bdbff016f13df6160d5809b34c5d4",
+    "generated_at": "2026-08-25T06:56:45+00:00",
     "source_coverage": {
       "days": 5,
       "places": 52,
@@ -1271,7 +1271,7 @@
       "selected_hotels": 3
     },
     "source_path": "trips/awaji-naruto-tokushima-kobe-2026/trip.json",
-    "source_sha256": "d113dc9fc54c67eeb6b27e111f3ff89738dd4e67c8f623ed9abb228ebc84882f",
+    "source_sha256": "875f2e25987402fc715ebd3e4809afed2ff29bc6568d455f90d9b6096a6ee673",
     "trip_schema": "trip-v1"
   },
   "operations": {
@@ -2519,15 +2519,15 @@
       "maps_query": "兵庫県淡路市楠本2425-2 兵庫県立淡路島公園内",
       "name": "ラーメン一楽（二次元之森 忍里內）",
       "official_url": null,
-      "opening_hours_note": "二次元之森園區餐飲；官方營業時間依忍里當日營運公告，Day 1 12:45 抵達前確認供餐與最後點餐。",
+      "opening_hours_note": "ラーメン一樂：平日 11:00–15:00（最後點餐 14:30）、16:00–18:00（最後點餐 17:30）；8/27（週四）12:45–13:30 位於午間營業時段內。",
       "provenance": {
-        "confidence": 0.8,
-        "note": "地點與用餐順序來自 Sheet；動態營業資訊待重查。",
-        "provider": "Google Sheet 行程總覽",
-        "retrieved_at": "2026-08-23T03:30:00+08:00",
-        "source_type": "user_input",
-        "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=1150292496",
-        "status": "unverified"
+        "confidence": 0.95,
+        "note": "官方料金與營業資訊列示 NARUTO&BORUTO 忍里 10:00 開始、20:00 最終入場；ラーメン一樂平日 11:00–15:00、16:00–18:00，最後點餐分別為 14:30、17:30；營業時間可能因季節或活動調整。",
+        "provider": "ニジゲンノモリ 官方料金與營業資訊",
+        "retrieved_at": "2026-08-25T14:48:30+08:00",
+        "source_type": "official",
+        "source_url": "https://nijigennomori.com/price/",
+        "status": "confirmed"
       }
     },
     {
@@ -2905,13 +2905,13 @@
       "supports": "place:awaji-nakajima-park"
     },
     {
-      "authority": "Google Sheet 行程總覽",
-      "confidence": 0.8,
+      "authority": "ニジゲンノモリ 官方料金與營業資訊",
+      "confidence": 0.95,
       "conflicts": false,
       "freshness": "unknown",
-      "last_checked": "2026-08-23T03:30:00+08:00",
-      "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=1150292496",
-      "status": "unverified",
+      "last_checked": "2026-08-25T14:48:30+08:00",
+      "source_url": "https://nijigennomori.com/price/",
+      "status": "confirmed",
       "supports": "place:ramen-ichiraku-nijigen"
     },
     {

--- a/web/src/app/TripApp.tsx
+++ b/web/src/app/TripApp.tsx
@@ -90,9 +90,8 @@ export default function TripApp({ tripMeta = null, tripSlug }: TripAppProps) {
     if (base === 'offline-no-cache') return 'offline-no-cache'
     if (base === 'offline-cache') return 'offline-cache'
     if (base === 'critical') return 'critical'
-    if (bundleLoader.isUpdateAvailable) return 'newer-version'
     return 'normal'
-  }, [bundleLoader.bundle, bundleLoader.isOnline, bundleLoader.isUpdateAvailable, bundleLoader.status, routeNotFound])
+  }, [bundleLoader.bundle, bundleLoader.isOnline, bundleLoader.status, routeNotFound])
 
   const normalizeDay = useCallback(
     (candidate: string | undefined) => {
@@ -245,9 +244,6 @@ export default function TripApp({ tripMeta = null, tripSlug }: TripAppProps) {
         sections={SECTION_DEFINITIONS}
         activeSection={selectedSection}
         onNavigateSection={gotoSection}
-        onRetry={() => {
-          window.location.reload()
-        }}
         isDrawerOpen={drawerOpen}
         setDrawerOpen={setDrawerOpen}
       >
@@ -267,9 +263,6 @@ export default function TripApp({ tripMeta = null, tripSlug }: TripAppProps) {
       sections={SECTION_DEFINITIONS}
       activeSection={selectedSection}
       onNavigateSection={gotoSection}
-      onRetry={() => {
-        window.location.reload()
-      }}
       isDrawerOpen={drawerOpen}
       setDrawerOpen={setDrawerOpen}
     >

--- a/web/src/hooks/useBundleLoader.ts
+++ b/web/src/hooks/useBundleLoader.ts
@@ -8,10 +8,7 @@ interface BundleLoaderState {
   status: LoadStatus
   error: string
   isOnline: boolean
-  isUpdateAvailable: boolean
 }
-
-const STORAGE_KEYS = { remoteVersion: 'trip:active:bundle-version:v1' }
 
 function resolveAppBaseUrl(baseUrl: string, pageUrl: string): URL {
   const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
@@ -47,19 +44,8 @@ export function useBundleLoader(tripSlug?: string): BundleLoaderState {
   const [status, setStatus] = useState<LoadStatus>('loading')
   const [error, setError] = useState('')
   const [isOnline, setIsOnline] = useState(true)
-  const [isUpdateAvailable, setIsUpdateAvailable] = useState(false)
 
   const baseUrl = String(import.meta.env.BASE_URL || '/')
-
-  const checkVersion = useCallback((data: Bundle) => {
-    const remoteGenerated = data.meta?.generated_at
-    if (!remoteGenerated) return
-    const remoteStored = localStorage.getItem(STORAGE_KEYS.remoteVersion)
-    if (remoteStored && remoteStored !== remoteGenerated) {
-      setIsUpdateAvailable(true)
-    }
-    localStorage.setItem(STORAGE_KEYS.remoteVersion, remoteGenerated)
-  }, [])
 
   const load = useCallback(async () => {
     setStatus('loading')
@@ -91,14 +77,12 @@ export function useBundleLoader(tripSlug?: string): BundleLoaderState {
       const data = parsed.value
       bundleRef.current = data
       setBundle(data)
-      setIsUpdateAvailable(false)
-      checkVersion(data)
       setStatus('ready')
     } catch (err) {
       setError(err instanceof Error ? err.message : '資料格式錯誤')
       setStatus('error')
     }
-  }, [baseUrl, checkVersion, tripSlug])
+  }, [baseUrl, tripSlug])
 
   useEffect(() => {
     setIsOnline(window.navigator.onLine)
@@ -124,6 +108,5 @@ export function useBundleLoader(tripSlug?: string): BundleLoaderState {
     status,
     error,
     isOnline,
-    isUpdateAvailable: isOnline ? isUpdateAvailable : false,
   }
 }

--- a/web/src/layouts/MobileHeader.tsx
+++ b/web/src/layouts/MobileHeader.tsx
@@ -17,7 +17,6 @@ const LABEL_BY_STATUS: Record<TripStatusType, string> = {
   critical: '異常提示',
   'offline-cache': '離線快取可用',
   'offline-no-cache': '離線無快取',
-  'newer-version': '有新版可用',
   'route-not-found': '頁面不存在',
   normal: '正常',
 }

--- a/web/src/layouts/TripShell.tsx
+++ b/web/src/layouts/TripShell.tsx
@@ -11,7 +11,6 @@ export type TripStatusType =
   | 'critical'
   | 'offline-cache'
   | 'offline-no-cache'
-  | 'newer-version'
   | 'route-not-found'
 
 interface TripShellProps {
@@ -21,7 +20,6 @@ interface TripShellProps {
   sections: SectionDefinition[]
   activeSection: string
   onNavigateSection: (nextSection: string) => void
-  onRetry: () => void
   isDrawerOpen: boolean
   setDrawerOpen: (open: boolean) => void
   children: ReactNode
@@ -34,7 +32,6 @@ const statusText: Record<TripStatusType, string> = {
   critical: '行程提醒：含關鍵警示',
   'offline-cache': '目前離線，使用快取資料',
   'offline-no-cache': '目前離線，無可用快取資料',
-  'newer-version': '有可用新版，建議重整理',
   'route-not-found': '頁面不存在',
 }
 
@@ -45,7 +42,6 @@ export default function TripShell({
   sections,
   activeSection,
   onNavigateSection,
-  onRetry,
   isDrawerOpen,
   setDrawerOpen,
   children,
@@ -156,11 +152,6 @@ export default function TripShell({
             </div>
             <div className="shell-status-line">
               <span>{currentStatusText}</span>
-              {shellStatus === 'newer-version' ? (
-                <button type="button" onClick={onRetry}>
-                  重新載入
-                </button>
-              ) : null}
             </div>
           </header>
 

--- a/web/src/pages/FoodPage.tsx
+++ b/web/src/pages/FoodPage.tsx
@@ -1,16 +1,12 @@
 import { useMemo } from 'react'
 import { Bundle, findPlaceLabel } from '../contracts/trip'
 import { buildMapsLink } from '../contracts/trip'
-import { buildRoutePath } from '../app/route-registry'
-import { useState } from 'react'
 
 interface FoodPageProps {
   bundle: Bundle
 }
 
 export function FoodPage({ bundle }: FoodPageProps) {
-  const [copying, setCopying] = useState('')
-
   const mealGroups = useMemo(() => {
     return bundle.days
       .map((day) => ({
@@ -20,26 +16,12 @@ export function FoodPage({ bundle }: FoodPageProps) {
       .filter((group) => group.meals.length > 0)
   }, [bundle.days])
 
-  const copyText = async (key: string, text: string) => {
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopying(key)
-      setTimeout(() => setCopying((current) => (current === key ? '' : current)), 1500)
-    } catch {
-      const errKey = `${key}-err`
-      setCopying(errKey)
-      setTimeout(() => setCopying((current) => (current === errKey ? '' : current)), 1200)
-    }
-  }
-
   return (
     <section className="card hub-card-wrapper" aria-label="餐飲與補給">
       <header className="hub-header">
         <h2>餐飲與補給</h2>
-        <p>顯示行程中公開可映射的「餐飲」節點；其餘欄位留待未來證據補齊。</p>
+        <p>依每日行程整理用餐時間與地點，快速開啟 Google Maps。</p>
       </header>
-
-      <p className="shell-message">資料版本：{bundle.meta.generated_at}</p>
 
       <div className="hub-stats">
         <p>餐食段落：{mealGroups.reduce((sum, group) => sum + group.meals.length, 0)}</p>
@@ -54,28 +36,9 @@ export function FoodPage({ bundle }: FoodPageProps) {
               {group.meals.map((meal) => (
                 <li className="hub-item" key={meal.id}>
                   <div className="hub-item-row">
-                    <span className="hub-status estimated">{meal.start_at ? 'estimated' : 'unverified'}</span>
-                    <h4>{findPlaceLabel(bundle.places, meal.place_id)}</h4>
+                    <h4>{findPlaceLabel(bundle.places, meal.place_id)}<a className="hub-map-link" href={buildMapsLink(findPlaceLabel(bundle.places, meal.place_id))} target="_blank" rel="noreferrer" aria-label={`${findPlaceLabel(bundle.places, meal.place_id)} Google Maps`}>Google Maps ↗</a></h4>
                   </div>
-                  <p>時段：{meal.start_at ? new Date(meal.start_at).toLocaleTimeString('zh-TW', { hour: '2-digit', minute: '2-digit' }) : '待補'}</p>
-                  {meal.notes ? <p>備註：{meal.notes}</p> : <p>備註：public-safe 未提供</p>}
-                  <div className="hub-actions">
-                    <a className="hub-inline-button" href={buildRoutePath({ section: 'today', day: group.date, item: meal.id })}>
-                      回行程
-                    </a>
-                    <a className="hub-inline-button" href={buildMapsLink(findPlaceLabel(bundle.places, meal.place_id))} target="_blank" rel="noreferrer">
-                      導航
-                    </a>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        copyText(`meal-${meal.id}`, `餐食：${findPlaceLabel(bundle.places, meal.place_id)}（${group.date}）`)
-                      }
-                    >
-                      {copying === `meal-${meal.id}` ? '已複製' : copying === `meal-${meal.id}-err` ? '複製失敗' : '複製餐廳'}
-                    </button>
-                  </div>
-                  <p className="hub-meta">open status: public-safe 未提供 / queue risk: 未提供 / 替代方案：待補</p>
+                  <p>用餐時間：{meal.start_at ? new Date(meal.start_at).toLocaleTimeString('zh-TW', { hour: '2-digit', minute: '2-digit' }) : '—'}</p>
                 </li>
               ))}
             </ul>
@@ -83,7 +46,7 @@ export function FoodPage({ bundle }: FoodPageProps) {
         ))
       ) : (
         <p className="hub-empty">
-          目前行程公開資料尚未提供餐廳明細、排隊風險、停靠補給策略。請以行程原始項目與景點頁備援。
+          目前沒有餐飲節點。
         </p>
       )}
     </section>

--- a/web/src/pages/ItineraryPage.tsx
+++ b/web/src/pages/ItineraryPage.tsx
@@ -12,7 +12,7 @@ import {
   operationalStatusClass,
   operationalStatusLabel,
 } from '../contracts/trip'
-import { buildRoutePath, TripRoute } from '../app/route-registry'
+import { TripRoute } from '../app/route-registry'
 import { buildMapsDirectionsLink } from '../lib/google-maps-links'
 
 interface ItineraryPageProps {
@@ -59,7 +59,7 @@ function currentMinutesInTripZone(timeZone: string, dayDate: string): number | n
 }
 
 function timeLabel(value: string | null): string {
-  if (!value) return '待補'
+  if (!value) return '—'
   return value.match(/T(\d{2}:\d{2})/)?.[1] || value
 }
 
@@ -104,7 +104,7 @@ function itemState(item: BundleDayItem, reservationUnresolved: boolean, leg?: Bu
   if (item.optional || item.kind === 'optional' || item.notes?.toLowerCase().includes('optional')) states.push('可選')
   if (item.cancelable || item.notes?.includes('可取消')) states.push('可取消')
   if (leg) states.push(operationalStatusLabel(leg.status))
-  if (item.unresolved || reservationUnresolved || !item.start_at || !item.end_at) states.push('待補')
+  if (item.unresolved || reservationUnresolved || !item.start_at || !item.end_at) states.push('需處理')
   return [...new Set(states)]
 }
 
@@ -180,7 +180,6 @@ export function heroNextItem(day: BundleDay, currentMinutes: number | null): Bun
 }
 
 export function ItineraryPage({ bundle, route, onNavigate }: ItineraryPageProps) {
-  const [copiedId, setCopiedId] = useState('')
   const [query, setQuery] = useState('')
   const [quickMode, setQuickMode] = useState<'all' | 'now' | 'next'>('all')
   const [showPrintView, setShowPrintView] = useState(false)
@@ -227,15 +226,6 @@ export function ItineraryPage({ bundle, route, onNavigate }: ItineraryPageProps)
     .map((item) => ({ id: item.id, time: timeLabel(item.start_at), label: findPlaceLabel(bundle.places, item.place_id) }))
   const primaryRisk = primaryRiskForDay(bundle, selectedDay)
 
-  const copyText = async (label: string, text: string) => {
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopiedId(label)
-      window.setTimeout(() => setCopiedId((current) => current === label ? '' : current), 1400)
-    } catch {
-      setCopiedId('error')
-    }
-  }
   const navigateTo = (day: string, item?: string) => onNavigate({ section: 'today', day, item })
 
   return (
@@ -266,7 +256,7 @@ export function ItineraryPage({ bundle, route, onNavigate }: ItineraryPageProps)
         <div className="day-stats" aria-label="今日摘要數量">
           <span><strong>{selectedDay.items.length}</strong> 停靠</span>
           <span><strong>{metrics.fixed}</strong> 固定</span>
-          <span className={metrics.unresolved ? 'has-warning' : ''}><strong>{metrics.unresolved}</strong> 待補</span>
+          <span className={metrics.unresolved ? 'has-warning' : ''}><strong>{metrics.unresolved}</strong> 需處理</span>
         </div>
       </header>
 
@@ -291,13 +281,11 @@ export function ItineraryPage({ bundle, route, onNavigate }: ItineraryPageProps)
           const visualKind = itemVisualKind(item, !!reservation)
           const leg = transportLegForItem(bundle, item, selectedDay.date)
           const states = itemState(item, reservation?.unresolved === true, leg)
-          const itemCopied = copiedId === `${selectedDay.date}-${item.id}`
           const title = leg ? `${leg.from_label} → ${leg.to_label}` : findPlaceLabel(bundle.places, item.place_id)
           const detail = leg
             ? leg.estimated_duration_minutes == null ? '車程尚未確認' : `約 ${leg.estimated_duration_minutes} 分鐘`
-            : item.notes || `停留 ${item.expected_stay_minutes == null ? '尚未提供' : `${item.expected_stay_minutes} 分鐘`} · 前段移動 ${item.transfer_minutes == null ? '尚未提供' : `${item.transfer_minutes} 分鐘`}`
+            : item.notes || `停留 ${item.expected_stay_minutes == null ? '—' : `${item.expected_stay_minutes} 分鐘`} · 前段移動 ${item.transfer_minutes == null ? '—' : `${item.transfer_minutes} 分鐘`}`
           const mapsHref = leg ? legDirectionsLink(bundle, leg) : place?.google_maps_url || buildMapsLink(place?.maps_query || place?.name || item.place_id)
-          const copyValue = leg ? `${leg.from_label} → ${leg.to_label}` : `${title} ${findPlaceAddress(bundle.places, item.place_id)}`
           const itemAlternatives = (item.alternative_place_ids || [])
             .map((placeId) => bundle.places?.find((candidate) => candidate.id === placeId))
             .filter((candidate): candidate is BundlePlace => !!candidate)
@@ -307,19 +295,14 @@ export function ItineraryPage({ bundle, route, onNavigate }: ItineraryPageProps)
             <div className="timeline-track"><span>{visualKind === 'reservation' ? '◆' : visualKind === 'meal' ? '✦' : visualKind === 'move' ? '→' : '●'}</span>{index < visibleItems.length - 1 && <i />}</div>
             <div className="timeline-card">
               <div className="timeline-card-topline"><span className="timeline-category">{visualKind === 'reservation' ? '固定預約' : visualKind === 'meal' ? '餐飲安排' : visualKind === 'move' ? '逐段交通' : '行程停靠'}</span><div className="status-chips">{states.map((state) => <span key={state} className="status-chip">{state}</span>)}</div></div>
-              <h3>{title}{!leg && place?.name_ja ? <small>{place.name_ja}</small> : null}</h3>
+              <h3>{title}{!leg && place?.name_ja ? <small>{place.name_ja}</small> : null}<a className="timeline-map-link" href={mapsHref} target="_blank" rel="noreferrer" aria-label={`${title} Google Maps`}>Google Maps ↗</a></h3>
               <p className="timeline-detail">{detail}</p>
               {!leg && findPlaceAddress(bundle.places, item.place_id) && <p className="timeline-address">{findPlaceAddress(bundle.places, item.place_id)}</p>}
-              {leg ? <div className="timeline-risk">{leg.status !== 'estimated' ? <span className={operationalStatusClass(leg.status)}>{operationalStatusLabel(leg.status)}</span> : null}<p><strong>風險／延誤切點：</strong>{leg.note || '未提供；出發前以 Google Maps 即時路況確認。'}</p></div> : null}
+              {leg ? <div className="timeline-risk">{leg.status !== 'estimated' ? <span className={operationalStatusClass(leg.status)}>{operationalStatusLabel(leg.status)}</span> : null}<p><strong>風險／延誤切點：</strong>{leg.note || '出發前以 Google Maps 即時路況確認。'}</p></div> : null}
               {!leg && place?.opening_hours_note ? <p className={`timeline-context ${fieldNeedsRecheck(place, 'opening_hours_note') ? 'needs-recheck' : ''}`}><strong>營業時間：</strong>{place.opening_hours_note}</p> : null}
               {!leg && place?.parking ? <p className={`timeline-context ${fieldNeedsRecheck(place, 'parking') ? 'needs-recheck' : ''}`}><strong>停車：</strong>{place.parking}</p> : null}
               {place?.accessibility_notes && !accessibilityNoteCovered(item.notes, place.accessibility_notes) ? <p className="timeline-context"><strong>家庭／無障礙：</strong>{place.accessibility_notes}</p> : null}
               {!leg && itemAlternatives.length ? <div className="timeline-inline-alternatives"><strong>試算表備案：</strong>{itemAlternatives.map((alternative) => <a key={alternative.id} href={alternative.google_maps_url || buildMapsLink(alternative.maps_query || alternative.address || alternative.name || alternative.id)} target="_blank" rel="noreferrer">{alternative.name || alternative.id}</a>)}</div> : null}
-              <div className="timeline-actions">
-                <a href={mapsHref} target="_blank" rel="noreferrer">{leg ? '逐段導航' : '導航地圖'}</a>
-                <button type="button" onClick={() => copyText(`${selectedDay.date}-${item.id}`, copyValue)}>{itemCopied ? '已複製' : '複製地點'}</button>
-                <a href={buildRoutePath({ section: 'today', day: selectedDay.date, item: item.id })}>分享連結</a>
-              </div>
             </div>
           </article>
         })}

--- a/web/src/pages/LodgingPage.tsx
+++ b/web/src/pages/LodgingPage.tsx
@@ -26,11 +26,11 @@ interface LodgingItem {
 }
 
 function timeLabel(value: string | null | undefined) {
-  return value?.match(/T(\d{2}:\d{2})/)?.[1] || '未提供'
+  return value?.match(/T(\d{2}:\d{2})/)?.[1] || '—'
 }
 
 function dateLabel(value: string | undefined) {
-  if (!value) return '未提供'
+  if (!value) return '—'
   try {
     return new Intl.DateTimeFormat('zh-TW', {
       month: 'numeric',
@@ -68,8 +68,8 @@ export function LodgingPage({ bundle }: LodgingPageProps) {
       const boundaryNote = explicitCheckOut
         ? '退房時間已列入行程'
         : nextCheckIn
-          ? '退房日依下一處入住日呈現；確切退房時間未提供'
-          : '退房日與時間未提供'
+          ? '退房日依下一處入住日呈現'
+          : '退房資訊尚未排入行程'
       return {
         id: entry.placeId,
         placeId: entry.placeId,
@@ -101,7 +101,7 @@ export function LodgingPage({ bundle }: LodgingPageProps) {
   return (
     <section className="lodging-workspace" aria-label="住宿手冊">
       <header className="page-intro">
-        <div><p className="eyebrow">STAY GUIDE</p><h1>住宿接力</h1><p>入住日期、地址與當日行程放在一起；未提供的設備與需求不自行推論。</p></div>
+        <div><p className="eyebrow">STAY GUIDE</p><h1>住宿接力</h1><p>入住日期、地址與當日行程放在一起，方便出發前快速查看。</p></div>
         <div className="page-intro-stats"><span><strong>{lodgings.length}</strong> 處住宿</span><span><strong>{totalNights}</strong> 晚</span></div>
       </header>
 
@@ -127,7 +127,7 @@ export function LodgingPage({ bundle }: LodgingPageProps) {
                   <i>→</i>
                   <div><small>CHECK OUT</small><strong>{dateLabel(lodging.checkOutDate)}</strong><span>{timeLabel(lodging.checkOutTime)}</span></div>
                 </div>
-                <div className="stay-address"><span aria-hidden="true">⌖</span><div><small>完整地址</small><p>{lodging.place?.address || 'Canonical Trip 尚未提供完整地址'}</p></div></div>
+                {lodging.place?.address ? <div className="stay-address"><span aria-hidden="true">⌖</span><div><small>完整地址</small><p>{lodging.place.address}</p></div></div> : null}
                 {lodging.place?.opening_hours_note ? <p className="stay-note"><strong>入住／退房規則：</strong>{lodging.place.opening_hours_note}</p> : null}
                 <p className="stay-boundary-note">{lodging.boundaryNote}</p>
                 {lodging.note ? <p className="stay-note"><strong>入住提醒：</strong>{lodging.note}</p> : null}

--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -35,7 +35,7 @@ function formatDay(date: string): string {
 }
 
 function formatTime(value: string | null): string {
-  return value?.match(/T(\d{2}:\d{2})/)?.[1] || '未提供'
+  return value?.match(/T(\d{2}:\d{2})/)?.[1] || '—'
 }
 
 function transportModeLabel(mode: string): string {
@@ -235,7 +235,7 @@ export function MapPage({ bundle, route, currentDay }: MapPageProps) {
                     </dl>
                     <div className="route-risk-note">
                       <strong>導航注意／延誤切點</strong>
-                      <p>{leg.note || '尚未提供專屬切點；出發前請以 Google Maps 即時路況重新確認。'}</p>
+                      <p>{leg.note || '出發前請以 Google Maps 即時路況重新確認。'}</p>
                     </div>
                     <div className="route-card-actions">
                       <a data-route-url={directionsHref} href={directionsHref} target="_blank" rel="noreferrer">逐段導航</a>

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -50,7 +50,7 @@ function formatDay(date: string): string {
 }
 
 function timeLabel(value: string | null): string {
-  return value?.match(/T(\d{2}:\d{2})/)?.[1] || '未提供'
+  return value?.match(/T(\d{2}:\d{2})/)?.[1] || '—'
 }
 
 function fixedLabel(item: { kind: string; notes?: string }, fallback: string): string {
@@ -163,7 +163,7 @@ export function OverviewPage({ bundle, trip }: OverviewPageProps) {
                 <div className="overview-day-copy">
                   <p>{formatDay(day.date)} · {day.items.length} 個停靠</p>
                   <h3>{day.summary}</h3>
-                  <div className="overview-day-route"><span>{first ? findPlaceLabel(bundle.places, first.place_id) : '未提供起點'}</span><i>→</i><span>{last ? findPlaceLabel(bundle.places, last.place_id) : '未提供終點'}</span></div>
+                  <div className="overview-day-route"><span>{first ? findPlaceLabel(bundle.places, first.place_id) : '—'}</span><i>→</i><span>{last ? findPlaceLabel(bundle.places, last.place_id) : '—'}</span></div>
                   <div className="overview-day-foot"><span>住宿：{lodging?.name || '返程／未安排'}</span><span>固定 {fixedCount} 項</span></div>
                 </div>
               </a>
@@ -179,7 +179,7 @@ export function OverviewPage({ bundle, trip }: OverviewPageProps) {
             {lodgingCards.map(({ placeId, place, checkIn, checkOut }, index) => (
               <article key={placeId}>
                 <span className="stay-sequence">{index + 1}</span>
-                <div><p>{checkIn || '入住日未提供'} → {checkOut || '退房日未提供'}</p><h3>{place?.name || placeId}</h3><small>{place?.address || '完整地址尚未由 Canonical Trip 提供'}</small></div>
+                <div><p>{checkIn || '—'} → {checkOut || '—'}</p><h3>{place?.name || placeId}</h3>{place?.address ? <small>{place.address}</small> : null}</div>
               </article>
             ))}
           </div>

--- a/web/src/pages/ReservationsPage.tsx
+++ b/web/src/pages/ReservationsPage.tsx
@@ -1,11 +1,8 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import {
   Bundle,
   BundleReservation,
-  operationalStatusClass,
-  operationalStatusLabel,
 } from '../contracts/trip'
-import { buildRoutePath } from '../app/route-registry'
 
 interface ReservationsPageProps {
   bundle: Bundle
@@ -60,27 +57,10 @@ function formatDate(value: string) {
 }
 
 function formatTime(value: string | null) {
-  return value?.match(/T(\d{2}:\d{2})/)?.[1] || '時間未提供'
-}
-
-function resolveReservationStatus(reservation: BundleReservation) {
-  if (reservation.unresolved) return 'unresolved' as const
-  if (reservation.status) return reservation.status
-  if (reservation.time && reservation.name) return 'confirmed' as const
-  if (reservation.time || reservation.name) return 'estimated' as const
-  return 'unverified' as const
-}
-
-function buildDayItemLink(bundle: Bundle, reservation: BundleReservation) {
-  const day = bundle.days.find((itemDay) => itemDay.date === reservation.day) ?? bundle.days[0]
-  if (!day) return buildRoutePath({ section: 'today' })
-  const direct = day.items.find((item) => item.id === reservation.id || item.id === reservation.itinerary_item_id)
-  if (direct) return buildRoutePath({ section: 'today', day: day.date, item: direct.id })
-  return buildRoutePath({ section: 'today', day: day.date })
+  return value?.match(/T(\d{2}:\d{2})/)?.[1] || '—'
 }
 
 export function ReservationsPage({ bundle }: ReservationsPageProps) {
-  const [copying, setCopying] = useState('')
   const grouped = useMemo(() => {
     const byDay = new Map<string, BundleReservation[]>()
     bundle.reservations.forEach((reservation) => {
@@ -92,28 +72,12 @@ export function ReservationsPage({ bundle }: ReservationsPageProps) {
       .map(([day, reservations]) => ({ day, reservations: reservations.sort((a, b) => (a.time || '').localeCompare(b.time || '')) }))
   }, [bundle.reservations])
 
-  const statuses = bundle.reservations.map(resolveReservationStatus)
-  const confirmedCount = statuses.filter((status) => status === 'confirmed').length
-  const pendingCount = statuses.filter((status) => status !== 'confirmed').length
-
-  const copyText = async (key: string, text: string) => {
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopying(key)
-      window.setTimeout(() => setCopying(''), 1500)
-    } catch {
-      setCopying('error')
-    }
-  }
-
   return (
     <section className="reservation-workspace" aria-label="預約與票券">
       <header className="page-intro">
-        <div><p className="eyebrow">BOOKING DESK</p><h1>預約與固定時間</h1><p>把日期、時間、地址、聯絡方式與當日行程集中在同一處；未知欄位維持未確認。</p></div>
-        <div className="page-intro-stats"><span><strong>{bundle.reservations.length}</strong> 件</span><span><strong>{confirmedCount}</strong> 已確認</span><span className={pendingCount ? 'has-warning' : ''}><strong>{pendingCount}</strong> 待處理</span></div>
+        <div><p className="eyebrow">BOOKING DESK</p><h1>預約與固定時間</h1><p>集中查看已排定的日期、時間與集合地點。</p></div>
+        <div className="page-intro-stats"><span><strong>{bundle.reservations.length}</strong> 件預約</span></div>
       </header>
-
-      {pendingCount ? <div className="reservation-alert"><strong>出發前仍需確認</strong><p>{pendingCount} 件資料含未驗證或未補齊欄位。使用官方連結或電話確認後，再以最新資訊為準。</p></div> : null}
 
       <div className="reservation-groups">
         {grouped.map((group) => (
@@ -121,36 +85,17 @@ export function ReservationsPage({ bundle }: ReservationsPageProps) {
             <header><span>{formatDate(group.day)}</span><strong>{group.reservations.length} 件預約</strong></header>
             <div className="reservation-list">
               {group.reservations.map((reservation) => {
-                const status = resolveReservationStatus(reservation)
                 const place = bundle.places?.find((candidate) => candidate.id === reservation.place_id)
                 const placeName = place?.name || reservation.name || reservation.place_id
                 const address = place?.address
                 const mapHref = place?.google_maps_url || `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(place?.maps_query || placeName)}`
-                const route = buildDayItemLink(bundle, reservation)
-                const ics = buildReservationCalendarIcs(reservation)
-                const icsHref = ics ? `data:text/calendar;charset=utf-8,${encodeURIComponent(ics)}` : null
-                const summary = [reservation.name || '名稱未提供', formatDate(reservation.day), formatTime(reservation.time), placeName, address].filter(Boolean).join('｜')
 
                 return (
                   <article className="reservation-card" key={reservation.id}>
-                    <div className="reservation-time"><strong>{formatTime(reservation.time)}</strong><span>{formatDate(reservation.day)}</span></div>
+                    <div className="reservation-time"><strong>{formatTime(reservation.time)}</strong></div>
                     <div className="reservation-main">
-                      <div className="reservation-title-row"><div><span className={operationalStatusClass(status)}>{operationalStatusLabel(status)}</span><h2>{reservation.name || '預約名稱未提供'}</h2></div><span className="reservation-kind">{reservation.kind}</span></div>
-                      <dl className="reservation-facts">
-                        <div><dt>地點</dt><dd>{placeName}</dd></div>
-                        <div><dt>地址</dt><dd>{address || '完整地址未提供'}</dd></div>
-                        <div><dt>資料來源</dt><dd>{reservation.source || 'Canonical Trip'}</dd></div>
-                        <div><dt>最後確認</dt><dd>{reservation.last_checked_at || '未提供'}</dd></div>
-                      </dl>
-                      {reservation.unresolved ? <p className="reservation-risk"><strong>待處理：</strong>此預約尚有未補齊欄位，請勿把目前內容視為最終確認。</p> : null}
-                      <div className="reservation-actions">
-                        <button type="button" onClick={() => copyText(reservation.id, summary)}>{copying === reservation.id ? '摘要已複製' : '複製預約摘要'}</button>
-                        <a href={route}>回到當日行程</a>
-                        <a href={mapHref} target="_blank" rel="noreferrer">地圖</a>
-                        {icsHref ? <a href={icsHref} download={`${reservation.id}.ics`}>加入行事曆</a> : null}
-                        {reservation.phone ? <a href={`tel:${reservation.phone}`}>撥打電話</a> : null}
-                        {reservation.official_url ? <a className="primary" href={reservation.official_url} target="_blank" rel="noreferrer">官方連結</a> : null}
-                      </div>
+                      <div className="reservation-title-row"><h2>{reservation.name || placeName}<a className="reservation-map-link" href={mapHref} target="_blank" rel="noreferrer" aria-label={`${placeName} Google Maps`}>Google Maps ↗</a></h2></div>
+                      {address ? <p className="reservation-address">{address}</p> : null}
                     </div>
                   </article>
                 )
@@ -160,8 +105,7 @@ export function ReservationsPage({ bundle }: ReservationsPageProps) {
         ))}
       </div>
 
-      {bundle.reservations.length === 0 ? <div className="honest-empty"><strong>Canonical Trip 尚無預約紀錄</strong><p>頁面不會從一般行程文字自行推定已預約。固定行程仍可在每日時間軸查看。</p><a href="#/today">查看每日行程</a></div> : null}
-      <footer className="data-footnote">場次與營業狀態請以官方最新通知為準。</footer>
+      {bundle.reservations.length === 0 ? <div className="honest-empty"><strong>目前沒有預約紀錄</strong><p>固定行程仍可在每日行程查看。</p><a href="#/today">查看每日行程</a></div> : null}
     </section>
   )
 }

--- a/web/src/pages/TidesPage.tsx
+++ b/web/src/pages/TidesPage.tsx
@@ -21,15 +21,15 @@ export function TidesPage({ bundle, day }: TidesPageProps) {
     <section className="card hub-card-wrapper" aria-label="潮汐與動態條件">
       <header className="hub-header">
         <h2>潮汐與動態條件</h2>
-        <p>{tide?.summary || '潮汐資料載入失敗，請重新整理頁面。'}</p>
+        <p>{tide?.summary || '潮汐資料目前無法顯示。'}</p>
       </header>
 
       <div className="hub-stats">
         <p>提醒：{warnings.length}</p>
-        <p>潮汐資料：{hasTideData ? tide?.status_label || '官方預測' : '資料未載入'}</p>
+        <p>潮汐資料：{hasTideData ? tide?.status_label || '官方預測' : '—'}</p>
       </div>
 
-      <p className="shell-message">資料站：{tide?.station || '洲本（SUMOTO）'}；資料時間：日本時間</p>
+      <p className="shell-message">測站：{tide?.station || '洲本（SUMOTO）'}；時間：日本時間</p>
 
       <section className="hub-section">
         {tideDays.map((item) => (
@@ -64,7 +64,7 @@ export function TidesPage({ bundle, day }: TidesPageProps) {
       ) : null}
 
       <p className="hub-footer">
-        來源：{tide?.source_url ? <a href={tide.source_url} target="_blank" rel="noreferrer">{tide.provider || '官方'}潮位表</a> : '來源資料未載入'}；出發前請再核對最新海象與設施公告。
+        {tide?.source_url ? <a href={tide.source_url} target="_blank" rel="noreferrer">查看官方潮位表</a> : null}
       </p>
     </section>
   )

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -167,15 +167,19 @@ a {
 .hub-card-wrapper {
   display: grid;
   gap: 10px;
+  padding: 22px;
 }
 
 .hub-header h2 {
   margin-bottom: 6px;
+  font-size: 1.35rem;
 }
 
 .hub-header p {
   margin: 0;
   color: var(--text-sub);
+  font-size: 0.95rem;
+  line-height: 1.6;
 }
 
 .hub-stats {
@@ -189,7 +193,9 @@ a {
   background: var(--muted-bg);
   border: 1px solid var(--line);
   border-radius: 10px;
-  padding: 8px 10px;
+  padding: 11px 13px;
+  color: var(--text);
+  font-size: 0.92rem;
 }
 
 .hub-section {
@@ -210,12 +216,13 @@ a {
 }
 
 .hub-item {
-  border: 1px solid #d3dfec;
-  border-radius: 10px;
-  padding: 10px;
-  background: #f8fbff;
+  border: 1px solid #b8cbd6;
+  border-radius: 14px;
+  padding: 15px;
+  background: #ffffff;
   display: grid;
-  gap: 6px;
+  gap: 9px;
+  box-shadow: 0 5px 14px rgba(20, 48, 67, .08);
 }
 
 .hub-item-row {
@@ -232,11 +239,15 @@ a {
 
 .hub-item p {
   margin: 0;
+  color: #274755;
+  font-size: 0.93rem;
+  line-height: 1.6;
 }
 
 .hub-meta {
-  color: var(--text-sub);
-  font-size: 0.85rem;
+  color: #486574;
+  font-size: 0.88rem;
+  line-height: 1.55;
 }
 
 .hub-footer {
@@ -266,6 +277,44 @@ a {
   margin: 0;
   display: grid;
   gap: 6px;
+}
+
+.hub-alert-list li {
+  padding: 9px 11px;
+  border: 1px solid #c4d4dc;
+  border-radius: 9px;
+  color: #284b59;
+  background: #f4f8fa;
+  font-size: 0.92rem;
+}
+
+.hub-map-link,
+.timeline-map-link,
+.reservation-map-link {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 9px;
+  padding: 3px 7px;
+  border: 1px solid #9fc4d2;
+  border-radius: 7px;
+  color: #075f84;
+  background: #edf7fa;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.hub-map-link:hover,
+.timeline-map-link:hover,
+.reservation-map-link:hover {
+  background: #dceff4;
+}
+
+.hub-map-link,
+.timeline-map-link,
+.reservation-map-link {
+  min-height: 34px;
 }
 
 .hub-actions {
@@ -740,6 +789,114 @@ textarea {
   .card {
     box-shadow: none;
     break-inside: avoid;
+  }
+}
+
+/* Readability pass for operational hub pages and compact reservation cards. */
+.hub-card-wrapper {
+  padding: 22px;
+}
+
+.hub-card-wrapper .hub-header h2 {
+  font-size: 1.35rem;
+}
+
+.hub-card-wrapper .hub-header p,
+.hub-card-wrapper .hub-item p {
+  font-size: .93rem;
+  line-height: 1.6;
+}
+
+.hub-card-wrapper .hub-item {
+  border-color: #b8cbd6;
+  background: #fff;
+  box-shadow: 0 5px 14px rgba(20, 48, 67, .08);
+}
+
+.hub-card-wrapper .hub-meta {
+  color: #486574;
+  font-size: .88rem;
+}
+
+.hub-card-wrapper .hub-alert-list li {
+  padding: 9px 11px;
+  border: 1px solid #c4d4dc;
+  border-radius: 9px;
+  color: #284b59;
+  background: #f4f8fa;
+  font-size: .92rem;
+}
+
+.hub-map-link,
+.timeline-map-link,
+.reservation-map-link {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 9px;
+  padding: 3px 7px;
+  border: 1px solid #9fc4d2;
+  border-radius: 7px;
+  color: #075f84;
+  background: #edf7fa;
+  font-size: .72rem;
+  font-weight: 700;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.hub-map-link:hover,
+.timeline-map-link:hover,
+.reservation-map-link:hover {
+  background: #dceff4;
+}
+
+.reservation-card {
+  border-color: #b8cbd6;
+  box-shadow: 0 6px 16px rgba(20, 48, 67, .08);
+}
+
+.reservation-title-row h2 {
+  margin: 0;
+  color: #203e4b;
+  font-size: 1.08rem;
+  line-height: 1.45;
+}
+
+.reservation-address {
+  margin: 8px 0 0;
+  color: #3f5e6a;
+  font-size: .88rem;
+  line-height: 1.55;
+}
+
+.timeline-card h3 {
+  line-height: 1.5;
+}
+
+@media (max-width: 640px) {
+  .hub-card-wrapper {
+    padding: 16px;
+  }
+
+  .reservation-card {
+    grid-template-columns: 76px minmax(0, 1fr);
+    gap: 13px;
+    padding: 15px;
+  }
+
+  .reservation-time {
+    padding-right: 11px;
+  }
+
+  .reservation-title-row h2 {
+    font-size: 1rem;
+  }
+
+  .reservation-map-link,
+  .timeline-map-link,
+  .hub-map-link {
+    min-height: 44px;
+    font-size: .68rem;
   }
 }
 

--- a/web/tests/e2e.mjs
+++ b/web/tests/e2e.mjs
@@ -195,7 +195,7 @@ try {
   await assertStyleContrast(mobile, '.day-tab:focus-visible', 'outlineColor', '.itinerary-day-nav', 'backgroundColor', 3, 'light control focus indicator')
   await assertTouchTargets(mobile, '.print-button', 'print')
   await assertTouchTargets(mobile, '.quick-mode button', 'quick mode')
-  await assertTouchTargets(mobile, '.timeline-actions a, .timeline-actions button', 'timeline action')
+  await assertTouchTargets(mobile, '.timeline-map-link', 'timeline Google Maps link')
   await mobile.locator('#itinerary-search').fill('淡路')
   await mobile.locator('.search-results button').first().waitFor()
   await assertTouchTargets(mobile, '.search-results button', 'search result')
@@ -255,7 +255,7 @@ try {
       const fixedCard = routePage.locator('.day-answer-grid > div').filter({ hasText: '固定時間' })
       const fixedText = await fixedCard.textContent()
       if (!fixedText?.includes('12:45') || !fixedText.includes('神戶機場 第二航廈')) throw new Error('Day 5 hero did not preserve the JX1835 departure time and origin')
-      const flightMapHref = await routePage.locator('#item-day5-departure-flight').getByRole('link', { name: '導航地圖' }).getAttribute('href')
+      const flightMapHref = await routePage.locator('#item-day5-departure-flight').locator('.timeline-map-link').getAttribute('href')
       const flightMapQuery = flightMapHref ? new URL(flightMapHref).searchParams.get('query') : null
       const normalizedFlightMapQuery = flightMapQuery?.toLowerCase() || ''
       if ((!normalizedFlightMapQuery.includes('kobe') && !flightMapQuery?.includes('神戸空港')) || flightMapQuery?.includes('桃園')) throw new Error(`Day 5 flight navigation target is incorrect: ${flightMapQuery}`)

--- a/web/tests/handbook.test.tsx
+++ b/web/tests/handbook.test.tsx
@@ -6,6 +6,7 @@ import { groupContiguousLegs, MapPage } from '../src/pages/MapPage'
 import { heroNextItem, ItineraryPage } from '../src/pages/ItineraryPage'
 import { OverviewPage } from '../src/pages/OverviewPage'
 import { PackingPage } from '../src/pages/PackingPage'
+import { ReservationsPage } from '../src/pages/ReservationsPage'
 import { TidesPage } from '../src/pages/TidesPage'
 import { buildReservationCalendarIcs } from '../src/pages/ReservationsPage'
 import type { TripCatalogEntry } from '../src/contracts/trip-registry'
@@ -177,6 +178,26 @@ describe('Issue 97 travel handbook', () => {
     expect(ics).toContain('DTSTART:20260828T084500Z')
     expect(ics).toContain('DTEND:20260828T094500Z')
     expect(ics).not.toContain('DTSTART:20260828T164500')
+  })
+
+  it('keeps reservation cards focused on time, place, address, and map link', () => {
+    render(<ReservationsPage bundle={{
+      ...bundle,
+      reservations: [{
+        id: 'reservation-1',
+        day: dates[0],
+        time: `${dates[0]}T12:50:00+09:00`,
+        name: 'うずしおクルーズ（福良港）',
+        place_id: 'b',
+        kind: 'fixed-reservation',
+      }],
+    }} />)
+    expect(screen.getByRole('heading', { name: /うずしおクルーズ（福良港）/ })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '淡路住宿 Google Maps' })).toBeInTheDocument()
+    expect(screen.queryByText('資料來源')).not.toBeInTheDocument()
+    expect(screen.queryByText('最後確認')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.queryByText('fixed-reservation')).not.toBeInTheDocument()
   })
 
   it('keeps itinerary day navigation route-aware', () => {


### PR DESCRIPTION
## 變更摘要
- 預約頁僅保留時間、名稱、地址與 Google Maps deep link，移除重複日期、資料來源、最後確認、狀態標籤與多餘按鈕。
- 以官方料金與營業資訊補入拉麵一樂平日 11:00–15:00（最後點餐 14:30）、16:00–18:00（最後點餐 17:30），並同步重建 Canonical Trip 公開 bundle。
- 移除首次載入時的版本刷新提示；將地圖快速連結移到景點標題旁。
- 提高餐飲與潮汐頁的對比、字級、padding 與卡片層次，並清理相關頁面的缺值 fallback。

## Acceptance criteria
- [x] 預約畫面不再顯示重複日期／地點／地址、資料來源、最後確認、固定預約類型、確認標籤或不必要操作按鈕。
- [x] 景點與預約保留可直接開啟地圖的快速連結。
- [x] 拉麵一樂營業時段來自官方精確頁，Canonical Trip、兩份 public bundle 與餐飲節點一致。
- [x] 首次載入不再顯示要求刷新或新版提示。
- [x] 潮汐、餐飲與行程頁提高手機閱讀所需的對比、字級、padding 與卡片層次。
- [x] 不在相關畫面顯示泛用的「未提供／待補」文字。

## Write ownership
- 本 PR 單一 implementation owner：Codex。
- 寫入範圍：`trips/awaji-naruto-tokushima-kobe-2026/**`、`web/src/**`、`web/public/trips/awaji-2026/**`、`web/tests/**`、`tests/trips/test_awaji_2026_constraints.py`。
- 未修改 primary checkout；未納入 `web/dist` 或 `web/node_modules`。

## 驗證
- `cd web && npm run lint`
- `cd web && npm run typecheck`
- `cd web && npm test -- --run`（23 passed）
- `cd web && npm run test:e2e`
- `python3 -m pytest -q`（246 passed）
- `python3 -m unittest tests.trips.test_awaji_2026_constraints`（29 passed）
- `python3 scripts/check-awaji-contamination.py`
- `git diff --check`
- CI framework、python、pytest、website：全部通過。

## 風險與依賴
- 住宿、地圖與來源導覽等其他頁面仍依 Canonical Trip 現有資料；本 PR 不自行推論缺失資料。
- 官方營業資訊可能因季節或活動調整，資料已附精確官方來源與檢索時間。
- 無外部服務依賴；地圖連結由使用者裝置開啟官方地圖服務。

## 已知流程例外
- Repository collaboration guard 需要真實且開啟的 GitHub Issue；本次依使用者明確要求直接以 PR 作為交付單位，因此未建立虛構 Issue。