### PR TITLE
整理手冊頁首版面與行程狀態文字

### DIFF
--- a/web/src/contracts/trip-registry.ts
+++ b/web/src/contracts/trip-registry.ts
@@ -63,7 +63,7 @@ export function isCatalogEntry(value: unknown): value is TripCatalogEntry {
 }
 
 export function formatDateRange(entry: { date_range: { start_date: string; end_date: string } }): string {
-  if (!entry.date_range.start_date || !entry.date_range.end_date) return '待補'
+  if (!entry.date_range.start_date || !entry.date_range.end_date) return '日期未排定'
   return `${entry.date_range.start_date} ~ ${entry.date_range.end_date}`
 }
 

--- a/web/src/contracts/trip.ts
+++ b/web/src/contracts/trip.ts
@@ -294,7 +294,7 @@ export function findPlaceAddress(places: BundlePlace[] = [], placeId: string): s
 
 export function toFriendlyStatus(status: Bundle['status']): string {
   if (status === 'ok') return '可執行'
-  if (status === 'warning') return '待補資訊'
+  if (status === 'warning') return '有提醒'
   return '嚴重訊息'
 }
 
@@ -312,11 +312,11 @@ export function operationalStatusLabel(status: OperationalStatus | undefined | n
   if (status === 'warning') return '注意'
   if (status === 'error' || status === 'critical') return '有風險'
   if (status === 'info') return '資訊'
-  if (status === 'unverified') return '未驗證'
+  if (status === 'unverified') return '來源資訊'
   if (status === 'stale') return '已過時'
   if (status === 'conflict') return '衝突'
-  if (status === 'unresolved') return '未補齊'
-  return '待補'
+  if (status === 'unresolved') return '需處理'
+  return '需處理'
 }
 
 export function operationalStatusClass(status: OperationalStatus | undefined | null): string {

--- a/web/src/design-system/status.ts
+++ b/web/src/design-system/status.ts
@@ -13,14 +13,14 @@ export type DataStatusTone =
 
 const STATUS_LABELS: Record<DataStatusTone, string> = {
   confirmed: '可執行',
-  estimated: '待更新',
+  estimated: '規劃估計',
   reported: '已回報',
   'user-confirmed': '已確認',
-  warning: '待補資訊',
+  warning: '有提醒',
   error: '嚴重訊息',
   critical: '關鍵風險',
   info: '注意',
-  unverified: '未驗證',
+  unverified: '來源資訊',
   stale: '資料過期',
   conflict: '衝突',
 }

--- a/web/src/features/trip-catalog/TripCatalogPage.tsx
+++ b/web/src/features/trip-catalog/TripCatalogPage.tsx
@@ -53,7 +53,7 @@ function statusText(status: string): string {
 
 function readinessText(readiness: string): string {
   if (readiness === 'ready') return '可出發'
-  if (readiness === 'incomplete') return '待補'
+  if (readiness === 'incomplete') return '行前確認'
   return '阻斷'
 }
 

--- a/web/src/layouts/TripShell.tsx
+++ b/web/src/layouts/TripShell.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
-import { Bundle, toFriendlyStatus } from '../contracts/trip'
+import { Bundle } from '../contracts/trip'
 import { SectionDefinition } from '../app/route-registry'
 import { DesktopSidebar } from './DesktopSidebar'
 import { MobileHeader } from './MobileHeader'
@@ -57,7 +57,7 @@ export default function TripShell({
 
   const title = bundle?.title ?? 'Golden Trip'
   const subtitle = bundle?.date_range
-    ? `${bundle.date_range.start_date} ~ ${bundle.date_range.end_date}（${toFriendlyStatus(bundle.status)}）`
+    ? `${bundle.date_range.start_date} ~ ${bundle.date_range.end_date}`
     : '行程資料載入中'
 
   useEffect(() => {
@@ -141,10 +141,7 @@ export default function TripShell({
         <main className="app-main" id="trip-main" aria-labelledby={pageTitleId}>
           <header className="desktop-topbar">
             <div><span className="desktop-topbar-section">{activeLabel}</span><span className="desktop-topbar-divider">/</span><span>{subtitle}</span></div>
-            <div className="desktop-topbar-tools">
-              <div className="desktop-quick-actions"><button type="button" onClick={() => onNavigateSection('today')}>今日行程</button><button type="button" onClick={() => onNavigateSection('map')}>導航</button></div>
-              <span className="desktop-status"><i />{currentStatusText}</span><span className="desktop-travelers">{travelerText}</span>
-            </div>
+            <div className="desktop-topbar-tools"><span className="desktop-status"><i />{currentStatusText}</span><span className="desktop-travelers"><small>旅客</small>{travelerText}</span></div>
           </header>
           <header className="trip-main-header">
             <div className="main-title" id={pageTitleId}>

--- a/web/src/pages/ItineraryPage.tsx
+++ b/web/src/pages/ItineraryPage.tsx
@@ -283,7 +283,7 @@ export function ItineraryPage({ bundle, route, onNavigate }: ItineraryPageProps)
           const states = itemState(item, reservation?.unresolved === true, leg)
           const title = leg ? `${leg.from_label} → ${leg.to_label}` : findPlaceLabel(bundle.places, item.place_id)
           const detail = leg
-            ? leg.estimated_duration_minutes == null ? '車程尚未確認' : `約 ${leg.estimated_duration_minutes} 分鐘`
+            ? leg.estimated_duration_minutes == null ? '車程：—' : `約 ${leg.estimated_duration_minutes} 分鐘`
             : item.notes || `停留 ${item.expected_stay_minutes == null ? '—' : `${item.expected_stay_minutes} 分鐘`} · 前段移動 ${item.transfer_minutes == null ? '—' : `${item.transfer_minutes} 分鐘`}`
           const mapsHref = leg ? legDirectionsLink(bundle, leg) : place?.google_maps_url || buildMapsLink(place?.maps_query || place?.name || item.place_id)
           const itemAlternatives = (item.alternative_place_ids || [])

--- a/web/src/pages/LodgingPage.tsx
+++ b/web/src/pages/LodgingPage.tsx
@@ -69,7 +69,7 @@ export function LodgingPage({ bundle }: LodgingPageProps) {
         ? '退房時間已列入行程'
         : nextCheckIn
           ? '退房日依下一處入住日呈現'
-          : '退房資訊尚未排入行程'
+          : '退房日與時間：—'
       return {
         id: entry.placeId,
         placeId: entry.placeId,
@@ -119,7 +119,7 @@ export function LodgingPage({ bundle }: LodgingPageProps) {
               <div className="lodging-card-main">
                 <header>
                   <div><span className={operationalStatusClass(status)}>{operationalStatusLabel(status)}</span><h2>{lodging.place?.name || lodging.placeId}</h2>{lodging.place?.name_ja ? <p>{lodging.place.name_ja}</p> : null}</div>
-                  <span className="night-pill">{lodging.nights ? `${lodging.nights} 晚` : '晚數未確認'}</span>
+                  <span className="night-pill">{lodging.nights ? `${lodging.nights} 晚` : '晚數：—'}</span>
                 </header>
                 {lodging.place?.image_url ? <figure className="lodging-photo"><img src={lodging.place.image_url} alt={lodging.place.image_alt || `${lodging.place.name || lodging.placeId} 圖片`} loading="lazy" /><figcaption>{lodging.place.image_source_url ? <a href={lodging.place.image_source_url} target="_blank" rel="noreferrer">圖片來源</a> : '住宿圖片'}</figcaption></figure> : null}
                 <div className="stay-dates">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -940,6 +940,11 @@ button { font-family: inherit; }
 .desktop-topbar-divider { color: #c5d0d6; }
 .desktop-status, .desktop-travelers { display: inline-flex; align-items: center; gap: 6px; padding: 7px 10px; border-radius: 9px; background: #f6f9fa; border: 1px solid #e4ebee; color: #526875; font-size: .7rem; }
 .desktop-status i { width: 7px; height: 7px; background: #2ba88f; border-radius: 50%; }
+.desktop-topbar-tools { gap: 10px; }
+.desktop-status, .desktop-travelers { min-height: 34px; padding: 6px 10px; white-space: nowrap; }
+.desktop-status { color: #24695f; border-color: #bfe3d9; background: #f1faf7; }
+.desktop-travelers { color: #304e5d; background: #fff; }
+.desktop-travelers small { color: #83949c; font-size: .64rem; }
 .trip-main-header { margin: 0 0 12px; }
 .main-title { font-size: 1.36rem; font-weight: 800; letter-spacing: -.025em; }
 .shell-status-line { margin-top: 4px; font-size: .78rem; }
@@ -1043,8 +1048,6 @@ body,
 .trip-sidebar-footer p { margin: 0; line-height: 1.55; }
 .trip-sidebar-footer small { color: #6f8999; }
 .desktop-topbar-tools { min-width: 0; }
-.desktop-quick-actions { display: flex; gap: 6px; }
-.desktop-quick-actions button { min-height: 34px; padding: 6px 10px; border: 1px solid #dce7ea; color: #466471; background: #fff; font-size: .7rem; }
 
 .page-intro {
   display: flex;
@@ -1214,7 +1217,6 @@ body,
 
 .desktop-status,
 .desktop-travelers,
-.desktop-quick-actions button,
 .day-tab,
 .print-button,
 .quick-mode button,
@@ -1233,7 +1235,6 @@ body,
   border-color: var(--line-strong);
 }
 
-.desktop-quick-actions button,
 .day-tab,
 .print-button,
 .quick-mode button,
@@ -1475,8 +1476,7 @@ body,
 .search-results button,
 .timeline-actions a,
 .timeline-actions button,
-.handbook-day-tabs button,
-.desktop-quick-actions button {
+.handbook-day-tabs button {
   min-width: 44px;
   min-height: 44px;
 }

--- a/web/tests/e2e.mjs
+++ b/web/tests/e2e.mjs
@@ -140,6 +140,7 @@ try {
   mobile.setDefaultTimeout(10000)
 
   await openRoute(mobile, 'overview')
+  if ((await mobile.locator('.mobile-topbar-title small').textContent())?.includes('待補')) throw new Error('mobile trip subtitle still exposes a placeholder status')
   if (await mobile.locator('.mobile-bottom-nav').count()) throw new Error('mobile bottom navigation must not be rendered')
   const menuButton = mobile.locator('.menu-button')
   await assertTouchTargets(mobile, '.menu-button', 'hamburger menu')
@@ -233,6 +234,8 @@ try {
     await openRoute(desktop, route)
     await desktop.locator('.trip-sidebar').waitFor({ state: 'visible' })
     await desktop.locator('.app-main').waitFor({ state: 'visible' })
+    if (await desktop.locator('.desktop-quick-actions').count()) throw new Error('desktop quick-action buttons should not duplicate sidebar navigation')
+    if ((await desktop.locator('.desktop-travelers').textContent())?.replace(/\s+/g, '') !== '旅客6大1小') throw new Error('desktop traveler summary was not rendered as compact context')
     await assertNoHorizontalOverflow(desktop, `1440px ${route}`)
   }
   await assertTextContrast(desktop, '.trip-nav-item.is-active small', 4.5, 'active desktop navigation description')


### PR DESCRIPTION
## 變更摘要
- 移除日期副標後的「待補資訊」狀態拼接，日期只顯示實際旅遊區間。
- 移除桌面頁首重複的「今日行程／導航」大按鈕，保留側邊導覽作為唯一入口。
- 將狀態與旅客數整理為緊湊資訊標籤，正確顯示「旅客 6 大 1 小」。
- 全面整理前端可見的待補、未提供、尚未確認等 fallback，改為具體狀態或中性符號。

## Acceptance criteria
- [x] 手冊頁不再顯示 `2026-08-27 ~ 2026-08-31（待補資訊）`。
- [x] 頁首資訊在桌面與手機版具備清楚間距與一致層級。
- [x] 不再重複顯示頂部快速操作大按鈕。
- [x] 淡路島旅客資訊顯示為 6 大 1 小。
- [x] 相關前端畫面不再顯示泛用待補／未提供字樣。

## Write ownership
- 單一 implementation owner：Codex。
- 寫入範圍：`web/src/**`、`web/tests/e2e.mjs`。
- 未修改 primary checkout；未納入 `web/dist` 或 `web/node_modules`。

## 驗證
- `cd web && npm run lint`
- `cd web && npm run typecheck`
- `cd web && npm test -- --run`（23 passed）
- `cd web && npm run test:e2e`
- `python3 -m pytest -q`（246 passed）
- `python3 -m unittest tests.trips.test_awaji_2026_constraints`（29 passed）
- `python3 scripts/check-awaji-contamination.py`
- `git diff --check`

## 風險與依賴
- 本次只調整頁首呈現與狀態文字，不改變 Canonical Trip 行程資料。
- 桌面快速操作移除後，仍由側邊導覽與手機抽屜提供頁面切換。
- 無外部服務依賴。

## 流程例外
- 本次為使用者直接交辦，沒有虛構 GitHub Issue；依既有授權直接以 PR 交付。