### PR TITLE
改用 Google Maps 圖示並精簡景點操作

### DIFF
--- a/web/src/contracts/trip.ts
+++ b/web/src/contracts/trip.ts
@@ -278,7 +278,7 @@ export function formatMoney(value: { amount: number; currency: string } | null):
 
 export function buildMapsLink(placeLabel: string): string {
   const query = encodeURIComponent(placeLabel.trim())
-  return `https://www.openstreetmap.org/search?query=${query}`
+  return `https://www.google.com/maps/search/?api=1&query=${query}`
 }
 
 export function findPlaceLabel(places: BundlePlace[] = [], placeId: string): string {

--- a/web/src/layouts/DesktopSidebar.tsx
+++ b/web/src/layouts/DesktopSidebar.tsx
@@ -48,7 +48,7 @@ export function DesktopSidebar({ sections, activeSection, onNavigate, title, sub
           </button>
         ))}
       </nav>
-      <footer className="trip-sidebar-footer"><span>●</span><p>已快取內容可離線閱讀<br /><small>地圖需連線開啟 OpenStreetMap</small></p></footer>
+      <footer className="trip-sidebar-footer"><span>●</span><p>已快取內容可離線閱讀<br /><small>地圖需連線開啟 Google Maps</small></p></footer>
     </aside>
   )
 }

--- a/web/src/lib/google-maps-links.ts
+++ b/web/src/lib/google-maps-links.ts
@@ -21,10 +21,8 @@ export interface RouteDirectionChunk {
   fallbackReason?: string
 }
 
-const OPENSTREETMAP_SEARCH_URL = 'https://www.openstreetmap.org/search?query='
-// OpenStreetMap is a free, open map lookup. Without coordinates in the trip
-// bundle we deliberately open a searchable route label instead of fabricating
-// turn-by-turn directions.
+const GOOGLE_MAPS_DIR_URL = 'https://www.google.com/maps/dir/?'
+const GOOGLE_MAPS_SEARCH_URL = 'https://www.google.com/maps/search/?api=1&query='
 // Five stops means origin + three waypoints + destination.
 const MAX_WAYPOINTS_PER_ROUTE = 3
 const MAX_MAPS_URL_LENGTH = 1900
@@ -56,10 +54,10 @@ function stopQuery(stop: MapsStop): string {
 }
 
 export function buildMapsSearchLink(placeLabel: string): string {
-  return `${OPENSTREETMAP_SEARCH_URL}${encodeURIComponent(safeToString(placeLabel) || 'point')}`
+  return `${GOOGLE_MAPS_SEARCH_URL}${encodeURIComponent(safeToString(placeLabel) || 'point')}`
 }
 
-export function buildMapsDirectionsLink(chunks: MapsStop[], _travelMode: MapsTravelMode = 'driving'): string {
+export function buildMapsDirectionsLink(chunks: MapsStop[], travelMode: MapsTravelMode = 'driving'): string {
   const start = chunks.at(0)
   const end = chunks.at(-1)
   if (!start || !end || chunks.length < 2) {
@@ -67,8 +65,10 @@ export function buildMapsDirectionsLink(chunks: MapsStop[], _travelMode: MapsTra
   }
 
   const waypoints = chunks.slice(1, -1)
-  const routeLabel = [start, ...waypoints, end].map(stopQuery).join(' → ')
-  return buildMapsSearchLink(routeLabel.slice(0, MAX_MAPS_URL_LENGTH))
+  const params = new URLSearchParams({ api: '1', origin: stopQuery(start), destination: stopQuery(end), travelmode: travelMode })
+  if (waypoints.length > 0) params.set('waypoints', waypoints.map(stopQuery).join('|'))
+  const built = `${GOOGLE_MAPS_DIR_URL}${params.toString()}`
+  return built.length <= MAX_MAPS_URL_LENGTH ? built : buildMapsSearchLink(`${stopQuery(start)} 到 ${stopQuery(end)}`)
 }
 
 function normalizeStops(stops: MapsStop[]): MapsStop[] {

--- a/web/src/pages/FoodPage.tsx
+++ b/web/src/pages/FoodPage.tsx
@@ -20,7 +20,7 @@ export function FoodPage({ bundle }: FoodPageProps) {
     <section className="card hub-card-wrapper" aria-label="餐飲與補給">
       <header className="hub-header">
         <h2>餐飲與補給</h2>
-        <p>依每日行程整理用餐時間與地點，快速開啟 OpenStreetMap。</p>
+        <p>依每日行程整理用餐時間與地點。</p>
       </header>
 
       <div className="hub-stats">
@@ -36,7 +36,7 @@ export function FoodPage({ bundle }: FoodPageProps) {
               {group.meals.map((meal) => (
                 <li className="hub-item" key={meal.id}>
                   <div className="hub-item-row">
-                    <h4>{findPlaceLabel(bundle.places, meal.place_id)}<a className="hub-map-link" href={buildMapsSearchLink(findPlaceLabel(bundle.places, meal.place_id))} target="_blank" rel="noreferrer" aria-label={`${findPlaceLabel(bundle.places, meal.place_id)} OpenStreetMap`}>OpenStreetMap ↗</a></h4>
+                    <h4>{findPlaceLabel(bundle.places, meal.place_id)}<a className="hub-map-link" href={buildMapsSearchLink(findPlaceLabel(bundle.places, meal.place_id))} target="_blank" rel="noreferrer" aria-label={`${findPlaceLabel(bundle.places, meal.place_id)} 在 Google Maps 開啟`} title="在 Google Maps 開啟"><span aria-hidden="true">🗺️</span></a></h4>
                   </div>
                   <p>用餐時間：{meal.start_at ? new Date(meal.start_at).toLocaleTimeString('zh-TW', { hour: '2-digit', minute: '2-digit' }) : '—'}</p>
                 </li>

--- a/web/src/pages/ItineraryPage.tsx
+++ b/web/src/pages/ItineraryPage.tsx
@@ -286,23 +286,18 @@ export function ItineraryPage({ bundle, route, onNavigate }: ItineraryPageProps)
             ? leg.estimated_duration_minutes == null ? '車程：—' : `約 ${leg.estimated_duration_minutes} 分鐘`
             : item.notes || `停留 ${item.expected_stay_minutes == null ? '—' : `${item.expected_stay_minutes} 分鐘`} · 前段移動 ${item.transfer_minutes == null ? '—' : `${item.transfer_minutes} 分鐘`}`
           const mapsHref = leg ? legDirectionsLink(bundle, leg) : buildMapsLink(place?.maps_query || place?.address || place?.name || item.place_id)
-          const itemAlternatives = (item.alternative_place_ids || [])
-            .map((placeId) => bundle.places?.find((candidate) => candidate.id === placeId))
-            .filter((candidate): candidate is BundlePlace => !!candidate)
-
           return <article tabIndex={-1} className={`timeline-entry ${visualKind} ${item.id === route.item ? 'item-highlight' : ''}`} id={`item-${item.id}`} key={item.id}>
             <div className="timeline-time"><strong>{timeLabel(item.start_at)}</strong><span>{item.end_at && item.end_at !== item.start_at ? timeLabel(item.end_at) : visualKind === 'reservation' ? '固定' : ''}</span></div>
             <div className="timeline-track"><span>{visualKind === 'reservation' ? '◆' : visualKind === 'meal' ? '✦' : visualKind === 'move' ? '→' : '●'}</span>{index < visibleItems.length - 1 && <i />}</div>
             <div className="timeline-card">
               <div className="timeline-card-topline"><span className="timeline-category">{visualKind === 'reservation' ? '固定預約' : visualKind === 'meal' ? '餐飲安排' : visualKind === 'move' ? '逐段交通' : '行程停靠'}</span><div className="status-chips">{states.map((state) => <span key={state} className="status-chip">{state}</span>)}</div></div>
-              <h3>{title}{!leg && place?.name_ja ? <small>{place.name_ja}</small> : null}<a className="timeline-map-link" href={mapsHref} target="_blank" rel="noreferrer" aria-label={`${title} OpenStreetMap`}>OpenStreetMap ↗</a></h3>
+              <h3>{title}{!leg && place?.name_ja ? <small>{place.name_ja}</small> : null}<a className="timeline-map-link" href={mapsHref} target="_blank" rel="noreferrer" aria-label={`${title} 在 Google Maps 開啟`} title="在 Google Maps 開啟"><span aria-hidden="true">🗺️</span></a></h3>
               <p className="timeline-detail">{detail}</p>
               {!leg && findPlaceAddress(bundle.places, item.place_id) && <p className="timeline-address">{findPlaceAddress(bundle.places, item.place_id)}</p>}
-              {leg ? <div className="timeline-risk">{leg.status !== 'estimated' ? <span className={operationalStatusClass(leg.status)}>{operationalStatusLabel(leg.status)}</span> : null}<p><strong>風險／延誤切點：</strong>{leg.note || '出發前以 OpenStreetMap 確認位置與路線。'}</p></div> : null}
+              {leg ? <div className="timeline-risk">{leg.status !== 'estimated' ? <span className={operationalStatusClass(leg.status)}>{operationalStatusLabel(leg.status)}</span> : null}<p><strong>風險／延誤切點：</strong>{leg.note || '出發前以 Google Maps 確認位置與路線。'}</p></div> : null}
               {!leg && place?.opening_hours_note ? <p className={`timeline-context ${fieldNeedsRecheck(place, 'opening_hours_note') ? 'needs-recheck' : ''}`}><strong>營業時間：</strong>{place.opening_hours_note}</p> : null}
               {!leg && place?.parking ? <p className={`timeline-context ${fieldNeedsRecheck(place, 'parking') ? 'needs-recheck' : ''}`}><strong>停車：</strong>{place.parking}</p> : null}
               {place?.accessibility_notes && !accessibilityNoteCovered(item.notes, place.accessibility_notes) ? <p className="timeline-context"><strong>家庭／無障礙：</strong>{place.accessibility_notes}</p> : null}
-              {!leg && itemAlternatives.length ? <div className="timeline-inline-alternatives"><strong>試算表備案：</strong>{itemAlternatives.map((alternative) => <a key={alternative.id} href={buildMapsLink(alternative.maps_query || alternative.address || alternative.name || alternative.id)} target="_blank" rel="noreferrer">{alternative.name || alternative.id}</a>)}</div> : null}
             </div>
           </article>
         })}

--- a/web/src/pages/LodgingPage.tsx
+++ b/web/src/pages/LodgingPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import {
   Bundle,
   BundlePlace,
@@ -6,7 +6,6 @@ import {
   operationalStatusClass,
   operationalStatusLabel,
 } from '../contracts/trip'
-import { buildRoutePath } from '../app/route-registry'
 
 interface LodgingPageProps {
   bundle: Bundle
@@ -21,7 +20,6 @@ interface LodgingItem {
   checkOutTime?: string
   nights?: number
   boundaryNote: string
-  route: string
   note?: string
 }
 
@@ -50,7 +48,6 @@ function daysBetween(start?: string, end?: string) {
 }
 
 export function LodgingPage({ bundle }: LodgingPageProps) {
-  const [copiedId, setCopiedId] = useState('')
   const lodgings = useMemo<LodgingItem[]>(() => {
     const allItems = bundle.days.flatMap((day) => day.items)
     const base = bundle.selected.hotel_place_ids.map((placeId) => {
@@ -80,24 +77,12 @@ export function LodgingPage({ bundle }: LodgingPageProps) {
         checkOutTime: entry.checkOut?.start_at || undefined,
         nights: daysBetween(checkInDate, checkOutDate),
         boundaryNote,
-        route: buildRoutePath({ section: 'today', day: checkInDate, item: entry.checkIn?.id }),
         note: entry.checkIn?.notes || undefined,
       }
     })
   }, [bundle.days, bundle.places, bundle.selected.hotel_place_ids])
 
   const totalNights = lodgings.reduce((sum, lodging) => sum + (lodging.nights || 0), 0)
-  const copyAddress = async (lodging: LodgingItem) => {
-    if (!lodging.place?.address) return
-    try {
-      await navigator.clipboard.writeText(`${lodging.place.name || lodging.placeId}\n${lodging.place.address}`)
-      setCopiedId(lodging.id)
-      window.setTimeout(() => setCopiedId(''), 1400)
-    } catch {
-      setCopiedId('error')
-    }
-  }
-
   return (
     <section className="lodging-workspace" aria-label="住宿手冊">
       <header className="page-intro">
@@ -133,10 +118,7 @@ export function LodgingPage({ bundle }: LodgingPageProps) {
                 {lodging.note ? <p className="stay-note"><strong>入住提醒：</strong>{lodging.note}</p> : null}
                 {lodging.place?.accessibility_notes ? <p className="stay-note"><strong>家庭／無障礙：</strong>{lodging.place.accessibility_notes}</p> : null}
                 <div className="stay-actions">
-                  <a className="primary" href={mapsHref} target="_blank" rel="noreferrer">開啟導航</a>
-                  <button type="button" disabled={!lodging.place?.address} onClick={() => copyAddress(lodging)}>{copiedId === lodging.id ? '地址已複製' : '複製住宿地址'}</button>
-                  <a href={lodging.route}>查看入住日</a>
-                  {lodging.place?.official_url ? <a href={lodging.place.official_url} target="_blank" rel="noreferrer">官方網站</a> : null}
+                  <a className="primary map-icon-link" href={mapsHref} target="_blank" rel="noreferrer" aria-label={`${lodging.place?.name || lodging.placeId} 在 Google Maps 開啟`} title="在 Google Maps 開啟"><span aria-hidden="true">🗺️</span></a>
                 </div>
               </div>
             </article>

--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -165,9 +165,9 @@ export function MapPage({ bundle, route, currentDay }: MapPageProps) {
         <div>
           <p className="eyebrow">ROUTE DESK</p>
           <h1>地圖與逐段交通</h1>
-          <p>網站呈現行前規劃估計；按下地圖連結後，以 OpenStreetMap 查找位置與路線。</p>
+          <p>網站呈現行前規劃估計；按下地圖圖示後，以 Google Maps 開啟位置與路線。</p>
         </div>
-        <div className="map-trust-note"><strong>免費開源</strong><span>只產生 OpenStreetMap 查找連結，不在網站內宣稱即時車程。</span></div>
+        <div className="map-trust-note"><strong>Google Maps</strong><span>只產生免 API key 的地圖連結，不在網站內宣稱即時車程。</span></div>
       </header>
 
       <nav className="handbook-day-tabs" aria-label="地圖日期切換">
@@ -235,11 +235,10 @@ export function MapPage({ bundle, route, currentDay }: MapPageProps) {
                     </dl>
                     <div className="route-risk-note">
                       <strong>導航注意／延誤切點</strong>
-                      <p>{leg.note || '出發前請以 OpenStreetMap 重新確認位置與路線。'}</p>
+                      <p>{leg.note || '出發前請以 Google Maps 重新確認位置與路線。'}</p>
                     </div>
                     <div className="route-card-actions">
-                      <a data-route-url={directionsHref} href={directionsHref} target="_blank" rel="noreferrer">開啟 OpenStreetMap</a>
-                      {leg.source_url ? <a className="secondary-link" href={leg.source_url} target="_blank" rel="noreferrer">查看估計來源</a> : null}
+                      <a className="map-icon-link" data-route-url={directionsHref} href={directionsHref} target="_blank" rel="noreferrer" aria-label="在 Google Maps 開啟逐段路線" title="在 Google Maps 開啟逐段路線"><span aria-hidden="true">🗺️</span></a>
                     </div>
                   </div>
                 </li>

--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -194,8 +194,18 @@ export function MapPage({ bundle, route, currentDay }: MapPageProps) {
           </div>
           <div className="daily-route-actions">
             {fullRouteChunks.map((chunk) => (
-              <a key={chunk.id} href={chunk.href} target="_blank" rel="noreferrer">
-                {fullRouteChunks.length > 1 ? `${transportModeLabel(chunk.travelMode)}：${chunk.sourceLabel} → ${chunk.destinationLabel}` : '開啟今日完整路線'}
+              <a
+                key={chunk.id}
+                className="map-icon-link"
+                href={chunk.href}
+                target="_blank"
+                rel="noreferrer"
+                aria-label={fullRouteChunks.length > 1
+                  ? `在 Google Maps 開啟${transportModeLabel(chunk.travelMode)}：${chunk.sourceLabel} 到 ${chunk.destinationLabel}`
+                  : '在 Google Maps 開啟今日完整路線'}
+                title="在 Google Maps 開啟"
+              >
+                <span aria-hidden="true">🗺️</span>
               </a>
             ))}
           </div>

--- a/web/src/pages/OverviewPage.tsx
+++ b/web/src/pages/OverviewPage.tsx
@@ -201,7 +201,7 @@ export function OverviewPage({ bundle, trip }: OverviewPageProps) {
 
       <footer className="overview-footer">
         <span>預算快照：{formatMoney(bundle.budget?.total)}</span>
-        <span>OpenStreetMap 位置與路線連結</span>
+        <span>Google Maps 位置與路線連結</span>
       </footer>
     </section>
   )

--- a/web/src/pages/ReservationsPage.tsx
+++ b/web/src/pages/ReservationsPage.tsx
@@ -95,7 +95,7 @@ export function ReservationsPage({ bundle }: ReservationsPageProps) {
                   <article className="reservation-card" key={reservation.id}>
                     <div className="reservation-time"><strong>{formatTime(reservation.time)}</strong></div>
                     <div className="reservation-main">
-                      <div className="reservation-title-row"><h2>{reservation.name || placeName}<a className="reservation-map-link" href={mapHref} target="_blank" rel="noreferrer" aria-label={`${placeName} OpenStreetMap`}>OpenStreetMap ↗</a></h2></div>
+                      <div className="reservation-title-row"><h2>{reservation.name || placeName}<a className="reservation-map-link" href={mapHref} target="_blank" rel="noreferrer" aria-label={`${placeName} 在 Google Maps 開啟`} title="在 Google Maps 開啟"><span aria-hidden="true">🗺️</span></a></h2></div>
                       {address ? <p className="reservation-address">{address}</p> : null}
                     </div>
                   </article>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -305,6 +305,34 @@ a {
   vertical-align: middle;
 }
 
+.map-icon-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 42px;
+  min-height: 42px;
+  padding: 6px 9px;
+  border: 1px solid #9fc4d2;
+  border-radius: 9px;
+  background: #edf7fa;
+  color: #075f84;
+  text-decoration: none;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.map-icon-link:hover {
+  background: #dceff4;
+}
+
+.hub-map-link span,
+.timeline-map-link span,
+.reservation-map-link span {
+  display: block;
+  font-size: 1.15rem;
+  line-height: 1;
+}
+
 .hub-map-link:hover,
 .timeline-map-link:hover,
 .reservation-map-link:hover {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -924,6 +924,7 @@ textarea {
   .timeline-map-link,
   .hub-map-link {
     min-height: 44px;
+    min-width: 44px;
     font-size: .68rem;
   }
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -309,8 +309,8 @@ a {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 42px;
-  min-height: 42px;
+  min-width: 44px;
+  min-height: 44px;
   padding: 6px 9px;
   border: 1px solid #9fc4d2;
   border-radius: 9px;

--- a/web/tests/e2e.mjs
+++ b/web/tests/e2e.mjs
@@ -196,7 +196,7 @@ try {
   await assertStyleContrast(mobile, '.day-tab:focus-visible', 'outlineColor', '.itinerary-day-nav', 'backgroundColor', 3, 'light control focus indicator')
   await assertTouchTargets(mobile, '.print-button', 'print')
   await assertTouchTargets(mobile, '.quick-mode button', 'quick mode')
-  await assertTouchTargets(mobile, '.timeline-map-link', 'timeline OpenStreetMap link')
+  await assertTouchTargets(mobile, '.timeline-map-link', 'timeline Google Maps icon link')
   await mobile.locator('#itinerary-search').fill('淡路')
   await mobile.locator('.search-results button').first().waitFor()
   await assertTouchTargets(mobile, '.search-results button', 'search result')

--- a/web/tests/handbook.test.tsx
+++ b/web/tests/handbook.test.tsx
@@ -114,14 +114,17 @@ describe('Issue 97 travel handbook', () => {
     localStorage.clear()
   })
 
-  it('builds an OpenStreetMap route lookup without an API key', () => {
+  it('builds a Google Maps directions URL without an API key', () => {
     const href = buildMapsDirectionsLink([
       { label: '神戶機場', mapsQuery: 'Kobe Airport' },
       { label: '淡路住宿', mapsQuery: 'Awaji Hotel' },
     ])
     const url = new URL(href)
-    expect(url.pathname).toBe('/search')
-    expect(url.searchParams.get('query')).toBe('Kobe Airport → Awaji Hotel')
+    expect(url.pathname).toBe('/maps/dir/')
+    expect(url.searchParams.get('api')).toBe('1')
+    expect(url.searchParams.get('origin')).toBe('Kobe Airport')
+    expect(url.searchParams.get('destination')).toBe('Awaji Hotel')
+    expect(url.searchParams.get('travelmode')).toBe('driving')
   })
 
   it('shows leg analysis and switches across all five days', () => {
@@ -133,8 +136,8 @@ describe('Issue 97 travel handbook', () => {
     expect(screen.getByText('15 分鐘')).toBeInTheDocument()
     expect(screen.getByText('90 分鐘')).toBeInTheDocument()
     expect(screen.getByText(/若延誤 20 分鐘/)).toBeInTheDocument()
-    const routeLink = screen.getByRole('link', { name: '開啟 OpenStreetMap' })
-    expect(routeLink.getAttribute('href')).toContain('openstreetmap.org/search?query=')
+    const routeLink = screen.getByRole('link', { name: '在 Google Maps 開啟逐段路線' })
+    expect(routeLink.getAttribute('href')).toContain('google.com/maps/dir/')
     fireEvent.click(screen.getByRole('button', { name: /Day 5/ }))
     expect(screen.getByRole('heading', { name: '第 5 日摘要' })).toBeInTheDocument()
     expect(screen.queryByText('尚無逐段資料')).not.toBeInTheDocument()
@@ -159,7 +162,7 @@ describe('Issue 97 travel handbook', () => {
     expect(chunks.every((chunk) => chunk.waypoints.length <= 3)).toBe(true)
     expect(chunks.every((chunk) => [chunk.source, ...chunk.waypoints, chunk.destination].length <= 5)).toBe(true)
     expect(chunks[0].destination.id).toBe(chunks[1].source.id)
-    expect(new URL(chunks[0].href).searchParams.get('query')).toContain('站 0')
+    expect(new URL(chunks[0].href).searchParams.get('travelmode')).toBe('transit')
   })
 
   it('exports reservation timestamps as UTC instead of browser-local wall time', () => {
@@ -189,7 +192,7 @@ describe('Issue 97 travel handbook', () => {
       }],
     }} />)
     expect(screen.getByRole('heading', { name: /うずしおクルーズ（福良港）/ })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: '淡路住宿 OpenStreetMap' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '淡路住宿 在 Google Maps 開啟' })).toBeInTheDocument()
     expect(screen.queryByText('資料來源')).not.toBeInTheDocument()
     expect(screen.queryByText('最後確認')).not.toBeInTheDocument()
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
@@ -202,8 +205,9 @@ describe('Issue 97 travel handbook', () => {
     expect(screen.getAllByRole('tab')).toHaveLength(5)
     expect(screen.getByRole('heading', { name: /神戶機場 → 淡路住宿/ })).toBeInTheDocument()
     expect(screen.getByText('主要風險')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: '洲本城' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: '鳴門公園' })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: '洲本城' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: '鳴門公園' })).not.toBeInTheDocument()
+    expect(screen.getAllByRole('link', { name: /在 Google Maps 開啟/ }).length).toBeGreaterThan(0)
     // Dynamic facts remain visibly sourced and transport estimates are not repeated in the risk note.
     expect(screen.getByText(/營業時間：/)).toBeInTheDocument()
     expect(screen.getByText(/停車：/)).toBeInTheDocument()


### PR DESCRIPTION
## 變更
- 景點、餐飲、預約、住宿與交通入口統一改為 🗺️ 圖示，開啟 Google Maps。
- 移除 OpenStreetMap 文字入口與不必要的文字型地圖按鈕。
- 移除行程備案景點連結、住宿複製地址／查看入住日／官方網站等非必要操作。
- 更新 icon 可見性、手機觸控尺寸、前端測試與 E2E 選擇器。

## 驗證
- `npm run lint` — PASS
- `npm run typecheck` — PASS
- `npm test` — 23 passed
- `npm run build` — PASS
- `git diff --check` — PASS
