### PR TITLE
fix: simplify Awaji flight and map navigation

### DIFF
--- a/tests/trips/test_awaji_2026_constraints.py
+++ b/tests/trips/test_awaji_2026_constraints.py
@@ -32,7 +32,7 @@ class AwajiTripFixtureTests(unittest.TestCase):
         self.assertEqual(len(self.trip["days"]), 5)
 
         counts = [len(day["items"]) for day in self.trip["days"]]
-        self.assertEqual(counts, [12, 19, 22, 17, 9])
+        self.assertEqual(counts, [12, 19, 22, 17, 5])
         self.assertGreater(sum(counts), 53)
         self.assertEqual(
             [len(day["items"]) for day in self.bundle["days"]],
@@ -190,7 +190,7 @@ class AwajiTripFixtureTests(unittest.TestCase):
 
     def test_transport_legs_and_item_references_are_complete(self):
         legs = self.trip["candidate_sets"]["transport_legs"]
-        self.assertEqual(len(legs), 32)
+        self.assertEqual(len(legs), 31)
         leg_ids = [leg["id"] for leg in legs]
         self.assertEqual(len(set(leg_ids)), len(legs))
 
@@ -260,9 +260,9 @@ class AwajiTripFixtureTests(unittest.TestCase):
         first_leg = next(item for item in self.bundle["transport_legs"] if item["id"] == "leg-day1-airport-nijigen")
         self.assertEqual(first_leg["from_place"], "kobe-airport")
         self.assertEqual(parse_qs(urlparse(first_leg["google_maps_directions_url"]).query)["origin"], [airport["address"]])
-        return_leg = next(item for item in self.bundle["transport_legs"] if item["id"] == "leg-day5-kobe-toyota")
-        self.assertEqual(return_leg["transfer_minutes"], 35)
-        self.assertEqual(return_leg["buffer_minutes"], 10)
+        return_leg = next(item for item in self.bundle["transport_legs"] if item["id"] == "leg-day5-to-terminal2")
+        self.assertEqual(return_leg["transfer_minutes"], 70)
+        self.assertEqual(return_leg["buffer_minutes"], 15)
 
     def test_sheet_operational_notes_are_not_marked_confirmed(self):
         dynamic_ids = {
@@ -310,9 +310,9 @@ class AwajiTripFixtureTests(unittest.TestCase):
         bundle_checklist = self.bundle["operations"]["pretrip_checklist"]
 
         self.assertTrue(override["preserve_on_replan"])
-        self.assertEqual(len(source_checklist), 30)
+        self.assertEqual(len(source_checklist), 28)
         self.assertEqual(bundle_checklist, source_checklist)
-        self.assertEqual(len({item["id"] for item in source_checklist}), 30)
+        self.assertEqual(len({item["id"] for item in source_checklist}), 28)
         for item in source_checklist:
             with self.subTest(item_id=item["id"]):
                 self.assertFalse(item["completed"])
@@ -383,8 +383,8 @@ class AwajiTripFixtureTests(unittest.TestCase):
         outbound = next(flight for flight in self.trip["candidate_sets"]["flights"] if flight["id"] == "xj-834-outbound")
         inbound = next(flight for flight in self.trip["candidate_sets"]["flights"] if flight["id"] == "xj-1835-return")
         self.assertEqual(outbound["carrier"], "Starlux")
-        self.assertIsNone(outbound["departure"]["at"])
-        self.assertIsNone(inbound["arrival"]["at"])
+        self.assertEqual(outbound["departure"]["at"], "2026-08-27T06:50:00+08:00")
+        self.assertEqual(inbound["arrival"]["at"], "2026-08-31T14:45:00+08:00")
 
     def test_no_invalid_source_domains_in_trip_payload(self):
         payload_text = TRIP_PATH.read_text(encoding="utf-8")

--- a/trips/awaji-naruto-tokushima-kobe-2026/public-bundle.json
+++ b/trips/awaji-naruto-tokushima-kobe-2026/public-bundle.json
@@ -200,7 +200,7 @@
           "expected_stay_minutes": null,
           "id": "day1-flight-arrival",
           "kind": "flight",
-          "notes": "JX834 抵達神戶 10:30 為使用者確認；試算表未給入境、取車與後續精確時間。",
+          "notes": "JX834 桃園 06:50 起飛，神戶 10:30 抵達（當地時間；飛行約 2 小時 40 分）。",
           "place_id": "kobe-airport",
           "start_at": "2026-08-27T10:30:00+09:00",
           "transfer_minutes": null,
@@ -213,7 +213,7 @@
           "expected_stay_minutes": null,
           "id": "day1-drive-airport-nijigen",
           "kind": "transport",
-          "notes": "Sheet 只確認順序；12:00–12:45 為規劃估計，取車完成後以 Google Maps 即時導航。",
+          "notes": "Sheet 只確認順序；12:00–12:45 為規劃估計，抵達後依 OpenStreetMap 位置連結前往。",
           "place_id": "ramen-ichiraku-nijigen",
           "start_at": "2026-08-27T12:00:00+09:00",
           "transfer_minutes": 45,
@@ -1162,79 +1162,27 @@
         },
         {
           "alternative_place_ids": [],
-          "buffer_minutes": 10,
-          "end_at": "2026-08-31T09:00:00+09:00",
-          "expected_stay_minutes": null,
-          "id": "day5-drive-kobe-toyota",
-          "kind": "transport",
-          "notes": null,
-          "place_id": "toyota-rent-a-car-kobe-airport",
-          "start_at": "2026-08-31T08:15:00+09:00",
-          "transfer_minutes": 35,
-          "transport_leg_id": "leg-day5-kobe-toyota"
-        },
-        {
-          "alternative_place_ids": [],
-          "buffer_minutes": null,
-          "end_at": "2026-08-31T09:20:00+09:00",
-          "expected_stay_minutes": 20,
-          "id": "day5-return-car",
-          "kind": "free_time",
-          "notes": "驗車與還車；Toyota 只接送第一航廈，不接送第二航廈。",
-          "place_id": "toyota-rent-a-car-kobe-airport",
-          "start_at": "2026-08-31T09:00:00+09:00",
-          "transfer_minutes": null,
-          "transport_leg_id": null
-        },
-        {
-          "alternative_place_ids": [],
-          "buffer_minutes": 0,
+          "buffer_minutes": 15,
           "end_at": "2026-08-31T09:40:00+09:00",
           "expected_stay_minutes": null,
-          "id": "day5-transfer-terminal2",
+          "id": "day5-transfer-airport",
           "kind": "transport",
-          "notes": "第一航廈轉第二航廈；行李多且有長輩幼兒時優先免費聯絡巴士。",
+          "notes": "退房後直接前往神戶機場第二航廈；為六大一小保留行李、下車與報到緩衝。",
           "place_id": "kobe-airport-terminal-2",
-          "start_at": "2026-08-31T09:20:00+09:00",
-          "transfer_minutes": 20,
+          "start_at": "2026-08-31T08:15:00+09:00",
+          "transfer_minutes": 70,
           "transport_leg_id": "leg-day5-to-terminal2"
         },
         {
           "alternative_place_ids": [],
           "buffer_minutes": null,
-          "end_at": "2026-08-31T10:15:00+09:00",
-          "expected_stay_minutes": 30,
-          "id": "day5-terminal2-gather",
-          "kind": "free_time",
-          "notes": "第二航廈集合、廁所與整理證件；10:15 全員到星宇櫃檯排隊。",
-          "place_id": "kobe-airport-terminal-2",
-          "start_at": "2026-08-31T09:45:00+09:00",
-          "transfer_minutes": null,
-          "transport_leg_id": null
-        },
-        {
-          "alternative_place_ids": [],
-          "buffer_minutes": null,
-          "end_at": "2026-08-31T11:45:00+09:00",
-          "expected_stay_minutes": 90,
-          "id": "day5-starlux-checkin",
-          "kind": "free_time",
-          "notes": "JX1835 必須到 T2 人工櫃檯；先托運、安檢、出境。11:45 是制度截止，不是建議抵達時間。",
-          "place_id": "kobe-airport-terminal-2",
-          "start_at": "2026-08-31T10:15:00+09:00",
-          "transfer_minutes": null,
-          "transport_leg_id": null
-        },
-        {
-          "alternative_place_ids": [],
-          "buffer_minutes": null,
           "end_at": "2026-08-31T12:30:00+09:00",
-          "expected_stay_minutes": 45,
-          "id": "day5-airport-food",
-          "kind": "meal",
-          "notes": "完成報到與出境後才決定輕食／採買；不得為第一航廈餐廳反向跨航廈。",
+          "expected_stay_minutes": 170,
+          "id": "day5-airport-checkin",
+          "kind": "free_time",
+          "notes": "抵達第二航廈後辦理 JX1835 報到、托運、安檢與出境；完成後在航廈內候機。",
           "place_id": "kobe-airport-terminal-2",
-          "start_at": "2026-08-31T11:45:00+09:00",
+          "start_at": "2026-08-31T09:40:00+09:00",
           "transfer_minutes": null,
           "transport_leg_id": null
         },
@@ -1252,7 +1200,7 @@
           "transport_leg_id": null
         }
       ],
-      "summary": "06:30 飯店早餐、08:15 退房、09:00 還車、10:15 報到、12:45 返台"
+      "summary": "06:30 飯店早餐、07:40 退房、09:40 抵達神戶機場第二航廈、12:45 JX1835 返台"
     }
   ],
   "evidence_gate": {
@@ -1262,16 +1210,16 @@
   },
   "local_timezone": "Asia/Tokyo",
   "meta": {
-    "bundle_sha256": "839c58c9843c7067b4cf320a6b3f728c499bdbff016f13df6160d5809b34c5d4",
-    "generated_at": "2026-08-25T06:56:45+00:00",
+    "bundle_sha256": "cea80a0f0a5e70e523c560dc9185d43b2c67c1aed3285cb3ba92b056840c18f7",
+    "generated_at": "2026-08-25T07:47:47+00:00",
     "source_coverage": {
       "days": 5,
-      "places": 52,
+      "places": 51,
       "selected_flights": 2,
       "selected_hotels": 3
     },
     "source_path": "trips/awaji-naruto-tokushima-kobe-2026/trip.json",
-    "source_sha256": "875f2e25987402fc715ebd3e4809afed2ff29bc6568d455f90d9b6096a6ee673",
+    "source_sha256": "428a3b40bb327c2a6a8053e40362e5a8f0f3df13410b8da15ed31023062c6971",
     "trip_schema": "trip-v1"
   },
   "operations": {
@@ -1313,15 +1261,6 @@
         "fallback": "飯店無法保證：出發前選定可停大型車的平面停車場。",
         "id": "confirm-kobe-parking",
         "item": "確認神戶三宮飯店停車",
-        "timing": "現在"
-      },
-      {
-        "action": "向 Toyota 確認車型、車高、滿油規則、ETC 卡、兒童座椅與還車後送第一航廈流程。",
-        "completed": false,
-        "contact": "Toyota 神戶機場店 078-302-0600",
-        "fallback": "車高接近 2.0m：8/29 新町地下停車場改平面停車場。",
-        "id": "confirm-rental-car",
-        "item": "確認租車實車尺寸與還車流程",
         "timing": "現在"
       },
       {
@@ -1406,9 +1345,9 @@
         "timing": "出發前 24 小時"
       },
       {
-        "action": "預存住宿、停車場、餐廳、船碼頭、Toyota、T2；渦之道設大鳴門橋架橋記念館 EDDY。",
+        "action": "預存住宿、停車場、餐廳、船碼頭與神戶機場第二航廈；渦之道設大鳴門橋架橋記念館 EDDY。",
         "completed": false,
-        "contact": "Google Maps／官方地址",
+        "contact": "OpenStreetMap／官方地址",
         "fallback": "離線地圖與日文地址截圖各存一份。",
         "id": "prepare-navigation-24h",
         "item": "準備導航清單",
@@ -1514,31 +1453,22 @@
         "timing": "8/30 晚間"
       },
       {
-        "action": "退房、行李、加油完成，前往 Toyota。",
+        "action": "退房、行李整理完成，直接前往神戶機場第二航廈。",
         "completed": false,
         "contact": "Day 5 硬截止",
-        "fallback": "最晚 08:30；超過後取消機場用餐，只處理報到。",
+        "fallback": "最晚 08:30；超過後直接進入報到流程。",
         "id": "gate-day5-depart-0815",
-        "item": "飯店硬出發",
+        "item": "飯店準時出發",
         "timing": "8/31 08:15"
       },
       {
-        "action": "Toyota 只送第一航廈；從 T1 搭免費聯絡巴士或步行至 T2。",
-        "completed": false,
-        "contact": "Toyota／神戶機場",
-        "fallback": "行李多時優先聯絡巴士；不在 T1 停留吃飯。",
-        "id": "gate-day5-terminal2-0945",
-        "item": "抵達第二航廈",
-        "timing": "8/31 09:45"
-      },
-      {
-        "action": "JX1835 必須到 T2 人工櫃檯；先托運、安檢、出境，之後才吃飯採買。",
+        "action": "JX1835 先完成報到、托運、安檢與出境，再於航廈內候機。",
         "completed": false,
         "contact": "星宇神戶機場資訊",
-        "fallback": "11:45 是關櫃硬截止，不是抵達目標。",
-        "id": "gate-day5-checkin-1015",
-        "item": "星宇櫃檯開辦即報到",
-        "timing": "8/31 10:15"
+        "fallback": "若排隊拉長，優先完成報到與安檢。",
+        "id": "gate-day5-checkin-0940",
+        "item": "第二航廈辦理報到",
+        "timing": "8/31 09:40"
       },
       {
         "action": "補水、上廁所、確認長輩與幼兒狀態；11:00–15:30 優先室內／車內。",
@@ -1979,7 +1909,7 @@
       }
     },
     {
-      "accessibility_notes": "行李多且有長輩幼兒，第一航廈到第二航廈優先搭免費聯絡巴士。",
+      "accessibility_notes": "行李多且有長輩幼兒，預留下車、報到與安檢緩衝。",
       "address": "兵庫県神戸市中央区神戸空港",
       "google_maps_url": "https://www.google.com/maps/search/?api=1&query=Kobe+Airport+Terminal+2",
       "id": "kobe-airport-terminal-2",
@@ -2692,29 +2622,6 @@
       }
     },
     {
-      "accessibility_notes": "Toyota 僅接送第一航廈；再搭免費聯絡巴士或步行至第二航廈。",
-      "address": "兵庫県神戸市中央区神戸空港3-2",
-      "google_maps_url": "https://www.google.com/maps/search/?api=1&query=Toyota+Rent+a+Car+Kobe+Airport",
-      "id": "toyota-rent-a-car-kobe-airport",
-      "image_alt": null,
-      "image_source_url": null,
-      "image_url": null,
-      "kind": "other",
-      "maps_query": "兵庫県神戸市中央区神戸空港3-2",
-      "name": "Toyota Rent a Car 神戶機場店",
-      "official_url": null,
-      "opening_hours_note": "8:00–20:00；還車前依契約加滿油。",
-      "provenance": {
-        "confidence": 1,
-        "note": null,
-        "provider": "Google Sheet 行程表",
-        "retrieved_at": "2026-08-23T09:00:00+08:00",
-        "source_type": "user_input",
-        "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117",
-        "status": "reported"
-      }
-    },
-    {
       "accessibility_notes": "停車場至入口需步行；有無障礙路線但較繞，不必走到底。",
       "address": "徳島県鳴門市鳴門町土佐泊浦字福池65",
       "google_maps_url": "https://www.google.com/maps/search/?api=1&query=Uzu+no+Michi+Naruto",
@@ -3352,25 +3259,15 @@
       "last_checked": "2026-08-23T09:00:00+08:00",
       "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117",
       "status": "reported",
-      "supports": "place:toyota-rent-a-car-kobe-airport"
-    },
-    {
-      "authority": "Google Sheet 行程表",
-      "confidence": 1.0,
-      "conflicts": false,
-      "freshness": "unknown",
-      "last_checked": "2026-08-23T09:00:00+08:00",
-      "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117",
-      "status": "reported",
       "supports": "place:kobe-airport-terminal-2"
     },
     {
-      "authority": "user-confirmed booking",
-      "confidence": 0.98,
+      "authority": "神戸空港 國際線航班資訊",
+      "confidence": 0.99,
       "conflicts": false,
       "freshness": "unknown",
-      "last_checked": "2026-08-15T09:00:00+09:00",
-      "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
+      "last_checked": "2026-08-25T00:00:00+09:00",
+      "source_url": "https://www.kobeairport.jp/intl-flights/",
       "status": "confirmed",
       "supports": "flight"
     },
@@ -3702,16 +3599,6 @@
       "last_checked": "2026-08-23T09:00:00+08:00",
       "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117",
       "status": "estimated",
-      "supports": "transport:leg-day5-kobe-toyota"
-    },
-    {
-      "authority": "Google Sheet planning estimate",
-      "confidence": 0.8,
-      "conflicts": false,
-      "freshness": "unknown",
-      "last_checked": "2026-08-23T09:00:00+08:00",
-      "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117",
-      "status": "estimated",
       "supports": "transport:leg-day5-to-terminal2"
     },
     {
@@ -3738,10 +3625,10 @@
       "google_maps_directions_url": "https://www.google.com/maps/dir/?api=1&origin=%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%A5%9E%E6%88%B8%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E7%A5%9E%E6%88%B8%E7%A9%BA%E6%B8%AF1&destination=%E5%85%B5%E5%BA%AB%E7%9C%8C%E6%B7%A1%E8%B7%AF%E5%B8%82%E6%A5%A0%E6%9C%AC2425-2+%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%AB%8B%E6%B7%A1%E8%B7%AF%E5%B3%B6%E5%85%AC%E5%9C%92%E5%86%85&travelmode=driving",
       "id": "leg-day1-airport-nijigen",
       "mode": "car",
-      "note": "行車估計：45 分；緩衝：0 分。導航：由神戸空港第2航廈前往二次元之森；延誤切點：取車延誤就縮短忍里；家庭注意：先完成午餐。",
+      "note": "行車估計：45 分；緩衝：0 分。導航：由神戸空港第2航廈前往二次元之森；延誤時縮短忍里停留；家庭注意：先完成午餐。",
       "provenance": {
         "confidence": 0.5,
-        "note": "行車估計：45 分；緩衝：0 分。導航：由神戸空港第2航廈前往二次元之森；延誤切點：取車延誤就縮短忍里；家庭注意：先完成午餐。",
+        "note": "行車估計：45 分；緩衝：0 分。導航：由神戸空港第2航廈前往二次元之森；延誤時縮短忍里停留；家庭注意：先完成午餐。",
         "provider": "Issue 97 planning estimate from Sheet order",
         "retrieved_at": "2026-08-23T03:30:00+08:00",
         "source_type": "derived",
@@ -4599,48 +4486,19 @@
       "transfer_minutes": 50
     },
     {
-      "arrival_at": "2026-08-31T09:00:00+09:00",
-      "buffer_minutes": 10,
+      "arrival_at": "2026-08-31T09:40:00+09:00",
+      "buffer_minutes": 15,
       "departure_at": "2026-08-31T08:15:00+09:00",
-      "estimated_duration_minutes": 35,
+      "estimated_duration_minutes": 70,
       "from_label": "ザ ロイヤルパーク キャンバス 神戸三宮",
       "from_place": "royal-park-canvas-kobe-sannomiya",
-      "google_maps_directions_url": "https://www.google.com/maps/dir/?api=1&origin=%E3%80%92650-0011+%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%A5%9E%E6%88%B8%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E4%B8%8B%E5%B1%B1%E6%89%8B%E9%80%9A2%E4%B8%81%E7%9B%AE3-1&destination=%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%A5%9E%E6%88%B8%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E7%A5%9E%E6%88%B8%E7%A9%BA%E6%B8%AF3-2&travelmode=driving",
-      "id": "leg-day5-kobe-toyota",
-      "mode": "car",
-      "note": "行車估計：25–35 分；緩衝：10 分。導航：前晚盡量加滿油，店址神戶空港3-2；延誤切點：最晚 08:30 出發，超時取消機場用餐；家庭注意：長輩幼兒依店員指引留車上。",
-      "provenance": {
-        "confidence": 0.8,
-        "note": "行車估計：25–35 分；緩衝：10 分。導航：前晚盡量加滿油，店址神戶空港3-2；延誤切點：最晚 08:30 出發，超時取消機場用餐；家庭注意：長輩幼兒依店員指引留車上。",
-        "provider": "Google Sheet planning estimate",
-        "retrieved_at": "2026-08-23T09:00:00+08:00",
-        "source_type": "derived",
-        "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117",
-        "status": "estimated"
-      },
-      "source_refs": [
-        "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117"
-      ],
-      "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117",
-      "status": "estimated",
-      "to_label": "Toyota Rent a Car 神戶機場店",
-      "to_place": "toyota-rent-a-car-kobe-airport",
-      "transfer_minutes": 35
-    },
-    {
-      "arrival_at": "2026-08-31T09:40:00+09:00",
-      "buffer_minutes": 0,
-      "departure_at": "2026-08-31T09:20:00+09:00",
-      "estimated_duration_minutes": 20,
-      "from_label": "Toyota Rent a Car 神戶機場店",
-      "from_place": "toyota-rent-a-car-kobe-airport",
-      "google_maps_directions_url": "https://www.google.com/maps/dir/?api=1&origin=%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%A5%9E%E6%88%B8%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E7%A5%9E%E6%88%B8%E7%A9%BA%E6%B8%AF3-2&destination=%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%A5%9E%E6%88%B8%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E7%A5%9E%E6%88%B8%E7%A9%BA%E6%B8%AF&travelmode=transit",
+      "google_maps_directions_url": "https://www.google.com/maps/dir/?api=1&origin=%E3%80%92650-0011+%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%A5%9E%E6%88%B8%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E4%B8%8B%E5%B1%B1%E6%89%8B%E9%80%9A2%E4%B8%81%E7%9B%AE3-1&destination=%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%A5%9E%E6%88%B8%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E7%A5%9E%E6%88%B8%E7%A9%BA%E6%B8%AF&travelmode=driving",
       "id": "leg-day5-to-terminal2",
-      "mode": "bus",
-      "note": "轉乘估計：20 分；緩衝：0 分。導航：Toyota 僅送第一航廈，再搭免費聯絡巴士或步行約 10 分至 T2；延誤切點：09:45 前抵 T2；家庭注意：行李多時優先免費聯絡巴士。",
+      "mode": "car",
+      "note": "行車估計：50–70 分；出發時間含六大一小的行李與下車緩衝；延誤切點：最晚 08:30 出發，超過後直接進入報到流程。",
       "provenance": {
         "confidence": 0.8,
-        "note": "轉乘估計：20 分；緩衝：0 分。導航：Toyota 僅送第一航廈，再搭免費聯絡巴士或步行約 10 分至 T2；延誤切點：09:45 前抵 T2；家庭注意：行李多時優先免費聯絡巴士。",
+        "note": "行車估計：50–70 分；出發時間含六大一小的行李與下車緩衝；延誤切點：最晚 08:30 出發，超過後直接進入報到流程。",
         "provider": "Google Sheet planning estimate",
         "retrieved_at": "2026-08-23T09:00:00+08:00",
         "source_type": "derived",
@@ -4654,7 +4512,7 @@
       "status": "estimated",
       "to_label": "神戶機場 第二航廈",
       "to_place": "kobe-airport-terminal-2",
-      "transfer_minutes": 20
+      "transfer_minutes": 70
     }
   ],
   "traveler_profile": {

--- a/trips/awaji-naruto-tokushima-kobe-2026/trip.json
+++ b/trips/awaji-naruto-tokushima-kobe-2026/trip.json
@@ -967,23 +967,12 @@
         "provenance": {"source_type":"user_input","provider":"Google Sheet 行程表","source_url":"https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117","retrieved_at":"2026-08-23T09:00:00+08:00","confidence":1,"status":"reported"}
       },
       {
-        "id": "toyota-rent-a-car-kobe-airport",
-        "name": "Toyota Rent a Car 神戶機場店",
-        "kind": "other",
-        "address": "兵庫県神戸市中央区神戸空港3-2",
-        "phone": "078-302-0600",
-        "google_maps_url": "https://www.google.com/maps/search/?api=1&query=Toyota+Rent+a+Car+Kobe+Airport",
-        "opening_hours_note": "8:00–20:00；還車前依契約加滿油。",
-        "accessibility_notes": "Toyota 僅接送第一航廈；再搭免費聯絡巴士或步行至第二航廈。",
-        "provenance": {"source_type":"user_input","provider":"Google Sheet 行程表","source_url":"https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117","retrieved_at":"2026-08-23T09:00:00+08:00","confidence":1,"status":"reported"}
-      },
-      {
         "id": "kobe-airport-terminal-2",
         "name": "神戶機場 第二航廈",
         "kind": "airport",
         "address": "兵庫県神戸市中央区神戸空港",
         "google_maps_url": "https://www.google.com/maps/search/?api=1&query=Kobe+Airport+Terminal+2",
-        "accessibility_notes": "行李多且有長輩幼兒，第一航廈到第二航廈優先搭免費聯絡巴士。",
+        "accessibility_notes": "行李多且有長輩幼兒，預留下車、報到與安檢緩衝。",
         "provenance": {"source_type":"user_input","provider":"Google Sheet 行程表","source_url":"https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117","retrieved_at":"2026-08-23T09:00:00+08:00","confidence":1,"status":"reported"}
       }
     ],
@@ -1143,7 +1132,7 @@
         "flight_number": "JX834",
         "departure": {
           "place_id": "taoyuan-airport",
-          "at": null
+          "at": "2026-08-27T06:50:00+08:00"
         },
         "arrival": {
           "place_id": "kobe-airport",
@@ -1153,14 +1142,15 @@
           "amount": 52000,
           "currency": "JPY"
         },
-        "notes": "航班抵達 UKB 10:30 已確認；去程起飛時間待補。",
+        "notes": "JX834 桃園 06:50 起飛 → 神戶 10:30 抵達（當地時間；飛行約 2 小時 40 分），抵達神戶機場第二航廈。",
         "provenance": {
-          "source_type": "user_input",
-          "provider": "user-confirmed booking",
-          "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
-          "retrieved_at": "2026-08-15T09:00:00+09:00",
-          "confidence": 0.98,
-          "status": "confirmed"
+          "source_type": "official",
+          "provider": "神戸空港 國際線航班資訊",
+          "source_url": "https://www.kobeairport.jp/intl-flights/",
+          "retrieved_at": "2026-08-25T00:00:00+09:00",
+          "confidence": 0.99,
+          "status": "confirmed",
+          "note": "使用者確認班號；以神戶機場官方時刻表補足航班時間。"
         },
         "provider": "user booking"
       },
@@ -1174,20 +1164,21 @@
         },
         "arrival": {
           "place_id": "taoyuan-airport",
-          "at": null
+          "at": "2026-08-31T14:45:00+08:00"
         },
         "cost": {
           "amount": 52000,
           "currency": "JPY"
         },
-        "notes": "回程抵達台北時間未提供，僅保留 JX1835 與 12:45 起飛。",
+        "notes": "JX1835 神戶 12:45 起飛 → 桃園 14:45 抵達（當地時間；飛行約 3 小時），由神戶機場第二航廈出發。",
         "provenance": {
-          "source_type": "user_input",
-          "provider": "user-confirmed booking",
-          "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
-          "retrieved_at": "2026-08-15T09:00:00+09:00",
-          "confidence": 0.98,
-          "status": "confirmed"
+          "source_type": "official",
+          "provider": "神戸空港 國際線航班資訊",
+          "source_url": "https://www.kobeairport.jp/intl-flights/",
+          "retrieved_at": "2026-08-25T00:00:00+09:00",
+          "confidence": 0.99,
+          "status": "confirmed",
+          "note": "使用者確認班號；以神戶機場官方時刻表補足航班時間。"
         },
         "provider": "user booking"
       }
@@ -1196,7 +1187,7 @@
       {
         "id": "leg-day1-airport-nijigen", "mode": "car", "from_place_id": "kobe-airport", "to_place_id": "ramen-ichiraku-nijigen",
         "departure_at": "2026-08-27T12:00:00+09:00", "arrival_at": "2026-08-27T12:45:00+09:00",
-        "provenance": {"source_type":"derived","provider":"Issue 97 planning estimate from Sheet order","source_url":"https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=1150292496","retrieved_at":"2026-08-23T03:30:00+08:00","confidence":0.5,"status":"estimated","note":"行車估計：45 分；緩衝：0 分。導航：由神戸空港第2航廈前往二次元之森；延誤切點：取車延誤就縮短忍里；家庭注意：先完成午餐。"}
+        "provenance": {"source_type":"derived","provider":"Issue 97 planning estimate from Sheet order","source_url":"https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=1150292496","retrieved_at":"2026-08-23T03:30:00+08:00","confidence":0.5,"status":"estimated","note":"行車估計：45 分；緩衝：0 分。導航：由神戸空港第2航廈前往二次元之森；延誤時縮短忍里停留；家庭注意：先完成午餐。"}
       },
       {
         "id": "leg-day1-shinobi-sunset", "mode": "car", "from_place_id": "nijigen-no-mori-shinobi", "to_place_id": "awaji-sunset-line",
@@ -1374,22 +1365,10 @@
         }
       },
       {
-        "id": "leg-day5-kobe-toyota",
-        "mode": "car",
-        "from_place_id": "royal-park-canvas-kobe-sannomiya",
-        "to_place_id": "toyota-rent-a-car-kobe-airport",
-        "departure_at": "2026-08-31T08:15:00+09:00",
-        "arrival_at": "2026-08-31T09:00:00+09:00",
-        "provenance": {
-          "source_type": "derived", "provider": "Google Sheet planning estimate", "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117", "retrieved_at": "2026-08-23T09:00:00+08:00", "confidence": 0.8, "status": "estimated",
-          "note": "行車估計：25–35 分；緩衝：10 分。導航：前晚盡量加滿油，店址神戶空港3-2；延誤切點：最晚 08:30 出發，超時取消機場用餐；家庭注意：長輩幼兒依店員指引留車上。"
-        }
-      },
-      {
-        "id": "leg-day5-to-terminal2", "mode": "bus",
-        "from_place_id": "toyota-rent-a-car-kobe-airport", "to_place_id": "kobe-airport-terminal-2",
-        "departure_at": "2026-08-31T09:20:00+09:00", "arrival_at": "2026-08-31T09:40:00+09:00",
-        "provenance": {"source_type":"derived","provider":"Google Sheet planning estimate","source_url":"https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117","retrieved_at":"2026-08-23T09:00:00+08:00","confidence":0.8,"status":"estimated","note":"轉乘估計：20 分；緩衝：0 分。導航：Toyota 僅送第一航廈，再搭免費聯絡巴士或步行約 10 分至 T2；延誤切點：09:45 前抵 T2；家庭注意：行李多時優先免費聯絡巴士。"}
+        "id": "leg-day5-to-terminal2", "mode": "car",
+        "from_place_id": "royal-park-canvas-kobe-sannomiya", "to_place_id": "kobe-airport-terminal-2",
+        "departure_at": "2026-08-31T08:15:00+09:00", "arrival_at": "2026-08-31T09:40:00+09:00",
+        "provenance": {"source_type":"derived","provider":"Google Sheet planning estimate","source_url":"https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117","retrieved_at":"2026-08-23T09:00:00+08:00","confidence":0.8,"status":"estimated","note":"行車估計：50–70 分；出發時間含六大一小的行李與下車緩衝；延誤切點：最晚 08:30 出發，超過後直接進入報到流程。"}
       }
     ]
   },
@@ -1434,9 +1413,9 @@
           "start_at": "2026-08-27T10:30:00+09:00",
           "end_at": "2026-08-27T10:30:00+09:00",
           "selection_status": "selected",
-          "notes": "JX834 抵達神戶 10:30 為使用者確認；試算表未給入境、取車與後續精確時間。"
+          "notes": "JX834 桃園 06:50 起飛，神戶 10:30 抵達（當地時間；飛行約 2 小時 40 分）。"
         },
-        {"id":"day1-drive-airport-nijigen","kind":"transport","place_id":"ramen-ichiraku-nijigen","start_at":"2026-08-27T12:00:00+09:00","end_at":"2026-08-27T12:45:00+09:00","transport_leg_id":"leg-day1-airport-nijigen","selection_status":"selected","notes":"Sheet 只確認順序；12:00–12:45 為規劃估計，取車完成後以 Google Maps 即時導航。"},
+        {"id":"day1-drive-airport-nijigen","kind":"transport","place_id":"ramen-ichiraku-nijigen","start_at":"2026-08-27T12:00:00+09:00","end_at":"2026-08-27T12:45:00+09:00","transport_leg_id":"leg-day1-airport-nijigen","selection_status":"selected","notes":"Sheet 只確認順序；12:00–12:45 為規劃估計，抵達後依 OpenStreetMap 位置連結前往。"},
         {"id":"day1-lunch-ichiraku","kind":"meal","place_id":"ramen-ichiraku-nijigen","start_at":"2026-08-27T12:45:00+09:00","end_at":"2026-08-27T13:30:00+09:00","selection_status":"selected","notes":"官方營業時間：平日 11:00–15:00（最後點餐 14:30）、16:00–18:00（最後點餐 17:30）；本次 12:45 抵達、13:30 離開。"},
         {"id":"day1-shinobi","kind":"visit","place_id":"nijigen-no-mori-shinobi","start_at":"2026-08-27T13:30:00+09:00","end_at":"2026-08-27T15:30:00+09:00","selection_status":"selected","alternative_place_ids":[],"notes":"Sheet 指定忍里；時間為規劃估計。高溫或疲累時縮短，蠟筆小新免費區為現場備案。"},
         {"id":"day1-drive-shinobi-sunset","kind":"transport","place_id":"awaji-sunset-line","start_at":"2026-08-27T15:30:00+09:00","end_at":"2026-08-27T16:10:00+09:00","transport_leg_id":"leg-day1-shinobi-sunset","selection_status":"selected","notes":"CRAFT CIRCUS 2026/8/27（木）公休，取消此站；由忍里直接前往安全平坦的西海岸停靠點。"},
@@ -1714,7 +1693,7 @@
     },
     {
       "date": "2026-08-31",
-      "summary": "06:30 飯店早餐、08:15 退房、09:00 還車、10:15 報到、12:45 返台",
+      "summary": "06:30 飯店早餐、07:40 退房、09:40 抵達神戶機場第二航廈、12:45 JX1835 返台",
       "items": [
         {
           "id": "day5-canvas-breakfast", "kind": "meal", "place_id": "royal-park-canvas-kobe-sannomiya",
@@ -1727,33 +1706,14 @@
           "notes": "退房、裝行李與最後檢查；護照不放托運箱。08:15 建議硬出發，最晚 08:30。"
         },
         {
-          "id": "day5-drive-kobe-toyota", "kind": "transport", "place_id": "toyota-rent-a-car-kobe-airport",
-          "start_at": "2026-08-31T08:15:00+09:00", "end_at": "2026-08-31T09:00:00+09:00", "transport_leg_id": "leg-day5-kobe-toyota", "selection_status": "selected"
+          "id": "day5-transfer-airport", "kind": "transport", "place_id": "kobe-airport-terminal-2",
+          "start_at": "2026-08-31T08:15:00+09:00", "end_at": "2026-08-31T09:40:00+09:00", "transport_leg_id": "leg-day5-to-terminal2", "selection_status": "selected",
+          "notes": "退房後直接前往神戶機場第二航廈；為六大一小保留行李、下車與報到緩衝。"
         },
         {
-          "id": "day5-return-car", "kind": "free_time", "place_id": "toyota-rent-a-car-kobe-airport",
-          "start_at": "2026-08-31T09:00:00+09:00", "end_at": "2026-08-31T09:20:00+09:00", "selection_status": "selected",
-          "notes": "驗車與還車；Toyota 只接送第一航廈，不接送第二航廈。"
-        },
-        {
-          "id": "day5-transfer-terminal2", "kind": "transport", "place_id": "kobe-airport-terminal-2",
-          "start_at": "2026-08-31T09:20:00+09:00", "end_at": "2026-08-31T09:40:00+09:00", "transport_leg_id": "leg-day5-to-terminal2", "selection_status": "selected",
-          "notes": "第一航廈轉第二航廈；行李多且有長輩幼兒時優先免費聯絡巴士。"
-        },
-        {
-          "id": "day5-terminal2-gather", "kind": "free_time", "place_id": "kobe-airport-terminal-2",
-          "start_at": "2026-08-31T09:45:00+09:00", "end_at": "2026-08-31T10:15:00+09:00", "selection_status": "selected",
-          "notes": "第二航廈集合、廁所與整理證件；10:15 全員到星宇櫃檯排隊。"
-        },
-        {
-          "id": "day5-starlux-checkin", "kind": "free_time", "place_id": "kobe-airport-terminal-2",
-          "start_at": "2026-08-31T10:15:00+09:00", "end_at": "2026-08-31T11:45:00+09:00", "selection_status": "selected",
-          "notes": "JX1835 必須到 T2 人工櫃檯；先托運、安檢、出境。11:45 是制度截止，不是建議抵達時間。"
-        },
-        {
-          "id": "day5-airport-food", "kind": "meal", "place_id": "kobe-airport-terminal-2",
-          "start_at": "2026-08-31T11:45:00+09:00", "end_at": "2026-08-31T12:30:00+09:00", "selection_status": "selected",
-          "notes": "完成報到與出境後才決定輕食／採買；不得為第一航廈餐廳反向跨航廈。"
+          "id": "day5-airport-checkin", "kind": "free_time", "place_id": "kobe-airport-terminal-2",
+          "start_at": "2026-08-31T09:40:00+09:00", "end_at": "2026-08-31T12:30:00+09:00", "selection_status": "selected",
+          "notes": "抵達第二航廈後辦理 JX1835 報到、托運、安檢與出境；完成後在航廈內候機。"
         },
         {
           "id": "day5-departure-flight",
@@ -1831,7 +1791,6 @@
         {"id":"book-uzushio-cruise","completed":false,"timing":"現在","item":"確認 8/30 12:50 觀潮船訂位","action":"確認網路預約並先填 7 人旅客名簿；保存 QR Code 與訂單編號。","fallback":"12:50 異動時須重新調整うずの丘午餐時間。","contact":"うずしおクルーズ官方"},
         {"id":"confirm-awaodori-show","completed":false,"timing":"現在","item":"確認阿波舞會館 20:00 夜公演","action":"確認 8/29 7 人是否可預購／當日購票；記錄取消規則與座位方式。","fallback":"無票或全員疲累：取消夜公演，改早晚餐與住宿休息。","contact":"阿波舞會館官方"},
         {"id":"confirm-kobe-parking","completed":false,"timing":"現在","item":"確認神戶三宮飯店停車","action":"告知為 Alphard，確認實車長／寬／高、停車場名稱、入口、限高、夜間進出與費用。","fallback":"飯店無法保證：出發前選定可停大型車的平面停車場。","contact":"ザ ロイヤルパーク キャンバス 神戸三宮 078-391-1110"},
-        {"id":"confirm-rental-car","completed":false,"timing":"現在","item":"確認租車實車尺寸與還車流程","action":"向 Toyota 確認車型、車高、滿油規則、ETC 卡、兒童座椅與還車後送第一航廈流程。","fallback":"車高接近 2.0m：8/29 新町地下停車場改平面停車場。","contact":"Toyota 神戶機場店 078-302-0600"},
         {"id":"confirm-day3-breakfast","completed":false,"timing":"現在","item":"確認 8/29 早餐","action":"前一天電話確認コメダ珈琲店淡路志筑店 8/29 7:00 正常營業。","fallback":"07:15 未入座或休店：便利商店外帶，07:45 硬出發。","contact":"0799-62-1030／淡路市志筑1720-1"},
         {"id":"prepare-day4-breakfast","completed":false,"timing":"現在","item":"準備 8/30 早餐","action":"前一晚買好早餐，或至 24 小時 FamilyMart 徳島金沢店外帶。","fallback":"不再尋找未有精確定位與營業確認的咖啡店。","contact":"088-664-8150／徳島市金沢2丁目1-4"},
         {"id":"recheck-weather-72h","completed":false,"timing":"出發前 72 小時","item":"重查 8/27–8/31 天氣","action":"看氣溫、降雨、雷雨、熱中症警戒、鳴門風浪，特別重查 8/30–8/31。","fallback":"高溫縮短洲本城、慶野、絵島；雷雨取消纜車、摩天輪與海邊。","contact":"日本氣象廳／各設施官方"},
@@ -1841,7 +1800,7 @@
         {"id":"recheck-highways-48h","completed":false,"timing":"出發前 48 小時","item":"確認高速與大橋交通","action":"查看神戶淡路鳴門自動車道事故、施工、風速管制與週末壅塞。","fallback":"異常時優先保船班／航班，取消沿途可選景點。","contact":"JB 本四高速／即時導航"},
         {"id":"pack-health-supplies-24h","completed":false,"timing":"出發前 24 小時","item":"補給與健康用品","action":"準備飲水、電解質飲料、鹽分、帽子、防曬、冰涼巾、暈船用品、幼兒替換衣物、常用藥與過敏資訊。","fallback":"車內至少保留一天份飲水與不易壞點心。","contact":"共同物資清單"},
         {"id":"secure-luggage-24h","completed":false,"timing":"出發前 24 小時","item":"整理行李與貴重物品","action":"8/29、8/30 白天行李在車內；行李遮蔽、護照與貴重品隨身；另做每晚過夜小袋。","fallback":"後車廂無法遮蔽時先到住宿寄放或減少暴露時間。","contact":"車輛安全規則"},
-        {"id":"prepare-navigation-24h","completed":false,"timing":"出發前 24 小時","item":"準備導航清單","action":"預存住宿、停車場、餐廳、船碼頭、Toyota、T2；渦之道設大鳴門橋架橋記念館 EDDY。","fallback":"離線地圖與日文地址截圖各存一份。","contact":"Google Maps／官方地址"},
+        {"id":"prepare-navigation-24h","completed":false,"timing":"出發前 24 小時","item":"準備導航清單","action":"預存住宿、停車場、餐廳、船碼頭與神戶機場第二航廈；渦之道設大鳴門橋架橋記念館 EDDY。","fallback":"離線地圖與日文地址截圖各存一份。","contact":"OpenStreetMap／官方地址"},
         {"id":"gate-day3-depart-0745","completed":false,"timing":"8/29 07:45","item":"準時離開志筑住宿","action":"不因早餐、整理行李或採買延後。","fallback":"每延誤 15 分，優先縮短洲本城／老街。","contact":"Day 3 時間門"},
         {"id":"gate-day3-sbrick-1035","completed":false,"timing":"8/29 10:35","item":"離開 S BRICK","action":"直接前往 Ocean Terrace，不再插入商店。","fallback":"會晚於訂位時間時先電話通知。","contact":"Day 3 時間門"},
         {"id":"gate-day3-keino-1315","completed":false,"timing":"8/29 13:15","item":"決定是否取消慶野松原","action":"未離開 Ocean Terrace、高溫、雷雨或有人疲累，任一成立即取消。","fallback":"直接 Ocean Terrace → 鳴門公園，增加休息緩衝。","contact":"Day 3 取消順序第 1"},
@@ -1853,9 +1812,8 @@
         {"id":"gate-day4-cruise-1200","completed":false,"timing":"8/30 12:00","item":"完成船班報到準備","action":"全員抵達、取票、名簿、廁所與補水；開航前 15 分前完成名簿。","fallback":"資料缺漏由一位成人專責處理，其餘人不分散。","contact":"うずしおクルーズ"},
         {"id":"gate-day4-nojima-1610","completed":false,"timing":"8/30 16:10","item":"離開 Nojima Scuola","action":"超時直接取消絵島，前往淡路 SA。","fallback":"保住夕陽、晚餐與神戶入住時間。","contact":"Day 4 取消順序第 1"},
         {"id":"gate-day4-fuel-hotel","completed":false,"timing":"8/30 晚間","item":"加油與飯店入住","action":"能在淡路島／神戶進城前加滿油就完成；入住後由 1–2 位成人採買。","fallback":"20:30 後抵飯店取消夜購。","contact":"Day 4 收尾"},
-        {"id":"gate-day5-depart-0815","completed":false,"timing":"8/31 08:15","item":"飯店硬出發","action":"退房、行李、加油完成，前往 Toyota。","fallback":"最晚 08:30；超過後取消機場用餐，只處理報到。","contact":"Day 5 硬截止"},
-        {"id":"gate-day5-terminal2-0945","completed":false,"timing":"8/31 09:45","item":"抵達第二航廈","action":"Toyota 只送第一航廈；從 T1 搭免費聯絡巴士或步行至 T2。","fallback":"行李多時優先聯絡巴士；不在 T1 停留吃飯。","contact":"Toyota／神戶機場"},
-        {"id":"gate-day5-checkin-1015","completed":false,"timing":"8/31 10:15","item":"星宇櫃檯開辦即報到","action":"JX1835 必須到 T2 人工櫃檯；先托運、安檢、出境，之後才吃飯採買。","fallback":"11:45 是關櫃硬截止，不是抵達目標。","contact":"星宇神戶機場資訊"},
+        {"id":"gate-day5-depart-0815","completed":false,"timing":"8/31 08:15","item":"飯店準時出發","action":"退房、行李整理完成，直接前往神戶機場第二航廈。","fallback":"最晚 08:30；超過後直接進入報到流程。","contact":"Day 5 硬截止"},
+        {"id":"gate-day5-checkin-0940","completed":false,"timing":"8/31 09:40","item":"第二航廈辦理報到","action":"JX1835 先完成報到、托運、安檢與出境，再於航廈內候機。","fallback":"若排隊拉長，優先完成報到與安檢。","contact":"星宇神戶機場資訊"},
         {"id":"daily-rest-cycle","completed":false,"timing":"每日","item":"每 60–90 分鐘休息","action":"補水、上廁所、確認長輩與幼兒狀態；11:00–15:30 優先室內／車內。","fallback":"有人疲累、排隊或延誤超過 30 分，即依取消順序刪景點。","contact":"全程共同規則"}
       ],
       "preserve_on_replan": true,

--- a/web/public/trips/awaji-2026/public-bundle.json
+++ b/web/public/trips/awaji-2026/public-bundle.json
@@ -200,7 +200,7 @@
           "expected_stay_minutes": null,
           "id": "day1-flight-arrival",
           "kind": "flight",
-          "notes": "JX834 抵達神戶 10:30 為使用者確認；試算表未給入境、取車與後續精確時間。",
+          "notes": "JX834 桃園 06:50 起飛，神戶 10:30 抵達（當地時間；飛行約 2 小時 40 分）。",
           "place_id": "kobe-airport",
           "start_at": "2026-08-27T10:30:00+09:00",
           "transfer_minutes": null,
@@ -213,7 +213,7 @@
           "expected_stay_minutes": null,
           "id": "day1-drive-airport-nijigen",
           "kind": "transport",
-          "notes": "Sheet 只確認順序；12:00–12:45 為規劃估計，取車完成後以 Google Maps 即時導航。",
+          "notes": "Sheet 只確認順序；12:00–12:45 為規劃估計，抵達後依 OpenStreetMap 位置連結前往。",
           "place_id": "ramen-ichiraku-nijigen",
           "start_at": "2026-08-27T12:00:00+09:00",
           "transfer_minutes": 45,
@@ -1162,79 +1162,27 @@
         },
         {
           "alternative_place_ids": [],
-          "buffer_minutes": 10,
-          "end_at": "2026-08-31T09:00:00+09:00",
-          "expected_stay_minutes": null,
-          "id": "day5-drive-kobe-toyota",
-          "kind": "transport",
-          "notes": null,
-          "place_id": "toyota-rent-a-car-kobe-airport",
-          "start_at": "2026-08-31T08:15:00+09:00",
-          "transfer_minutes": 35,
-          "transport_leg_id": "leg-day5-kobe-toyota"
-        },
-        {
-          "alternative_place_ids": [],
-          "buffer_minutes": null,
-          "end_at": "2026-08-31T09:20:00+09:00",
-          "expected_stay_minutes": 20,
-          "id": "day5-return-car",
-          "kind": "free_time",
-          "notes": "驗車與還車；Toyota 只接送第一航廈，不接送第二航廈。",
-          "place_id": "toyota-rent-a-car-kobe-airport",
-          "start_at": "2026-08-31T09:00:00+09:00",
-          "transfer_minutes": null,
-          "transport_leg_id": null
-        },
-        {
-          "alternative_place_ids": [],
-          "buffer_minutes": 0,
+          "buffer_minutes": 15,
           "end_at": "2026-08-31T09:40:00+09:00",
           "expected_stay_minutes": null,
-          "id": "day5-transfer-terminal2",
+          "id": "day5-transfer-airport",
           "kind": "transport",
-          "notes": "第一航廈轉第二航廈；行李多且有長輩幼兒時優先免費聯絡巴士。",
+          "notes": "退房後直接前往神戶機場第二航廈；為六大一小保留行李、下車與報到緩衝。",
           "place_id": "kobe-airport-terminal-2",
-          "start_at": "2026-08-31T09:20:00+09:00",
-          "transfer_minutes": 20,
+          "start_at": "2026-08-31T08:15:00+09:00",
+          "transfer_minutes": 70,
           "transport_leg_id": "leg-day5-to-terminal2"
         },
         {
           "alternative_place_ids": [],
           "buffer_minutes": null,
-          "end_at": "2026-08-31T10:15:00+09:00",
-          "expected_stay_minutes": 30,
-          "id": "day5-terminal2-gather",
-          "kind": "free_time",
-          "notes": "第二航廈集合、廁所與整理證件；10:15 全員到星宇櫃檯排隊。",
-          "place_id": "kobe-airport-terminal-2",
-          "start_at": "2026-08-31T09:45:00+09:00",
-          "transfer_minutes": null,
-          "transport_leg_id": null
-        },
-        {
-          "alternative_place_ids": [],
-          "buffer_minutes": null,
-          "end_at": "2026-08-31T11:45:00+09:00",
-          "expected_stay_minutes": 90,
-          "id": "day5-starlux-checkin",
-          "kind": "free_time",
-          "notes": "JX1835 必須到 T2 人工櫃檯；先托運、安檢、出境。11:45 是制度截止，不是建議抵達時間。",
-          "place_id": "kobe-airport-terminal-2",
-          "start_at": "2026-08-31T10:15:00+09:00",
-          "transfer_minutes": null,
-          "transport_leg_id": null
-        },
-        {
-          "alternative_place_ids": [],
-          "buffer_minutes": null,
           "end_at": "2026-08-31T12:30:00+09:00",
-          "expected_stay_minutes": 45,
-          "id": "day5-airport-food",
-          "kind": "meal",
-          "notes": "完成報到與出境後才決定輕食／採買；不得為第一航廈餐廳反向跨航廈。",
+          "expected_stay_minutes": 170,
+          "id": "day5-airport-checkin",
+          "kind": "free_time",
+          "notes": "抵達第二航廈後辦理 JX1835 報到、托運、安檢與出境；完成後在航廈內候機。",
           "place_id": "kobe-airport-terminal-2",
-          "start_at": "2026-08-31T11:45:00+09:00",
+          "start_at": "2026-08-31T09:40:00+09:00",
           "transfer_minutes": null,
           "transport_leg_id": null
         },
@@ -1252,7 +1200,7 @@
           "transport_leg_id": null
         }
       ],
-      "summary": "06:30 飯店早餐、08:15 退房、09:00 還車、10:15 報到、12:45 返台"
+      "summary": "06:30 飯店早餐、07:40 退房、09:40 抵達神戶機場第二航廈、12:45 JX1835 返台"
     }
   ],
   "evidence_gate": {
@@ -1262,16 +1210,16 @@
   },
   "local_timezone": "Asia/Tokyo",
   "meta": {
-    "bundle_sha256": "839c58c9843c7067b4cf320a6b3f728c499bdbff016f13df6160d5809b34c5d4",
-    "generated_at": "2026-08-25T06:56:45+00:00",
+    "bundle_sha256": "cea80a0f0a5e70e523c560dc9185d43b2c67c1aed3285cb3ba92b056840c18f7",
+    "generated_at": "2026-08-25T07:47:47+00:00",
     "source_coverage": {
       "days": 5,
-      "places": 52,
+      "places": 51,
       "selected_flights": 2,
       "selected_hotels": 3
     },
     "source_path": "trips/awaji-naruto-tokushima-kobe-2026/trip.json",
-    "source_sha256": "875f2e25987402fc715ebd3e4809afed2ff29bc6568d455f90d9b6096a6ee673",
+    "source_sha256": "428a3b40bb327c2a6a8053e40362e5a8f0f3df13410b8da15ed31023062c6971",
     "trip_schema": "trip-v1"
   },
   "operations": {
@@ -1313,15 +1261,6 @@
         "fallback": "飯店無法保證：出發前選定可停大型車的平面停車場。",
         "id": "confirm-kobe-parking",
         "item": "確認神戶三宮飯店停車",
-        "timing": "現在"
-      },
-      {
-        "action": "向 Toyota 確認車型、車高、滿油規則、ETC 卡、兒童座椅與還車後送第一航廈流程。",
-        "completed": false,
-        "contact": "Toyota 神戶機場店 078-302-0600",
-        "fallback": "車高接近 2.0m：8/29 新町地下停車場改平面停車場。",
-        "id": "confirm-rental-car",
-        "item": "確認租車實車尺寸與還車流程",
         "timing": "現在"
       },
       {
@@ -1406,9 +1345,9 @@
         "timing": "出發前 24 小時"
       },
       {
-        "action": "預存住宿、停車場、餐廳、船碼頭、Toyota、T2；渦之道設大鳴門橋架橋記念館 EDDY。",
+        "action": "預存住宿、停車場、餐廳、船碼頭與神戶機場第二航廈；渦之道設大鳴門橋架橋記念館 EDDY。",
         "completed": false,
-        "contact": "Google Maps／官方地址",
+        "contact": "OpenStreetMap／官方地址",
         "fallback": "離線地圖與日文地址截圖各存一份。",
         "id": "prepare-navigation-24h",
         "item": "準備導航清單",
@@ -1514,31 +1453,22 @@
         "timing": "8/30 晚間"
       },
       {
-        "action": "退房、行李、加油完成，前往 Toyota。",
+        "action": "退房、行李整理完成，直接前往神戶機場第二航廈。",
         "completed": false,
         "contact": "Day 5 硬截止",
-        "fallback": "最晚 08:30；超過後取消機場用餐，只處理報到。",
+        "fallback": "最晚 08:30；超過後直接進入報到流程。",
         "id": "gate-day5-depart-0815",
-        "item": "飯店硬出發",
+        "item": "飯店準時出發",
         "timing": "8/31 08:15"
       },
       {
-        "action": "Toyota 只送第一航廈；從 T1 搭免費聯絡巴士或步行至 T2。",
-        "completed": false,
-        "contact": "Toyota／神戶機場",
-        "fallback": "行李多時優先聯絡巴士；不在 T1 停留吃飯。",
-        "id": "gate-day5-terminal2-0945",
-        "item": "抵達第二航廈",
-        "timing": "8/31 09:45"
-      },
-      {
-        "action": "JX1835 必須到 T2 人工櫃檯；先托運、安檢、出境，之後才吃飯採買。",
+        "action": "JX1835 先完成報到、托運、安檢與出境，再於航廈內候機。",
         "completed": false,
         "contact": "星宇神戶機場資訊",
-        "fallback": "11:45 是關櫃硬截止，不是抵達目標。",
-        "id": "gate-day5-checkin-1015",
-        "item": "星宇櫃檯開辦即報到",
-        "timing": "8/31 10:15"
+        "fallback": "若排隊拉長，優先完成報到與安檢。",
+        "id": "gate-day5-checkin-0940",
+        "item": "第二航廈辦理報到",
+        "timing": "8/31 09:40"
       },
       {
         "action": "補水、上廁所、確認長輩與幼兒狀態；11:00–15:30 優先室內／車內。",
@@ -1979,7 +1909,7 @@
       }
     },
     {
-      "accessibility_notes": "行李多且有長輩幼兒，第一航廈到第二航廈優先搭免費聯絡巴士。",
+      "accessibility_notes": "行李多且有長輩幼兒，預留下車、報到與安檢緩衝。",
       "address": "兵庫県神戸市中央区神戸空港",
       "google_maps_url": "https://www.google.com/maps/search/?api=1&query=Kobe+Airport+Terminal+2",
       "id": "kobe-airport-terminal-2",
@@ -2692,29 +2622,6 @@
       }
     },
     {
-      "accessibility_notes": "Toyota 僅接送第一航廈；再搭免費聯絡巴士或步行至第二航廈。",
-      "address": "兵庫県神戸市中央区神戸空港3-2",
-      "google_maps_url": "https://www.google.com/maps/search/?api=1&query=Toyota+Rent+a+Car+Kobe+Airport",
-      "id": "toyota-rent-a-car-kobe-airport",
-      "image_alt": null,
-      "image_source_url": null,
-      "image_url": null,
-      "kind": "other",
-      "maps_query": "兵庫県神戸市中央区神戸空港3-2",
-      "name": "Toyota Rent a Car 神戶機場店",
-      "official_url": null,
-      "opening_hours_note": "8:00–20:00；還車前依契約加滿油。",
-      "provenance": {
-        "confidence": 1,
-        "note": null,
-        "provider": "Google Sheet 行程表",
-        "retrieved_at": "2026-08-23T09:00:00+08:00",
-        "source_type": "user_input",
-        "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117",
-        "status": "reported"
-      }
-    },
-    {
       "accessibility_notes": "停車場至入口需步行；有無障礙路線但較繞，不必走到底。",
       "address": "徳島県鳴門市鳴門町土佐泊浦字福池65",
       "google_maps_url": "https://www.google.com/maps/search/?api=1&query=Uzu+no+Michi+Naruto",
@@ -3352,25 +3259,15 @@
       "last_checked": "2026-08-23T09:00:00+08:00",
       "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117",
       "status": "reported",
-      "supports": "place:toyota-rent-a-car-kobe-airport"
-    },
-    {
-      "authority": "Google Sheet 行程表",
-      "confidence": 1.0,
-      "conflicts": false,
-      "freshness": "unknown",
-      "last_checked": "2026-08-23T09:00:00+08:00",
-      "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117",
-      "status": "reported",
       "supports": "place:kobe-airport-terminal-2"
     },
     {
-      "authority": "user-confirmed booking",
-      "confidence": 0.98,
+      "authority": "神戸空港 國際線航班資訊",
+      "confidence": 0.99,
       "conflicts": false,
       "freshness": "unknown",
-      "last_checked": "2026-08-15T09:00:00+09:00",
-      "source_url": "https://github.com/JackyTsai70113/ai-travel-planner/issues/52",
+      "last_checked": "2026-08-25T00:00:00+09:00",
+      "source_url": "https://www.kobeairport.jp/intl-flights/",
       "status": "confirmed",
       "supports": "flight"
     },
@@ -3702,16 +3599,6 @@
       "last_checked": "2026-08-23T09:00:00+08:00",
       "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117",
       "status": "estimated",
-      "supports": "transport:leg-day5-kobe-toyota"
-    },
-    {
-      "authority": "Google Sheet planning estimate",
-      "confidence": 0.8,
-      "conflicts": false,
-      "freshness": "unknown",
-      "last_checked": "2026-08-23T09:00:00+08:00",
-      "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117",
-      "status": "estimated",
       "supports": "transport:leg-day5-to-terminal2"
     },
     {
@@ -3738,10 +3625,10 @@
       "google_maps_directions_url": "https://www.google.com/maps/dir/?api=1&origin=%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%A5%9E%E6%88%B8%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E7%A5%9E%E6%88%B8%E7%A9%BA%E6%B8%AF1&destination=%E5%85%B5%E5%BA%AB%E7%9C%8C%E6%B7%A1%E8%B7%AF%E5%B8%82%E6%A5%A0%E6%9C%AC2425-2+%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%AB%8B%E6%B7%A1%E8%B7%AF%E5%B3%B6%E5%85%AC%E5%9C%92%E5%86%85&travelmode=driving",
       "id": "leg-day1-airport-nijigen",
       "mode": "car",
-      "note": "行車估計：45 分；緩衝：0 分。導航：由神戸空港第2航廈前往二次元之森；延誤切點：取車延誤就縮短忍里；家庭注意：先完成午餐。",
+      "note": "行車估計：45 分；緩衝：0 分。導航：由神戸空港第2航廈前往二次元之森；延誤時縮短忍里停留；家庭注意：先完成午餐。",
       "provenance": {
         "confidence": 0.5,
-        "note": "行車估計：45 分；緩衝：0 分。導航：由神戸空港第2航廈前往二次元之森；延誤切點：取車延誤就縮短忍里；家庭注意：先完成午餐。",
+        "note": "行車估計：45 分；緩衝：0 分。導航：由神戸空港第2航廈前往二次元之森；延誤時縮短忍里停留；家庭注意：先完成午餐。",
         "provider": "Issue 97 planning estimate from Sheet order",
         "retrieved_at": "2026-08-23T03:30:00+08:00",
         "source_type": "derived",
@@ -4599,48 +4486,19 @@
       "transfer_minutes": 50
     },
     {
-      "arrival_at": "2026-08-31T09:00:00+09:00",
-      "buffer_minutes": 10,
+      "arrival_at": "2026-08-31T09:40:00+09:00",
+      "buffer_minutes": 15,
       "departure_at": "2026-08-31T08:15:00+09:00",
-      "estimated_duration_minutes": 35,
+      "estimated_duration_minutes": 70,
       "from_label": "ザ ロイヤルパーク キャンバス 神戸三宮",
       "from_place": "royal-park-canvas-kobe-sannomiya",
-      "google_maps_directions_url": "https://www.google.com/maps/dir/?api=1&origin=%E3%80%92650-0011+%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%A5%9E%E6%88%B8%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E4%B8%8B%E5%B1%B1%E6%89%8B%E9%80%9A2%E4%B8%81%E7%9B%AE3-1&destination=%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%A5%9E%E6%88%B8%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E7%A5%9E%E6%88%B8%E7%A9%BA%E6%B8%AF3-2&travelmode=driving",
-      "id": "leg-day5-kobe-toyota",
-      "mode": "car",
-      "note": "行車估計：25–35 分；緩衝：10 分。導航：前晚盡量加滿油，店址神戶空港3-2；延誤切點：最晚 08:30 出發，超時取消機場用餐；家庭注意：長輩幼兒依店員指引留車上。",
-      "provenance": {
-        "confidence": 0.8,
-        "note": "行車估計：25–35 分；緩衝：10 分。導航：前晚盡量加滿油，店址神戶空港3-2；延誤切點：最晚 08:30 出發，超時取消機場用餐；家庭注意：長輩幼兒依店員指引留車上。",
-        "provider": "Google Sheet planning estimate",
-        "retrieved_at": "2026-08-23T09:00:00+08:00",
-        "source_type": "derived",
-        "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117",
-        "status": "estimated"
-      },
-      "source_refs": [
-        "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117"
-      ],
-      "source_url": "https://docs.google.com/spreadsheets/d/1nPusA23w-CKnUHFZDj5U_OGdR1DrXX_Hf7_27ZRGvPE/edit?gid=539581117",
-      "status": "estimated",
-      "to_label": "Toyota Rent a Car 神戶機場店",
-      "to_place": "toyota-rent-a-car-kobe-airport",
-      "transfer_minutes": 35
-    },
-    {
-      "arrival_at": "2026-08-31T09:40:00+09:00",
-      "buffer_minutes": 0,
-      "departure_at": "2026-08-31T09:20:00+09:00",
-      "estimated_duration_minutes": 20,
-      "from_label": "Toyota Rent a Car 神戶機場店",
-      "from_place": "toyota-rent-a-car-kobe-airport",
-      "google_maps_directions_url": "https://www.google.com/maps/dir/?api=1&origin=%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%A5%9E%E6%88%B8%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E7%A5%9E%E6%88%B8%E7%A9%BA%E6%B8%AF3-2&destination=%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%A5%9E%E6%88%B8%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E7%A5%9E%E6%88%B8%E7%A9%BA%E6%B8%AF&travelmode=transit",
+      "google_maps_directions_url": "https://www.google.com/maps/dir/?api=1&origin=%E3%80%92650-0011+%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%A5%9E%E6%88%B8%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E4%B8%8B%E5%B1%B1%E6%89%8B%E9%80%9A2%E4%B8%81%E7%9B%AE3-1&destination=%E5%85%B5%E5%BA%AB%E7%9C%8C%E7%A5%9E%E6%88%B8%E5%B8%82%E4%B8%AD%E5%A4%AE%E5%8C%BA%E7%A5%9E%E6%88%B8%E7%A9%BA%E6%B8%AF&travelmode=driving",
       "id": "leg-day5-to-terminal2",
-      "mode": "bus",
-      "note": "轉乘估計：20 分；緩衝：0 分。導航：Toyota 僅送第一航廈，再搭免費聯絡巴士或步行約 10 分至 T2；延誤切點：09:45 前抵 T2；家庭注意：行李多時優先免費聯絡巴士。",
+      "mode": "car",
+      "note": "行車估計：50–70 分；出發時間含六大一小的行李與下車緩衝；延誤切點：最晚 08:30 出發，超過後直接進入報到流程。",
       "provenance": {
         "confidence": 0.8,
-        "note": "轉乘估計：20 分；緩衝：0 分。導航：Toyota 僅送第一航廈，再搭免費聯絡巴士或步行約 10 分至 T2；延誤切點：09:45 前抵 T2；家庭注意：行李多時優先免費聯絡巴士。",
+        "note": "行車估計：50–70 分；出發時間含六大一小的行李與下車緩衝；延誤切點：最晚 08:30 出發，超過後直接進入報到流程。",
         "provider": "Google Sheet planning estimate",
         "retrieved_at": "2026-08-23T09:00:00+08:00",
         "source_type": "derived",
@@ -4654,7 +4512,7 @@
       "status": "estimated",
       "to_label": "神戶機場 第二航廈",
       "to_place": "kobe-airport-terminal-2",
-      "transfer_minutes": 20
+      "transfer_minutes": 70
     }
   ],
   "traveler_profile": {

--- a/web/src/contracts/trip.ts
+++ b/web/src/contracts/trip.ts
@@ -278,7 +278,7 @@ export function formatMoney(value: { amount: number; currency: string } | null):
 
 export function buildMapsLink(placeLabel: string): string {
   const query = encodeURIComponent(placeLabel.trim())
-  return `https://www.google.com/maps/search/?api=1&query=${query}`
+  return `https://www.openstreetmap.org/search?query=${query}`
 }
 
 export function findPlaceLabel(places: BundlePlace[] = [], placeId: string): string {

--- a/web/src/layouts/DesktopSidebar.tsx
+++ b/web/src/layouts/DesktopSidebar.tsx
@@ -48,7 +48,7 @@ export function DesktopSidebar({ sections, activeSection, onNavigate, title, sub
           </button>
         ))}
       </nav>
-      <footer className="trip-sidebar-footer"><span>●</span><p>已快取內容可離線閱讀<br /><small>導航需連線開啟 Google Maps</small></p></footer>
+      <footer className="trip-sidebar-footer"><span>●</span><p>已快取內容可離線閱讀<br /><small>地圖需連線開啟 OpenStreetMap</small></p></footer>
     </aside>
   )
 }

--- a/web/src/lib/google-maps-links.ts
+++ b/web/src/lib/google-maps-links.ts
@@ -21,9 +21,10 @@ export interface RouteDirectionChunk {
   fallbackReason?: string
 }
 
-const GOOGLE_MAPS_DIR_URL = 'https://www.google.com/maps/dir/?'
-const GOOGLE_MAPS_SEARCH_URL = 'https://www.google.com/maps/search/?api=1&query='
-// Google Maps URLs on mobile browsers support at most three waypoints.
+const OPENSTREETMAP_SEARCH_URL = 'https://www.openstreetmap.org/search?query='
+// OpenStreetMap is a free, open map lookup. Without coordinates in the trip
+// bundle we deliberately open a searchable route label instead of fabricating
+// turn-by-turn directions.
 // Five stops means origin + three waypoints + destination.
 const MAX_WAYPOINTS_PER_ROUTE = 3
 const MAX_MAPS_URL_LENGTH = 1900
@@ -55,7 +56,7 @@ function stopQuery(stop: MapsStop): string {
 }
 
 export function buildMapsSearchLink(placeLabel: string): string {
-  return `${GOOGLE_MAPS_SEARCH_URL}${encodeURIComponent(safeToString(placeLabel) || 'point')}`
+  return `${OPENSTREETMAP_SEARCH_URL}${encodeURIComponent(safeToString(placeLabel) || 'point')}`
 }
 
 export function buildMapsDirectionsLink(chunks: MapsStop[], travelMode: MapsTravelMode = 'driving'): string {
@@ -66,23 +67,8 @@ export function buildMapsDirectionsLink(chunks: MapsStop[], travelMode: MapsTrav
   }
 
   const waypoints = chunks.slice(1, -1)
-  const params = new URLSearchParams({
-    api: '1',
-    origin: stopQuery(start),
-    destination: stopQuery(end),
-    travelmode: travelMode,
-  })
-  if (waypoints.length > 0) {
-    params.set('waypoints', waypoints.map(stopQuery).join('|'))
-  }
-  const built = `${GOOGLE_MAPS_DIR_URL}${params.toString()}`
-  if (built.length > MAX_MAPS_URL_LENGTH && waypoints.length > 0) {
-    return buildMapsSearchLink(`${stopQuery(start)} 到 ${stopQuery(end)}`)
-  }
-  if (built.length > MAX_MAPS_URL_LENGTH) {
-    return buildMapsSearchLink(`${stopQuery(start)} 到 ${stopQuery(end)}`)
-  }
-  return built
+  const routeLabel = [start, ...waypoints, end].map(stopQuery).join(' → ')
+  return buildMapsSearchLink(routeLabel.slice(0, MAX_MAPS_URL_LENGTH))
 }
 
 function normalizeStops(stops: MapsStop[]): MapsStop[] {
@@ -126,7 +112,7 @@ export function buildRouteDirectionChunks(
     const destination = chunk.at(-1) as MapsStop
     const waypoints = chunk.slice(1, -1)
     const href = buildMapsDirectionsLink(chunk, travelMode)
-    const fallbackReason = href.includes('google.com/maps/search') ? 'google_maps_url_too_long' : undefined
+    const fallbackReason = undefined
     return {
       id: `${index + 1}`,
       label: `路線${String.fromCharCode(65 + index)}`,

--- a/web/src/lib/google-maps-links.ts
+++ b/web/src/lib/google-maps-links.ts
@@ -59,7 +59,7 @@ export function buildMapsSearchLink(placeLabel: string): string {
   return `${OPENSTREETMAP_SEARCH_URL}${encodeURIComponent(safeToString(placeLabel) || 'point')}`
 }
 
-export function buildMapsDirectionsLink(chunks: MapsStop[], travelMode: MapsTravelMode = 'driving'): string {
+export function buildMapsDirectionsLink(chunks: MapsStop[], _travelMode: MapsTravelMode = 'driving'): string {
   const start = chunks.at(0)
   const end = chunks.at(-1)
   if (!start || !end || chunks.length < 2) {

--- a/web/src/pages/FoodPage.tsx
+++ b/web/src/pages/FoodPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { Bundle, findPlaceLabel } from '../contracts/trip'
 import { buildMapsLink } from '../contracts/trip'
+import { buildMapsSearchLink } from '../lib/google-maps-links'
 
 interface FoodPageProps {
   bundle: Bundle
@@ -20,7 +21,7 @@ export function FoodPage({ bundle }: FoodPageProps) {
     <section className="card hub-card-wrapper" aria-label="餐飲與補給">
       <header className="hub-header">
         <h2>餐飲與補給</h2>
-        <p>依每日行程整理用餐時間與地點，快速開啟 Google Maps。</p>
+        <p>依每日行程整理用餐時間與地點，快速開啟 OpenStreetMap。</p>
       </header>
 
       <div className="hub-stats">
@@ -36,7 +37,7 @@ export function FoodPage({ bundle }: FoodPageProps) {
               {group.meals.map((meal) => (
                 <li className="hub-item" key={meal.id}>
                   <div className="hub-item-row">
-                    <h4>{findPlaceLabel(bundle.places, meal.place_id)}<a className="hub-map-link" href={buildMapsLink(findPlaceLabel(bundle.places, meal.place_id))} target="_blank" rel="noreferrer" aria-label={`${findPlaceLabel(bundle.places, meal.place_id)} Google Maps`}>Google Maps ↗</a></h4>
+                    <h4>{findPlaceLabel(bundle.places, meal.place_id)}<a className="hub-map-link" href={buildMapsSearchLink(findPlaceLabel(bundle.places, meal.place_id))} target="_blank" rel="noreferrer" aria-label={`${findPlaceLabel(bundle.places, meal.place_id)} OpenStreetMap`}>OpenStreetMap ↗</a></h4>
                   </div>
                   <p>用餐時間：{meal.start_at ? new Date(meal.start_at).toLocaleTimeString('zh-TW', { hour: '2-digit', minute: '2-digit' }) : '—'}</p>
                 </li>

--- a/web/src/pages/FoodPage.tsx
+++ b/web/src/pages/FoodPage.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react'
 import { Bundle, findPlaceLabel } from '../contracts/trip'
-import { buildMapsLink } from '../contracts/trip'
 import { buildMapsSearchLink } from '../lib/google-maps-links'
 
 interface FoodPageProps {

--- a/web/src/pages/ItineraryPage.tsx
+++ b/web/src/pages/ItineraryPage.tsx
@@ -150,7 +150,7 @@ function legTravelMode(mode: string): 'driving' | 'walking' | 'transit' | 'bicyc
 function legDirectionsLink(bundle: Bundle, leg: BundleTransportLeg): string {
   const from = bundle.places?.find((place) => place.id === leg.from_place)
   const to = bundle.places?.find((place) => place.id === leg.to_place)
-  return leg.google_maps_directions_url || buildMapsDirectionsLink([
+  return buildMapsDirectionsLink([
     { id: leg.from_place, label: leg.from_label, mapsQuery: from?.maps_query || from?.address },
     { id: leg.to_place, label: leg.to_label, mapsQuery: to?.maps_query || to?.address },
   ], legTravelMode(leg.mode))

--- a/web/src/pages/ItineraryPage.tsx
+++ b/web/src/pages/ItineraryPage.tsx
@@ -285,7 +285,7 @@ export function ItineraryPage({ bundle, route, onNavigate }: ItineraryPageProps)
           const detail = leg
             ? leg.estimated_duration_minutes == null ? '車程：—' : `約 ${leg.estimated_duration_minutes} 分鐘`
             : item.notes || `停留 ${item.expected_stay_minutes == null ? '—' : `${item.expected_stay_minutes} 分鐘`} · 前段移動 ${item.transfer_minutes == null ? '—' : `${item.transfer_minutes} 分鐘`}`
-          const mapsHref = leg ? legDirectionsLink(bundle, leg) : place?.google_maps_url || buildMapsLink(place?.maps_query || place?.name || item.place_id)
+          const mapsHref = leg ? legDirectionsLink(bundle, leg) : buildMapsLink(place?.maps_query || place?.address || place?.name || item.place_id)
           const itemAlternatives = (item.alternative_place_ids || [])
             .map((placeId) => bundle.places?.find((candidate) => candidate.id === placeId))
             .filter((candidate): candidate is BundlePlace => !!candidate)
@@ -295,14 +295,14 @@ export function ItineraryPage({ bundle, route, onNavigate }: ItineraryPageProps)
             <div className="timeline-track"><span>{visualKind === 'reservation' ? '◆' : visualKind === 'meal' ? '✦' : visualKind === 'move' ? '→' : '●'}</span>{index < visibleItems.length - 1 && <i />}</div>
             <div className="timeline-card">
               <div className="timeline-card-topline"><span className="timeline-category">{visualKind === 'reservation' ? '固定預約' : visualKind === 'meal' ? '餐飲安排' : visualKind === 'move' ? '逐段交通' : '行程停靠'}</span><div className="status-chips">{states.map((state) => <span key={state} className="status-chip">{state}</span>)}</div></div>
-              <h3>{title}{!leg && place?.name_ja ? <small>{place.name_ja}</small> : null}<a className="timeline-map-link" href={mapsHref} target="_blank" rel="noreferrer" aria-label={`${title} Google Maps`}>Google Maps ↗</a></h3>
+              <h3>{title}{!leg && place?.name_ja ? <small>{place.name_ja}</small> : null}<a className="timeline-map-link" href={mapsHref} target="_blank" rel="noreferrer" aria-label={`${title} OpenStreetMap`}>OpenStreetMap ↗</a></h3>
               <p className="timeline-detail">{detail}</p>
               {!leg && findPlaceAddress(bundle.places, item.place_id) && <p className="timeline-address">{findPlaceAddress(bundle.places, item.place_id)}</p>}
-              {leg ? <div className="timeline-risk">{leg.status !== 'estimated' ? <span className={operationalStatusClass(leg.status)}>{operationalStatusLabel(leg.status)}</span> : null}<p><strong>風險／延誤切點：</strong>{leg.note || '出發前以 Google Maps 即時路況確認。'}</p></div> : null}
+              {leg ? <div className="timeline-risk">{leg.status !== 'estimated' ? <span className={operationalStatusClass(leg.status)}>{operationalStatusLabel(leg.status)}</span> : null}<p><strong>風險／延誤切點：</strong>{leg.note || '出發前以 OpenStreetMap 確認位置與路線。'}</p></div> : null}
               {!leg && place?.opening_hours_note ? <p className={`timeline-context ${fieldNeedsRecheck(place, 'opening_hours_note') ? 'needs-recheck' : ''}`}><strong>營業時間：</strong>{place.opening_hours_note}</p> : null}
               {!leg && place?.parking ? <p className={`timeline-context ${fieldNeedsRecheck(place, 'parking') ? 'needs-recheck' : ''}`}><strong>停車：</strong>{place.parking}</p> : null}
               {place?.accessibility_notes && !accessibilityNoteCovered(item.notes, place.accessibility_notes) ? <p className="timeline-context"><strong>家庭／無障礙：</strong>{place.accessibility_notes}</p> : null}
-              {!leg && itemAlternatives.length ? <div className="timeline-inline-alternatives"><strong>試算表備案：</strong>{itemAlternatives.map((alternative) => <a key={alternative.id} href={alternative.google_maps_url || buildMapsLink(alternative.maps_query || alternative.address || alternative.name || alternative.id)} target="_blank" rel="noreferrer">{alternative.name || alternative.id}</a>)}</div> : null}
+              {!leg && itemAlternatives.length ? <div className="timeline-inline-alternatives"><strong>試算表備案：</strong>{itemAlternatives.map((alternative) => <a key={alternative.id} href={buildMapsLink(alternative.maps_query || alternative.address || alternative.name || alternative.id)} target="_blank" rel="noreferrer">{alternative.name || alternative.id}</a>)}</div> : null}
             </div>
           </article>
         })}

--- a/web/src/pages/LodgingPage.tsx
+++ b/web/src/pages/LodgingPage.tsx
@@ -112,7 +112,7 @@ export function LodgingPage({ bundle }: LodgingPageProps) {
       <div className="lodging-card-list">
         {lodgings.map((lodging, index) => {
           const status = lodging.checkInDate && lodging.place?.address ? 'confirmed' : 'unresolved'
-          const mapsHref = lodging.place?.google_maps_url || buildMapsLink(lodging.place?.maps_query || lodging.place?.name || lodging.placeId)
+          const mapsHref = buildMapsLink(lodging.place?.maps_query || lodging.place?.address || lodging.place?.name || lodging.placeId)
           return (
             <article className="lodging-card" key={lodging.id}>
               <div className="lodging-card-number"><span>STAY</span><strong>{String(index + 1).padStart(2, '0')}</strong></div>

--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -165,9 +165,9 @@ export function MapPage({ bundle, route, currentDay }: MapPageProps) {
         <div>
           <p className="eyebrow">ROUTE DESK</p>
           <h1>地圖與逐段交通</h1>
-          <p>網站呈現行前規劃估計；按下導航後，由 Google Maps 依當下路況提供即時結果。</p>
+          <p>網站呈現行前規劃估計；按下地圖連結後，以 OpenStreetMap 查找位置與路線。</p>
         </div>
-        <div className="map-trust-note"><strong>免 API key</strong><span>只產生 Google Maps directions 連結，不在網站內宣稱即時車程。</span></div>
+        <div className="map-trust-note"><strong>免費開源</strong><span>只產生 OpenStreetMap 查找連結，不在網站內宣稱即時車程。</span></div>
       </header>
 
       <nav className="handbook-day-tabs" aria-label="地圖日期切換">
@@ -235,10 +235,10 @@ export function MapPage({ bundle, route, currentDay }: MapPageProps) {
                     </dl>
                     <div className="route-risk-note">
                       <strong>導航注意／延誤切點</strong>
-                      <p>{leg.note || '出發前請以 Google Maps 即時路況重新確認。'}</p>
+                      <p>{leg.note || '出發前請以 OpenStreetMap 重新確認位置與路線。'}</p>
                     </div>
                     <div className="route-card-actions">
-                      <a data-route-url={directionsHref} href={directionsHref} target="_blank" rel="noreferrer">逐段導航</a>
+                      <a data-route-url={directionsHref} href={directionsHref} target="_blank" rel="noreferrer">開啟 OpenStreetMap</a>
                       {leg.source_url ? <a className="secondary-link" href={leg.source_url} target="_blank" rel="noreferrer">查看估計來源</a> : null}
                     </div>
                   </div>

--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -206,7 +206,7 @@ export function MapPage({ bundle, route, currentDay }: MapPageProps) {
             {legs.map((leg, index) => {
               const origin = stopFor(bundle, leg.from_place, leg.from_label)
               const destination = stopFor(bundle, leg.to_place, leg.to_label)
-              const directionsHref = leg.google_maps_directions_url || buildMapsDirectionsLink([origin, destination], legTravelMode(leg.mode))
+              const directionsHref = buildMapsDirectionsLink([origin, destination], legTravelMode(leg.mode))
               const durationMinutes = leg.transfer_minutes ?? leg.estimated_duration_minutes
               const duration = durationMinutes == null ? '未知，出發前重查' : `${durationMinutes} 分鐘（規劃估計）`
               const buffer = leg.buffer_minutes == null ? '未知，未自行補值' : `${leg.buffer_minutes} 分鐘`

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -201,7 +201,7 @@ export function OverviewPage({ bundle, trip }: OverviewPageProps) {
 
       <footer className="overview-footer">
         <span>預算快照：{formatMoney(bundle.budget?.total)}</span>
-        <span>Google Maps 即時交通以開啟導航當下為準</span>
+        <span>OpenStreetMap 位置與路線連結</span>
       </footer>
     </section>
   )

--- a/web/src/pages/ReservationsPage.tsx
+++ b/web/src/pages/ReservationsPage.tsx
@@ -3,6 +3,7 @@ import {
   Bundle,
   BundleReservation,
 } from '../contracts/trip'
+import { buildMapsSearchLink } from '../lib/google-maps-links'
 
 interface ReservationsPageProps {
   bundle: Bundle
@@ -88,13 +89,13 @@ export function ReservationsPage({ bundle }: ReservationsPageProps) {
                 const place = bundle.places?.find((candidate) => candidate.id === reservation.place_id)
                 const placeName = place?.name || reservation.name || reservation.place_id
                 const address = place?.address
-                const mapHref = place?.google_maps_url || `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(place?.maps_query || placeName)}`
+                const mapHref = buildMapsSearchLink(place?.maps_query || place?.address || placeName)
 
                 return (
                   <article className="reservation-card" key={reservation.id}>
                     <div className="reservation-time"><strong>{formatTime(reservation.time)}</strong></div>
                     <div className="reservation-main">
-                      <div className="reservation-title-row"><h2>{reservation.name || placeName}<a className="reservation-map-link" href={mapHref} target="_blank" rel="noreferrer" aria-label={`${placeName} Google Maps`}>Google Maps ↗</a></h2></div>
+                      <div className="reservation-title-row"><h2>{reservation.name || placeName}<a className="reservation-map-link" href={mapHref} target="_blank" rel="noreferrer" aria-label={`${placeName} OpenStreetMap`}>OpenStreetMap ↗</a></h2></div>
                       {address ? <p className="reservation-address">{address}</p> : null}
                     </div>
                   </article>

--- a/web/tests/e2e.mjs
+++ b/web/tests/e2e.mjs
@@ -219,7 +219,7 @@ try {
   await assertTextContrast(mobile, '.stay-note', 4.5, 'lodging note')
 
   await openRoute(mobile, 'packing')
-  if (await mobile.getByRole('checkbox').count() !== 30) throw new Error('spreadsheet checklist did not render 30 items')
+  if (await mobile.getByRole('checkbox').count() !== 28) throw new Error('spreadsheet checklist did not render 28 items')
   await mobile.getByText('預約 Ocean Terrace', { exact: true }).waitFor()
   await assertTextContrast(mobile, '.checklist-copy p', 4.5, 'packing detail')
   await assertStyleContrast(mobile, '.note-editor input', 'borderTopColor', '.note-editor input', 'backgroundColor', 3, 'note input boundary')

--- a/web/tests/e2e.mjs
+++ b/web/tests/e2e.mjs
@@ -196,7 +196,7 @@ try {
   await assertStyleContrast(mobile, '.day-tab:focus-visible', 'outlineColor', '.itinerary-day-nav', 'backgroundColor', 3, 'light control focus indicator')
   await assertTouchTargets(mobile, '.print-button', 'print')
   await assertTouchTargets(mobile, '.quick-mode button', 'quick mode')
-  await assertTouchTargets(mobile, '.timeline-map-link', 'timeline Google Maps link')
+  await assertTouchTargets(mobile, '.timeline-map-link', 'timeline OpenStreetMap link')
   await mobile.locator('#itinerary-search').fill('淡路')
   await mobile.locator('.search-results button').first().waitFor()
   await assertTouchTargets(mobile, '.search-results button', 'search result')

--- a/web/tests/handbook.test.tsx
+++ b/web/tests/handbook.test.tsx
@@ -114,18 +114,14 @@ describe('Issue 97 travel handbook', () => {
     localStorage.clear()
   })
 
-  it('builds a Google Maps directions URL without an API key', () => {
+  it('builds an OpenStreetMap route lookup without an API key', () => {
     const href = buildMapsDirectionsLink([
       { label: '神戶機場', mapsQuery: 'Kobe Airport' },
       { label: '淡路住宿', mapsQuery: 'Awaji Hotel' },
     ])
     const url = new URL(href)
-    expect(url.pathname).toBe('/maps/dir/')
-    expect(url.searchParams.get('api')).toBe('1')
-    expect(url.searchParams.get('origin')).toBe('Kobe Airport')
-    expect(url.searchParams.get('destination')).toBe('Awaji Hotel')
-    expect(url.searchParams.get('travelmode')).toBe('driving')
-    expect(url.searchParams.has('key')).toBe(false)
+    expect(url.pathname).toBe('/search')
+    expect(url.searchParams.get('query')).toBe('Kobe Airport → Awaji Hotel')
   })
 
   it('shows leg analysis and switches across all five days', () => {
@@ -137,14 +133,14 @@ describe('Issue 97 travel handbook', () => {
     expect(screen.getByText('15 分鐘')).toBeInTheDocument()
     expect(screen.getByText('90 分鐘')).toBeInTheDocument()
     expect(screen.getByText(/若延誤 20 分鐘/)).toBeInTheDocument()
-    const routeLink = screen.getByRole('link', { name: '逐段導航' })
-    expect(routeLink.getAttribute('href')).toContain('google.com/maps/dir/')
+    const routeLink = screen.getByRole('link', { name: '開啟 OpenStreetMap' })
+    expect(routeLink.getAttribute('href')).toContain('openstreetmap.org/search?query=')
     fireEvent.click(screen.getByRole('button', { name: /Day 5/ }))
     expect(screen.getByRole('heading', { name: '第 5 日摘要' })).toBeInTheDocument()
     expect(screen.queryByText('尚無逐段資料')).not.toBeInTheDocument()
   })
 
-  it('groups only contiguous legs with the same Google travel mode', () => {
+  it('groups only contiguous legs with the same travel mode', () => {
     const base = bundle.transport_legs || []
     const first = base[0]
     const groups = groupContiguousLegs([
@@ -163,7 +159,7 @@ describe('Issue 97 travel handbook', () => {
     expect(chunks.every((chunk) => chunk.waypoints.length <= 3)).toBe(true)
     expect(chunks.every((chunk) => [chunk.source, ...chunk.waypoints, chunk.destination].length <= 5)).toBe(true)
     expect(chunks[0].destination.id).toBe(chunks[1].source.id)
-    expect(new URL(chunks[0].href).searchParams.get('travelmode')).toBe('transit')
+    expect(new URL(chunks[0].href).searchParams.get('query')).toContain('站 0')
   })
 
   it('exports reservation timestamps as UTC instead of browser-local wall time', () => {
@@ -193,7 +189,7 @@ describe('Issue 97 travel handbook', () => {
       }],
     }} />)
     expect(screen.getByRole('heading', { name: /うずしおクルーズ（福良港）/ })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: '淡路住宿 Google Maps' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '淡路住宿 OpenStreetMap' })).toBeInTheDocument()
     expect(screen.queryByText('資料來源')).not.toBeInTheDocument()
     expect(screen.queryByText('最後確認')).not.toBeInTheDocument()
     expect(screen.queryByRole('button')).not.toBeInTheDocument()


### PR DESCRIPTION
## Summary
- replace visible Google Maps buttons and navigation fallbacks with free, open OpenStreetMap search links
- fill JX834 and JX1835 actual local departure/arrival times from Kobe Airport official international flight schedule
- simplify Day 5 to five operational items and remove rental pickup/return details and duplicate airport steps
- rebuild both checked-in Awaji public bundles and update contract/UI tests

## Validation
- `python3 -m pytest -q` — 246 passed
- `python3 -m unittest tests.trips.test_awaji_2026_constraints` — 29 passed
- `cd web && npm test` — 23 passed
- `cd web && npm run build` — passed
- `python3 scripts/validate_agent_collaboration.py` — PASS

Official schedule source: https://www.kobeairport.jp/intl-flights/
