### PR TITLE
全站改用 map-pin 定位圖示

### DIFF
--- a/web/src/design-system/primitives/MapPinIcon.tsx
+++ b/web/src/design-system/primitives/MapPinIcon.tsx
@@ -1,0 +1,23 @@
+interface MapPinIconProps {
+  className?: string
+}
+
+/** Lucide-style open-source map-pin outline, kept inline to avoid an icon CDN. */
+export function MapPinIcon({ className }: MapPinIconProps) {
+  return (
+    <svg
+      className={className}
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M20 10c0 4.993-8 12-8 12S4 14.993 4 10a8 8 0 1 1 16 0Z" />
+      <circle cx="12" cy="10" r="3" />
+    </svg>
+  )
+}

--- a/web/src/pages/FoodPage.tsx
+++ b/web/src/pages/FoodPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { Bundle, findPlaceLabel } from '../contracts/trip'
+import { MapPinIcon } from '../design-system/primitives/MapPinIcon'
 import { buildMapsSearchLink } from '../lib/google-maps-links'
 
 interface FoodPageProps {
@@ -36,7 +37,7 @@ export function FoodPage({ bundle }: FoodPageProps) {
               {group.meals.map((meal) => (
                 <li className="hub-item" key={meal.id}>
                   <div className="hub-item-row">
-                    <h4>{findPlaceLabel(bundle.places, meal.place_id)}<a className="hub-map-link" href={buildMapsSearchLink(findPlaceLabel(bundle.places, meal.place_id))} target="_blank" rel="noreferrer" aria-label={`${findPlaceLabel(bundle.places, meal.place_id)} 在 Google Maps 開啟`} title="在 Google Maps 開啟"><span aria-hidden="true">🗺️</span></a></h4>
+                    <h4>{findPlaceLabel(bundle.places, meal.place_id)}<a className="hub-map-link" href={buildMapsSearchLink(findPlaceLabel(bundle.places, meal.place_id))} target="_blank" rel="noreferrer" aria-label={`${findPlaceLabel(bundle.places, meal.place_id)} 在 Google Maps 開啟`} title="在 Google Maps 開啟"><MapPinIcon /></a></h4>
                   </div>
                   <p>用餐時間：{meal.start_at ? new Date(meal.start_at).toLocaleTimeString('zh-TW', { hour: '2-digit', minute: '2-digit' }) : '—'}</p>
                 </li>

--- a/web/src/pages/ItineraryPage.tsx
+++ b/web/src/pages/ItineraryPage.tsx
@@ -13,6 +13,7 @@ import {
   operationalStatusLabel,
 } from '../contracts/trip'
 import { TripRoute } from '../app/route-registry'
+import { MapPinIcon } from '../design-system/primitives/MapPinIcon'
 import { buildMapsDirectionsLink } from '../lib/google-maps-links'
 
 interface ItineraryPageProps {
@@ -291,7 +292,7 @@ export function ItineraryPage({ bundle, route, onNavigate }: ItineraryPageProps)
             <div className="timeline-track"><span>{visualKind === 'reservation' ? '◆' : visualKind === 'meal' ? '✦' : visualKind === 'move' ? '→' : '●'}</span>{index < visibleItems.length - 1 && <i />}</div>
             <div className="timeline-card">
               <div className="timeline-card-topline"><span className="timeline-category">{visualKind === 'reservation' ? '固定預約' : visualKind === 'meal' ? '餐飲安排' : visualKind === 'move' ? '逐段交通' : '行程停靠'}</span><div className="status-chips">{states.map((state) => <span key={state} className="status-chip">{state}</span>)}</div></div>
-              <h3>{title}{!leg && place?.name_ja ? <small>{place.name_ja}</small> : null}<a className="timeline-map-link" href={mapsHref} target="_blank" rel="noreferrer" aria-label={`${title} 在 Google Maps 開啟`} title="在 Google Maps 開啟"><span aria-hidden="true">🗺️</span></a></h3>
+              <h3>{title}{!leg && place?.name_ja ? <small>{place.name_ja}</small> : null}<a className="timeline-map-link" href={mapsHref} target="_blank" rel="noreferrer" aria-label={`${title} 在 Google Maps 開啟`} title="在 Google Maps 開啟"><MapPinIcon /></a></h3>
               <p className="timeline-detail">{detail}</p>
               {!leg && findPlaceAddress(bundle.places, item.place_id) && <p className="timeline-address">{findPlaceAddress(bundle.places, item.place_id)}</p>}
               {leg ? <div className="timeline-risk">{leg.status !== 'estimated' ? <span className={operationalStatusClass(leg.status)}>{operationalStatusLabel(leg.status)}</span> : null}<p><strong>風險／延誤切點：</strong>{leg.note || '出發前以 Google Maps 確認位置與路線。'}</p></div> : null}

--- a/web/src/pages/LodgingPage.tsx
+++ b/web/src/pages/LodgingPage.tsx
@@ -6,6 +6,7 @@ import {
   operationalStatusClass,
   operationalStatusLabel,
 } from '../contracts/trip'
+import { MapPinIcon } from '../design-system/primitives/MapPinIcon'
 
 interface LodgingPageProps {
   bundle: Bundle
@@ -118,7 +119,7 @@ export function LodgingPage({ bundle }: LodgingPageProps) {
                 {lodging.note ? <p className="stay-note"><strong>入住提醒：</strong>{lodging.note}</p> : null}
                 {lodging.place?.accessibility_notes ? <p className="stay-note"><strong>家庭／無障礙：</strong>{lodging.place.accessibility_notes}</p> : null}
                 <div className="stay-actions">
-                  <a className="primary map-icon-link" href={mapsHref} target="_blank" rel="noreferrer" aria-label={`${lodging.place?.name || lodging.placeId} 在 Google Maps 開啟`} title="在 Google Maps 開啟"><span aria-hidden="true">🗺️</span></a>
+                  <a className="primary map-icon-link" href={mapsHref} target="_blank" rel="noreferrer" aria-label={`${lodging.place?.name || lodging.placeId} 在 Google Maps 開啟`} title="在 Google Maps 開啟"><MapPinIcon /></a>
                 </div>
               </div>
             </article>

--- a/web/src/pages/MapPage.tsx
+++ b/web/src/pages/MapPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { TripRoute } from '../app/route-registry'
+import { MapPinIcon } from '../design-system/primitives/MapPinIcon'
 import {
   Bundle,
   BundleDay,
@@ -205,7 +206,7 @@ export function MapPage({ bundle, route, currentDay }: MapPageProps) {
                   : '在 Google Maps 開啟今日完整路線'}
                 title="在 Google Maps 開啟"
               >
-                <span aria-hidden="true">🗺️</span>
+                <MapPinIcon />
               </a>
             ))}
           </div>
@@ -248,7 +249,7 @@ export function MapPage({ bundle, route, currentDay }: MapPageProps) {
                       <p>{leg.note || '出發前請以 Google Maps 重新確認位置與路線。'}</p>
                     </div>
                     <div className="route-card-actions">
-                      <a className="map-icon-link" data-route-url={directionsHref} href={directionsHref} target="_blank" rel="noreferrer" aria-label="在 Google Maps 開啟逐段路線" title="在 Google Maps 開啟逐段路線"><span aria-hidden="true">🗺️</span></a>
+                      <a className="map-icon-link" data-route-url={directionsHref} href={directionsHref} target="_blank" rel="noreferrer" aria-label="在 Google Maps 開啟逐段路線" title="在 Google Maps 開啟逐段路線"><MapPinIcon /></a>
                     </div>
                   </div>
                 </li>

--- a/web/src/pages/ReservationsPage.tsx
+++ b/web/src/pages/ReservationsPage.tsx
@@ -3,6 +3,7 @@ import {
   Bundle,
   BundleReservation,
 } from '../contracts/trip'
+import { MapPinIcon } from '../design-system/primitives/MapPinIcon'
 import { buildMapsSearchLink } from '../lib/google-maps-links'
 
 interface ReservationsPageProps {
@@ -95,7 +96,7 @@ export function ReservationsPage({ bundle }: ReservationsPageProps) {
                   <article className="reservation-card" key={reservation.id}>
                     <div className="reservation-time"><strong>{formatTime(reservation.time)}</strong></div>
                     <div className="reservation-main">
-                      <div className="reservation-title-row"><h2>{reservation.name || placeName}<a className="reservation-map-link" href={mapHref} target="_blank" rel="noreferrer" aria-label={`${placeName} 在 Google Maps 開啟`} title="在 Google Maps 開啟"><span aria-hidden="true">🗺️</span></a></h2></div>
+                      <div className="reservation-title-row"><h2>{reservation.name || placeName}<a className="reservation-map-link" href={mapHref} target="_blank" rel="noreferrer" aria-label={`${placeName} 在 Google Maps 開啟`} title="在 Google Maps 開啟"><MapPinIcon /></a></h2></div>
                       {address ? <p className="reservation-address">{address}</p> : null}
                     </div>
                   </article>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -351,12 +351,6 @@ a {
   background: #dceff4;
 }
 
-.hub-map-link,
-.timeline-map-link,
-.reservation-map-link {
-  min-height: 34px;
-}
-
 .hub-actions {
   display: flex;
   gap: 8px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -325,6 +325,15 @@ a {
   background: #dceff4;
 }
 
+.map-icon-link svg,
+.hub-map-link svg,
+.timeline-map-link svg,
+.reservation-map-link svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  display: block;
+}
+
 .hub-map-link span,
 .timeline-map-link span,
 .reservation-map-link span {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -293,10 +293,13 @@ a {
 .reservation-map-link {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   margin-left: 9px;
   padding: 3px 7px;
   border: 1px solid #9fc4d2;
   border-radius: 7px;
+  min-width: 44px;
+  min-height: 44px;
   color: #075f84;
   background: #edf7fa;
   font-size: 0.72rem;


### PR DESCRIPTION
## 變更內容
- 全站 Google Maps 入口改用一致的開源風格 inline SVG map-pin 圖示
- 移除地圖 emoji，避免不同裝置顯示不一致
- 保留 Google Maps href、aria-label、title 與 44×44 觸控尺寸

## 驗證
- `npm run lint`
- `npm run typecheck`
- `npm test`（23 tests passed）
- `npm run build`
- `git diff --check`

## Acceptance criteria
- 景點、餐飲、住宿、預約、交通皆顯示 map-pin 圖示
- 不恢復分享、複製或文字型地圖按鈕
- 圖示可直接開啟 Google Maps
- 手機觸控尺寸維持至少 44×44px